### PR TITLE
test: add multipart upload wedge regression gates

### DIFF
--- a/backend/distributed/multipart_test.go
+++ b/backend/distributed/multipart_test.go
@@ -788,16 +788,13 @@ func TestDistributed_MultipartUpload_PartOverwrite(t *testing.T) {
 // Acceptance:
 //   - On `main` today: at least some UploadPart calls hang past their per-
 //     request context deadline and the overall test trips its timeout.
-//   - After fixes land: all 10 concurrent parts complete, the data
-//     reconstructs correctly end-to-end.
+//   - Post-fix (7df9645 + 9dcd3dd + 43e20f6): all 10 concurrent parts
+//     complete and the data reconstructs correctly end-to-end. This is
+//     now the end-to-end regression gate for those fixes.
 //
 // Scope note: the 90 s total-elapsed bound is a deadlock detector, not a
 // performance regression. A per-part benchmark belongs in s3_bench_test.go.
 func TestDistributed_MultipartUpload_ConcurrentParts_Contention(t *testing.T) {
-	if os.Getenv("PREDASTORE_BUG_REPRO") != "1" {
-		t.Skip("bug reproducer — set PREDASTORE_BUG_REPRO=1 to run")
-	}
-
 	be, cleanup := setupMultipartTestBackend(t)
 	defer cleanup()
 

--- a/backend/distributed/multipart_test.go
+++ b/backend/distributed/multipart_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -767,4 +768,157 @@ func TestDistributed_MultipartUpload_PartOverwrite(t *testing.T) {
 	// Check that the data contains 0xBB (V2), not 0xAA (V1)
 	assert.Equal(t, byte(0xBB), readData[0], "Should contain V2 data, not V1")
 	assert.Equal(t, byte(0xBB), readData[multipart.MinPartSize-1], "Should contain V2 data, not V1")
+}
+
+// TestDistributed_MultipartUpload_ConcurrentParts_Contention is the end-to-end
+// reproducer for the AWS-CLI-style access pattern documented in
+// docs/development/bugs/multipart-upload-deadlock.md: one CreateMultipartUpload
+// followed by N UploadPart calls fired concurrently from N goroutines. This
+// is the scenario that wedges against a real spinifex-predastore deployment
+// when `aws s3 cp` (default 10 concurrent threads) is used on any file large
+// enough to split into parts that individually exceed the QUIC connection
+// window.
+//
+// The wedge's necessary conditions — shared pooled QUIC connection per node,
+// many streams per connection, per-part bodies on the order of the connection
+// window (15 MiB default), and server-side handlers that hold wal.mu across
+// the stream read — are all present in this harness because setupMultipart-
+// TestBackend wires up a 5-node QUIC topology with the production code path.
+//
+// Acceptance:
+//   - On `main` today: at least some UploadPart calls hang past their per-
+//     request context deadline and the overall test trips its timeout.
+//   - After fixes land: all 10 concurrent parts complete, the data
+//     reconstructs correctly end-to-end.
+//
+// Scope note: the 90 s total-elapsed bound is a deadlock detector, not a
+// performance regression. A per-part benchmark belongs in s3_bench_test.go.
+func TestDistributed_MultipartUpload_ConcurrentParts_Contention(t *testing.T) {
+	if os.Getenv("PREDASTORE_BUG_REPRO") != "1" {
+		t.Skip("bug reproducer — set PREDASTORE_BUG_REPRO=1 to run")
+	}
+
+	be, cleanup := setupMultipartTestBackend(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	const bucket = "test-bucket"
+	const key = "concurrent-parts.bin"
+	const numParts = 10
+	// Part size above quic-go's default MaxConnectionReceiveWindow (15 MiB).
+	// This is the minimal condition for the head-of-line wedge to form when
+	// multiple streams share one pooled connection.
+	const partSize = 16 * 1024 * 1024
+
+	createResp, err := be.CreateMultipartUpload(ctx, &backend.CreateMultipartUploadRequest{
+		Bucket: bucket,
+		Key:    key,
+	})
+	require.NoError(t, err)
+	uploadID := createResp.UploadID
+
+	type partResult struct {
+		partNumber int
+		etag       string
+		elapsed    time.Duration
+		err        error
+	}
+	results := make(chan partResult, numParts)
+
+	overallStart := time.Now()
+	var wg sync.WaitGroup
+	for p := 1; p <= numParts; p++ {
+		wg.Add(1)
+		go func(pn int) {
+			defer wg.Done()
+
+			// Deterministic per-part payload so the eventual reassembled
+			// object has a known byte pattern.
+			data := make([]byte, partSize)
+			for i := range data {
+				data[i] = byte((pn*31 + i) % 256)
+			}
+
+			partCtx, partCancel := context.WithTimeout(ctx, 2*time.Minute)
+			defer partCancel()
+
+			start := time.Now()
+			resp, perr := be.UploadPart(partCtx, &backend.UploadPartRequest{
+				Bucket:     bucket,
+				Key:        key,
+				UploadID:   uploadID,
+				PartNumber: pn,
+				Body:       bytes.NewReader(data),
+			})
+			elapsed := time.Since(start)
+			if perr != nil {
+				results <- partResult{partNumber: pn, elapsed: elapsed, err: perr}
+				return
+			}
+			results <- partResult{partNumber: pn, etag: resp.ETag, elapsed: elapsed}
+		}(p)
+	}
+
+	wg.Wait()
+	close(results)
+	overallElapsed := time.Since(overallStart)
+
+	completed := make([]backend.CompletedPart, 0, numParts)
+	for r := range results {
+		require.NoError(t, r.err, "part %d failed after %v", r.partNumber, r.elapsed)
+		t.Logf("part %d completed in %v", r.partNumber, r.elapsed)
+		completed = append(completed, backend.CompletedPart{
+			PartNumber: r.partNumber,
+			ETag:       r.etag,
+		})
+	}
+
+	// Deadlock detector. 10 × 16 MiB serialized through five nodes on
+	// loopback should finish well under the bound; the wedge blows through
+	// this via the per-part 2-minute deadline.
+	require.Less(t, overallElapsed, 90*time.Second,
+		"suspected multipart wedge (Bug C): overall elapsed %v exceeded budget", overallElapsed)
+
+	// Sort completed parts by part number before CompleteMultipartUpload —
+	// the results channel delivers out of order.
+	sortPartsByNumber(completed)
+
+	completeResp, err := be.CompleteMultipartUpload(ctx, &backend.CompleteMultipartUploadRequest{
+		Bucket:   bucket,
+		Key:      key,
+		UploadID: uploadID,
+		Parts:    completed,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, completeResp)
+
+	// End-to-end sanity: the reassembled object reads back at the expected
+	// total size. Per-byte verification would double runtime for little
+	// extra signal; the multipart lifecycle tests cover that already.
+	getResp, err := be.GetObject(ctx, &backend.GetObjectRequest{
+		Bucket:     bucket,
+		Key:        key,
+		RangeStart: -1,
+		RangeEnd:   -1,
+	})
+	require.NoError(t, err)
+	defer getResp.Body.Close()
+
+	total, err := io.Copy(io.Discard, getResp.Body)
+	require.NoError(t, err)
+	require.Equal(t, int64(numParts)*int64(partSize), total,
+		"reassembled object size mismatch")
+
+	t.Logf("10 concurrent parts × 16 MiB reassembled in %v", overallElapsed)
+}
+
+// sortPartsByNumber orders CompletedPart entries by PartNumber in place.
+// CompleteMultipartUpload requires parts to be in order.
+func sortPartsByNumber(parts []backend.CompletedPart) {
+	for i := 1; i < len(parts); i++ {
+		for j := i; j > 0 && parts[j-1].PartNumber > parts[j].PartNumber; j-- {
+			parts[j-1], parts[j] = parts[j], parts[j-1]
+		}
+	}
 }

--- a/quic/quicclient/pool_test.go
+++ b/quic/quicclient/pool_test.go
@@ -1,0 +1,172 @@
+package quicclient
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	quic "github.com/quic-go/quic-go"
+	"github.com/stretchr/testify/require"
+)
+
+// poolTestPortCounter hands each test invocation a unique UDP port.
+var poolTestPortCounter atomic.Int32
+
+// startMinimalQUICListener spins up a trivial quic-go listener that accepts
+// connections and streams but never replies. Enough to exercise the pool's
+// dial + cleanup behaviour without pulling in quicserver (which would create
+// an import cycle since quicclient is imported by quicserver transitively).
+func startMinimalQUICListener(t *testing.T) (string, func()) {
+	t.Helper()
+
+	tlsConf := generateTestTLSConfig(t)
+	tlsConf.NextProtos = []string{alpn}
+
+	port := 47000 + int(poolTestPortCounter.Add(1))
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	ln, err := quic.ListenAddr(addr, tlsConf, &quic.Config{
+		KeepAlivePeriod: 15 * time.Second,
+		MaxIdleTimeout:  60 * time.Second,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		for {
+			conn, err := ln.Accept(ctx)
+			if err != nil {
+				return
+			}
+			go func(c *quic.Conn) {
+				for {
+					s, err := c.AcceptStream(ctx)
+					if err != nil {
+						return
+					}
+					_ = s
+				}
+			}(conn)
+		}
+	}()
+
+	return addr, func() {
+		cancel()
+		_ = ln.Close()
+	}
+}
+
+// TestQuicClientPool_ReapEvictsLiveConnection is the targeted reproducer for
+// Bug A in docs/development/bugs/multipart-upload-deadlock.md. The pool's
+// cleanup() evicts connections purely on `lastUsed` staleness and has no
+// awareness of in-flight streams. A long-running multipart upload that opens
+// one stream per part but doesn't re-Get the pooled connection will cross
+// the 2-minute idle threshold while the upload is still in flight; cleanup()
+// then closes the connection out from under the live streams.
+//
+// This test drives that exact shape deterministically by mutating the
+// `pc.lastUsed` timestamp directly (backdating it past the 2-minute
+// threshold) and then calling cleanup() once. Under the current (buggy)
+// implementation the connection is evicted even though we have an open,
+// in-flight stream. A proper fix — tracking in-flight streams, or bumping
+// lastUsed on stream open — will flip this test from failure to success.
+//
+// Acceptance:
+//   - On `main` today: assertions about the live connection surviving reap
+//     FAIL (connection is evicted and/or the stream is closed under us).
+//   - After fix: assertions PASS (reaper skips the connection with in-flight
+//     streams, and the stream remains usable).
+func TestQuicClientPool_ReapEvictsLiveConnection(t *testing.T) {
+	if os.Getenv("PREDASTORE_BUG_REPRO") != "1" {
+		t.Skip("bug reproducer — set PREDASTORE_BUG_REPRO=1 to run")
+	}
+	addr, stop := startMinimalQUICListener(t)
+	defer stop()
+
+	pool := NewPool()
+	defer pool.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := pool.Get(ctx, addr)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	// Open a stream on the pooled connection and hold it. This models an
+	// in-flight multipart part upload that has not yet completed.
+	stream, err := client.conn.OpenStreamSync(ctx)
+	require.NoError(t, err)
+	defer func() { _ = stream.Close() }()
+
+	// Backdate lastUsed past the 2-minute idle threshold used by cleanup().
+	// This is the condition a real upload hits whenever a single part takes
+	// longer than 2 minutes to drain (large part, slow network, contended
+	// server-side WAL lock, etc.).
+	pool.mu.RLock()
+	pc := pool.connections[addr]
+	pool.mu.RUnlock()
+	require.NotNil(t, pc, "connection should be in pool after Get")
+
+	pc.mu.Lock()
+	pc.lastUsed = time.Now().Add(-3 * time.Minute)
+	pc.mu.Unlock()
+
+	// Trigger the reaper synchronously (the 30s background ticker is too
+	// slow for a unit test).
+	pool.cleanup()
+
+	// Bug A signature: the pooled connection entry has been evicted even
+	// though a stream is in flight.
+	pool.mu.RLock()
+	_, stillPooled := pool.connections[addr]
+	pool.mu.RUnlock()
+	require.True(t, stillPooled,
+		"Bug A: pool.cleanup() evicted a connection with an in-flight stream. "+
+			"Reaper must either track active streams or consult the connection's "+
+			"stream count before closing.")
+
+	// Stronger signal: the stream itself should still be usable after reap.
+	// If cleanup() closed the underlying connection, this write will error.
+	_, err = stream.Write([]byte{0})
+	require.NoError(t, err,
+		"Bug A (secondary): connection was closed by reaper while stream was in flight")
+}
+
+// generateTestTLSConfig mirrors quicserver's makeServerTLSConfig but lives
+// in this package to avoid importing quicserver (which would create a cycle).
+func generateTestTLSConfig(t *testing.T) *tls.Config {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	require.NoError(t, err)
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+	}
+}

--- a/quic/quicclient/pool_test.go
+++ b/quic/quicclient/pool_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -65,30 +64,21 @@ func startMinimalQUICListener(t *testing.T) (string, func()) {
 	}
 }
 
-// TestQuicClientPool_ReapEvictsLiveConnection is the targeted reproducer for
-// Bug A in docs/development/bugs/multipart-upload-deadlock.md. The pool's
-// cleanup() evicts connections purely on `lastUsed` staleness and has no
-// awareness of in-flight streams. A long-running multipart upload that opens
-// one stream per part but doesn't re-Get the pooled connection will cross
-// the 2-minute idle threshold while the upload is still in flight; cleanup()
-// then closes the connection out from under the live streams.
+// TestQuicClientPool_ReapSkipsActiveRPCStreams validates the fix for Bug A
+// in docs/development/bugs/multipart-upload-deadlock.md. Pool.Get bumps
+// lastUsed on entry, but subsequent doPut/doDelete/do calls on the same
+// pooled client do not, so a handler that holds a stream longer than maxIdle
+// (2 minutes) became eligible for reaping mid-transfer. The fix tracks
+// active RPC streams on quicclient.Client (incActive/decActive around
+// doPut/doDelete/do) and makes cleanup() treat a stale connection with
+// activeStreams > 0 as busy rather than idle.
 //
-// This test drives that exact shape deterministically by mutating the
-// `pc.lastUsed` timestamp directly (backdating it past the 2-minute
-// threshold) and then calling cleanup() once. Under the current (buggy)
-// implementation the connection is evicted even though we have an open,
-// in-flight stream. A proper fix — tracking in-flight streams, or bumping
-// lastUsed on stream open — will flip this test from failure to success.
-//
-// Acceptance:
-//   - On `main` today: assertions about the live connection surviving reap
-//     FAIL (connection is evicted and/or the stream is closed under us).
-//   - After fix: assertions PASS (reaper skips the connection with in-flight
-//     streams, and the stream remains usable).
-func TestQuicClientPool_ReapEvictsLiveConnection(t *testing.T) {
-	if os.Getenv("PREDASTORE_BUG_REPRO") != "1" {
-		t.Skip("bug reproducer — set PREDASTORE_BUG_REPRO=1 to run")
-	}
+// This test drives the fix's exact code path: bump the client's
+// activeStreams counter (as doPut would do on entry), backdate lastUsed
+// past the threshold, call cleanup(), and assert the connection is NOT
+// evicted. This would have failed pre-fix (no counter existed) and must
+// pass post-fix.
+func TestQuicClientPool_ReapSkipsActiveRPCStreams(t *testing.T) {
 	addr, stop := startMinimalQUICListener(t)
 	defer stop()
 
@@ -102,44 +92,54 @@ func TestQuicClientPool_ReapEvictsLiveConnection(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
-	// Open a stream on the pooled connection and hold it. This models an
-	// in-flight multipart part upload that has not yet completed.
-	stream, err := client.conn.OpenStreamSync(ctx)
-	require.NoError(t, err)
-	defer func() { _ = stream.Close() }()
+	// Simulate an in-flight RPC by incrementing activeStreams the way
+	// doPut does after OpenStreamSync. Real workloads hit this via
+	// client.Put; we take the shortcut here because the minimal listener
+	// above does not speak the RPC protocol.
+	client.incActive()
+	defer client.decActive()
 
-	// Backdate lastUsed past the 2-minute idle threshold used by cleanup().
-	// This is the condition a real upload hits whenever a single part takes
-	// longer than 2 minutes to drain (large part, slow network, contended
-	// server-side WAL lock, etc.).
+	// Backdate lastUsed past the 2-minute idle threshold.
 	pool.mu.RLock()
 	pc := pool.connections[addr]
 	pool.mu.RUnlock()
-	require.NotNil(t, pc, "connection should be in pool after Get")
+	require.NotNil(t, pc)
 
 	pc.mu.Lock()
 	pc.lastUsed = time.Now().Add(-3 * time.Minute)
 	pc.mu.Unlock()
 
-	// Trigger the reaper synchronously (the 30s background ticker is too
-	// slow for a unit test).
+	// Trigger the reaper synchronously (background ticker runs every 30s).
 	pool.cleanup()
 
-	// Bug A signature: the pooled connection entry has been evicted even
-	// though a stream is in flight.
+	// Post-fix expectation: connection survives reap because
+	// activeStreams > 0.
 	pool.mu.RLock()
 	_, stillPooled := pool.connections[addr]
 	pool.mu.RUnlock()
 	require.True(t, stillPooled,
-		"Bug A: pool.cleanup() evicted a connection with an in-flight stream. "+
-			"Reaper must either track active streams or consult the connection's "+
-			"stream count before closing.")
+		"cleanup() evicted a connection with activeStreams > 0 — Bug A regression")
 
-	// Stronger signal: the stream itself should still be usable after reap.
-	// If cleanup() closed the underlying connection, this write will error.
-	_, err = stream.Write([]byte{0})
-	require.NoError(t, err,
-		"Bug A (secondary): connection was closed by reaper while stream was in flight")
+	// Sanity: once the RPC completes (decActive), the connection becomes
+	// eligible for reaping again on the next cleanup() pass.
+	client.decActive()
+	client.incActive() // restore the deferred decActive balance below
+	pc.mu.Lock()
+	pc.lastUsed = time.Now().Add(-3 * time.Minute)
+	pc.mu.Unlock()
+
+	// Drop the "active" marker and re-trigger reap. Now the connection
+	// must be evicted.
+	client.decActive()
+	pool.cleanup()
+	pool.mu.RLock()
+	_, stillPooled = pool.connections[addr]
+	pool.mu.RUnlock()
+	require.False(t, stillPooled,
+		"cleanup() failed to evict a genuinely idle connection — reaper is now over-conservative")
+
+	// Keep the deferred decActive balanced (we did one extra inc above).
+	client.incActive()
 }
 
 // generateTestTLSConfig mirrors quicserver's makeServerTLSConfig but lives

--- a/quic/quicserver/server_test.go
+++ b/quic/quicserver/server_test.go
@@ -1,0 +1,143 @@
+package quicserver_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore/quic/quicclient"
+	"github.com/mulgadc/predastore/quic/quicserver"
+	"github.com/stretchr/testify/require"
+)
+
+// quicServerTestPortCounter hands each test invocation a unique port to avoid
+// UDP bind conflicts when the OS has not fully released prior test sockets.
+var quicServerTestPortCounter atomic.Int32
+
+func newTestQuicServer(t *testing.T) (*quicserver.QuicServer, string) {
+	t.Helper()
+	dir := t.TempDir()
+	port := 46000 + int(quicServerTestPortCounter.Add(1))
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	qs, err := quicserver.NewWithRetry(filepath.Join(dir, "wal"), addr, 5)
+	require.NoError(t, err)
+	return qs, addr
+}
+
+// TestQuicServer_ConcurrentShardWrites_NoWedge validates that N concurrent
+// PUT shard requests on a single pooled QUIC connection complete within a
+// generous deadline. This is the narrow-scope reproducer for Bug C in
+// docs/development/bugs/multipart-upload-deadlock.md — the WAL+QUIC head-of-
+// line wedge. Required conditions for the wedge:
+//   - One pooled QUIC connection shared by multiple streams.
+//   - Per-stream bodies large enough in aggregate to saturate the connection-
+//     level flow-control window (quic-go default 15 MiB).
+//   - Server-side handlers that hold a global lock (wal.mu) while reading
+//     from the stream.
+//
+// On a wedged server the test hangs until the 60s budget elapses. On a healthy
+// server the writes serialize through wal.mu in well under a second each and
+// total wall time is bounded by loopback bandwidth.
+func TestQuicServer_ConcurrentShardWrites_NoWedge(t *testing.T) {
+	if os.Getenv("PREDASTORE_BUG_REPRO") != "1" {
+		t.Skip("bug reproducer — set PREDASTORE_BUG_REPRO=1 to run")
+	}
+
+	qs, addr := newTestQuicServer(t)
+	defer qs.Close()
+
+	// Explicitly use a single direct Dial (not DefaultPool) so we control the
+	// connection-sharing topology — all streams fan out from this one
+	// connection, which is the necessary condition for the wedge.
+	dialCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	client, err := quicclient.Dial(dialCtx, addr)
+	require.NoError(t, err)
+	defer client.Close()
+
+	// 16 MiB per shard exceeds quic-go's 15 MiB default connection window, so
+	// 10 concurrent streams cannot all be in flight simultaneously — the
+	// server's handling of the contended wal.mu determines whether progress
+	// is made at all.
+	const streams = 10
+	const shardSize = 16 * 1024 * 1024
+
+	errCh := make(chan error, streams)
+	var wg sync.WaitGroup
+	start := time.Now()
+
+	for i := range streams {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+
+			// Unique ObjectHash/ShardIndex per goroutine to avoid local
+			// metadata key collisions on the server's badger DB.
+			hash := sha256.Sum256(fmt.Appendf(nil, "wedge-test-%d", idx))
+			body := bytes.Repeat([]byte{byte(idx)}, shardSize)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+
+			_, perr := client.Put(ctx, quicserver.PutRequest{
+				Bucket:     "wedge",
+				Object:     fmt.Sprintf("obj-%d", idx),
+				ObjectHash: hash,
+				ShardSize:  shardSize,
+				ShardIndex: idx,
+			}, bytes.NewReader(body))
+			errCh <- perr
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+	elapsed := time.Since(start)
+
+	for e := range errCh {
+		require.NoError(t, e, "concurrent PUT shard failed")
+	}
+
+	// Deadlock detector, not a perf bound. 10 × 16 MiB serialized through a
+	// local WAL on loopback should finish comfortably under 90 s; a wedged
+	// path blows through this via the 60 s per-stream context deadline.
+	require.Less(t, elapsed, 90*time.Second, "suspected WAL+QUIC wedge")
+	t.Logf("10 concurrent shards (16 MiB each) completed in %v", elapsed)
+}
+
+// Fail fast if the accept loop dies without logging; tests above rely on the
+// server actually serving connections.
+func TestQuicServer_BasicPut(t *testing.T) {
+	qs, addr := newTestQuicServer(t)
+	defer qs.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	client, err := quicclient.Dial(ctx, addr)
+	require.NoError(t, err)
+	defer client.Close()
+
+	body := []byte("hello wedge")
+	hash := sha256.Sum256([]byte("basic-put"))
+	resp, err := client.Put(ctx, quicserver.PutRequest{
+		Bucket:     "basic",
+		Object:     "obj",
+		ObjectHash: hash,
+		ShardSize:  len(body),
+		ShardIndex: 0,
+	}, io.NopCloser(bytes.NewReader(body)))
+	require.NoError(t, err)
+	require.Equal(t, len(body), resp.WriteResult.TotalSize)
+
+	// Sanity: WAL file was created on disk.
+	entries, _ := os.ReadDir(filepath.Join(qs.WalDir))
+	require.NotEmpty(t, entries)
+}

--- a/quic/quicserver/wedge_test.go
+++ b/quic/quicserver/wedge_test.go
@@ -43,14 +43,12 @@ func newTestQuicServer(t *testing.T) (*quicserver.QuicServer, string) {
 //   - Server-side handlers that hold a global lock (wal.mu) while reading
 //     from the stream.
 //
-// On a wedged server the test hangs until the 60s budget elapses. On a healthy
-// server the writes serialize through wal.mu in well under a second each and
-// total wall time is bounded by loopback bandwidth.
+// On a wedged server the test hangs until the 60s budget elapses. Post-fix
+// (9dcd3dd drains the shard body into a memory buffer before taking wal.mu
+// and 43e20f6 widens QUIC flow-control windows), the writes serialize
+// through wal.mu in well under a second each. This is now a regression
+// gate for those two fixes together.
 func TestQuicServer_ConcurrentShardWrites_NoWedge(t *testing.T) {
-	if os.Getenv("PREDASTORE_BUG_REPRO") != "1" {
-		t.Skip("bug reproducer — set PREDASTORE_BUG_REPRO=1 to run")
-	}
-
 	qs, addr := newTestQuicServer(t)
 	defer qs.Close()
 

--- a/s3/wal/wal_test.go
+++ b/s3/wal/wal_test.go
@@ -8,10 +8,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // calculateMaxFileSize calculates the max file size (ShardSize + header overhead)
@@ -1092,5 +1094,97 @@ func TestSyncDoesNotBlockWrites(t *testing.T) {
 		// Success - write completed
 	case <-timeout:
 		t.Fatal("DEADLOCK: Write blocked by sync operation for more than 5 seconds")
+	}
+}
+
+// TestWAL_BufferedWALFile_SyncWriteRace is the targeted race repro for Bug B
+// in docs/development/bugs/multipart-upload-deadlock.md. bufferedWALFile has
+// no internal synchronisation around its *bufio.Writer; the syncer calls
+// Sync() (→ writer.Flush()) outside wal.mu while a concurrent Write() holder
+// calls activeWal.Write/Stat/Flush. This test drives the race directly:
+// one goroutine holds wal.mu and streams through wal.Write (which repeatedly
+// touches bufferedWALFile.writer); another goroutine, without holding any
+// lock, calls fileToSync.Sync() on the same bufferedWALFile. Under -race,
+// this triggers a DATA RACE on bufio.Writer internals. On a future fix that
+// gives bufferedWALFile its own mutex, -race stays clean.
+//
+// Gated behind PREDASTORE_BUG_REPRO=1 because it currently fails on main —
+// that is the point (validating the bug exists). When Bug B is fixed, remove
+// the gate so this becomes a standard regression test.
+func TestWAL_BufferedWALFile_SyncWriteRace(t *testing.T) {
+	if os.Getenv("PREDASTORE_BUG_REPRO") != "1" {
+		t.Skip("bug reproducer — set PREDASTORE_BUG_REPRO=1 to run")
+	}
+	tmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("wal-bufrace-%d", time.Now().UnixNano()))
+	require.NoError(t, os.MkdirAll(tmpDir, 0750))
+	defer os.RemoveAll(tmpDir)
+
+	w, err := New("", tmpDir)
+	require.NoError(t, err)
+	// The background syncer is not what we're testing — we drive Sync()
+	// directly to make the race deterministic.
+	w.StopWALSyncer()
+	defer w.Close()
+
+	// Prime: do one write so Shard.DB[0] exists.
+	primer := bytes.Repeat([]byte{0xAA}, 8*1024)
+	_, err = w.Write(bytes.NewReader(primer), len(primer))
+	require.NoError(t, err)
+
+	stop := make(chan struct{})
+	syncerDone := make(chan struct{})
+
+	// Direct racer: bypass syncWALIfDirty entirely and call Sync() on the
+	// bufferedWALFile in a hot loop. Sync() internally does writer.Flush()
+	// and file.Sync() without any lock coordinating with writers.
+	// Capture the bufferedWALFile pointer once so the racer never touches
+	// wal.mu during its hot loop — this removes any accidental HB edge the
+	// RLock/RUnlock pair might create.
+	w.mu.RLock()
+	db := w.Shard.DB[0]
+	w.mu.RUnlock()
+
+	go func() {
+		defer close(syncerDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = db.Sync()
+			}
+		}
+	}()
+
+	// Writers: 4 goroutines × 16 writes × 256 KiB. Each Write() holds wal.mu
+	// and calls activeWal.Write/Stat/Flush 32 times over; plenty of overlap
+	// with the syncer's unsynchronised Sync() calls.
+	const writers = 4
+	const writesPerWriter = 16
+	const payload = 256 * 1024
+
+	var wg sync.WaitGroup
+	errs := make(chan error, writers*writesPerWriter)
+	for i := range writers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			buf := bytes.Repeat([]byte{byte(id)}, payload)
+			for j := range writesPerWriter {
+				if _, werr := w.Write(bytes.NewReader(buf), payload); werr != nil {
+					errs <- fmt.Errorf("writer %d iter %d: %w", id, j, werr)
+					return
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(stop)
+	<-syncerDone
+	close(errs)
+
+	for e := range errs {
+		t.Errorf("write error: %v", e)
 	}
 }

--- a/s3/wal/wal_test.go
+++ b/s3/wal/wal_test.go
@@ -1110,16 +1110,10 @@ func TestSyncDoesNotBlockWrites(t *testing.T) {
 // one goroutine holds wal.mu and streams through wal.Write (which repeatedly
 // touches bufferedWALFile.writer); another goroutine, without holding any
 // lock, calls fileToSync.Sync() on the same bufferedWALFile. Under -race,
-// this triggers a DATA RACE on bufio.Writer internals. On a future fix that
-// gives bufferedWALFile its own mutex, -race stays clean.
-//
-// Gated behind PREDASTORE_BUG_REPRO=1 because it currently fails on main —
-// that is the point (validating the bug exists). When Bug B is fixed, remove
-// the gate so this becomes a standard regression test.
+// this triggers a DATA RACE on bufio.Writer internals. Post-fix (7df9645
+// added sync.Mutex on bufferedWALFile), -race stays clean; this test is
+// the regression gate.
 func TestWAL_BufferedWALFile_SyncWriteRace(t *testing.T) {
-	if os.Getenv("PREDASTORE_BUG_REPRO") != "1" {
-		t.Skip("bug reproducer — set PREDASTORE_BUG_REPRO=1 to run")
-	}
 	tmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("wal-bufrace-%d", time.Now().UnixNano()))
 	require.NoError(t, os.MkdirAll(tmpDir, 0750))
 	defer os.RemoveAll(tmpDir)


### PR DESCRIPTION
## Summary

Four targeted tests that gate against regression of the three multipart upload wedge bugs documented in [`docs/development/bugs/multipart-upload-deadlock.md`](https://github.com/mulgadc/mulga/blob/main/docs/development/bugs/multipart-upload-deadlock.md). Full test-design rationale in [`docs/development/bugs/multipart-upload-unittest.md`](https://github.com/mulgadc/mulga/blob/main/docs/development/bugs/multipart-upload-unittest.md).

| Test | File | Gates regression of |
|---|---|---|
| `TestWAL_BufferedWALFile_SyncWriteRace` | `s3/wal/wal_test.go` | `7df9645` (Bug B — `bufferedWALFile` mutex) |
| `TestQuicServer_ConcurrentShardWrites_NoWedge` | `quic/quicserver/wedge_test.go` (new, external `quicserver_test`) | `9dcd3dd` + `43e20f6` (Bug C — drain shard body before `wal.mu` + widened QUIC flow-control) |
| `TestDistributed_MultipartUpload_ConcurrentParts_Contention` | `backend/distributed/multipart_test.go` | All three bugs end-to-end |
| `TestQuicClientPool_ReapSkipsActiveRPCStreams` | `quic/quicclient/pool_test.go` (new) | `76fdbf1` (Bug A — `Client.ActiveStreams` counter in reaper) |

History:

1. Tests originally landed on commit `9cd78cf` with a `PREDASTORE_BUG_REPRO=1` env gate because they failed on `main` — that was the validation that the bugs existed.
2. After merging upstream main (which brought in PR #7's fixes for all three bugs), the gate was dropped and Test 4 was rewritten (commit `fef39ce`) to exercise the fix's `incActive`/`decActive` counter path. All four tests now pass under `-race` in the default suite.

## Test plan

- [x] `make preflight` passes (includes `-race` run of all four).
- [x] `go test -race -run TestWAL_BufferedWALFile_SyncWriteRace ./s3/wal/` — clean.
- [x] `go test -race -run TestQuicServer_ConcurrentShardWrites_NoWedge ./quic/quicserver/` — ~1.4 s.
- [x] `go test -race -run TestDistributed_MultipartUpload_ConcurrentParts_Contention ./backend/distributed/` — ~68 s.
- [x] `go test -run TestQuicClientPool_ReapSkipsActiveRPCStreams ./quic/quicclient/` — passes.

Closes mulga-962.