### PR TITLE
feat: require host and x-amz-date in SigV4 SignedHeaders

### DIFF
--- a/auth/sigv4.go
+++ b/auth/sigv4.go
@@ -28,6 +28,29 @@ func HashSHA256(s string) string {
 	return hex.EncodeToString(hash[:])
 }
 
+// RequireSignedHeaders enforces that SigV4 SignedHeaders includes both
+// "host" and "x-amz-date". Omitting either lets a captured Authorization
+// header be replayed against a different vhost or outside the clock-skew
+// window. AWS SDKs always sign both; rejecting requests that don't is safe.
+func RequireSignedHeaders(headers []string) error {
+	var hasHost, hasDate bool
+	for _, h := range headers {
+		switch strings.ToLower(strings.TrimSpace(h)) {
+		case "host":
+			hasHost = true
+		case "x-amz-date":
+			hasDate = true
+		}
+	}
+	if !hasHost {
+		return fmt.Errorf("SignedHeaders must include host")
+	}
+	if !hasDate {
+		return fmt.Errorf("SignedHeaders must include x-amz-date")
+	}
+	return nil
+}
+
 // HmacSHA256 returns the HMAC-SHA256 of data using the given key
 func HmacSHA256(key []byte, data string) []byte {
 	h := hmac.New(sha256.New, key)

--- a/auth/sigv4_test.go
+++ b/auth/sigv4_test.go
@@ -277,6 +277,67 @@ func TestGenerateAuthHeaderReq(t *testing.T) {
 	})
 }
 
+func TestRequireSignedHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []string
+		wantErr string
+	}{
+		{
+			name:    "host and x-amz-date present",
+			headers: []string{"host", "x-amz-date"},
+			wantErr: "",
+		},
+		{
+			name:    "host, x-amz-date, content-type present",
+			headers: []string{"content-type", "host", "x-amz-date"},
+			wantErr: "",
+		},
+		{
+			name:    "case-insensitive Host accepted",
+			headers: []string{"Host", "X-Amz-Date"},
+			wantErr: "",
+		},
+		{
+			name:    "leading/trailing whitespace tolerated",
+			headers: []string{" host ", "\tx-amz-date\t"},
+			wantErr: "",
+		},
+		{
+			name:    "missing host",
+			headers: []string{"x-amz-date"},
+			wantErr: "host",
+		},
+		{
+			name:    "missing x-amz-date",
+			headers: []string{"host"},
+			wantErr: "x-amz-date",
+		},
+		{
+			name:    "both missing",
+			headers: []string{"content-type"},
+			wantErr: "host",
+		},
+		{
+			name:    "empty list",
+			headers: []string{},
+			wantErr: "host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := RequireSignedHeaders(tt.headers)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
 func TestTimeFormatConstants(t *testing.T) {
 	assert.Equal(t, "20060102T150405Z", TimeFormat)
 	assert.Equal(t, "20060102", ShortTimeFormat)

--- a/s3/authmiddleware_test.go
+++ b/s3/authmiddleware_test.go
@@ -272,6 +272,71 @@ func TestSigV4AuthMiddleware(t *testing.T) {
 	}
 }
 
+// TestSigV4AuthMiddleware_RequireSignedHeaders verifies that requests whose
+// SigV4 SignedHeaders list omits "host" or "x-amz-date" are rejected with
+// AuthorizationHeaderMalformed. AWS SDKs always sign both; omitting either
+// would let a captured Authorization header replay against a different vhost
+// or outside the X-Amz-Date skew window.
+func TestSigV4AuthMiddleware_RequireSignedHeaders(t *testing.T) {
+	s3Config := &Config{
+		Region: "ap-southeast-2",
+		Buckets: []S3_Buckets{{
+			Name:     "test-bucket01",
+			Region:   "ap-southeast-2",
+			Type:     "distributed",
+			Pathname: "testdata/test-bucket01",
+			Public:   false,
+		}},
+		Auth: []AuthEntry{{
+			AccessKeyID:     "TESTACCESSKEY",
+			SecretAccessKey: "TESTSECRETKEY",
+			Policy: []PolicyRule{{
+				Bucket:  "test-bucket01",
+				Actions: []string{"s3:GetObject", "s3:ListBucket"},
+			}},
+		}},
+	}
+	server := NewHTTP2ServerWithBackend(s3Config, nil, NewConfigProvider(s3Config.Auth))
+
+	rewriteSignedHeaders := func(req *http.Request, list string) {
+		ah := req.Header.Get("Authorization")
+		parts := strings.Split(ah, ", ")
+		if len(parts) != 3 {
+			t.Fatalf("expected 3-part auth header, got %d", len(parts))
+		}
+		parts[1] = "SignedHeaders=" + list
+		req.Header.Set("Authorization", strings.Join(parts, ", "))
+	}
+
+	tests := []struct {
+		name       string
+		signedList string
+	}{
+		{"missing host", "x-amz-date"},
+		{"missing x-amz-date", "host"},
+		{"neither present", "content-type"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test-bucket01", nil)
+			ts := time.Now().UTC().Format(auth.TimeFormat)
+			err := auth.GenerateAuthHeaderReq("TESTACCESSKEY", "TESTSECRETKEY", ts, "ap-southeast-2", "s3", req)
+			assert.NoError(t, err)
+			rewriteSignedHeaders(req, tt.signedList)
+
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Fatal("next handler must not be invoked when SignedHeaders guard fires")
+			})
+			rr := httptest.NewRecorder()
+			server.sigV4AuthMiddleware(next).ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusForbidden, rr.Code)
+			assert.Contains(t, rr.Body.String(), "AuthorizationHeaderMalformed")
+		})
+	}
+}
+
 // TestSigV4AuthMiddleware_OversizeSignedBody verifies that a signed request
 // whose body exceeds maxAuthBodySize and does not use UNSIGNED-PAYLOAD or a
 // precomputed hash is rejected with 413 EntityTooLarge, not buffered and

--- a/s3/httpserver.go
+++ b/s3/httpserver.go
@@ -301,6 +301,10 @@ func (s *HTTP2Server) sigV4AuthMiddleware(next http.Handler) http.Handler {
 		// Canonical headers
 		// Note: Go's net/http moves Host header from r.Header to r.Host
 		headers := strings.Split(signedHeaders, ";")
+		if err := auth.RequireSignedHeaders(headers); err != nil {
+			s.writeS3Error(w, r, http.StatusForbidden, "AuthorizationHeaderMalformed", err.Error())
+			return
+		}
 		sort.Strings(headers)
 
 		canonicalHeaders := ""

--- a/s3db/auth_test.go
+++ b/s3db/auth_test.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/mulgadc/predastore/auth"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSignRequest(t *testing.T) {
@@ -293,6 +295,61 @@ func TestValidateSignatureHTTP_ReplayProtection(t *testing.T) {
 			if err != nil {
 				assert.Contains(t, err.Error(), tt.wantErrSub)
 			}
+		})
+	}
+}
+
+// TestValidateSignatureHTTP_RequireSignedHeaders verifies that requests
+// whose SigV4 SignedHeaders list omits "host" or "x-amz-date" are rejected
+// before signature comparison. AWS SDKs always sign both; omitting either
+// would let a captured Authorization header replay against a different vhost
+// or outside the X-Amz-Date skew window.
+func TestValidateSignatureHTTP_RequireSignedHeaders(t *testing.T) {
+	credentials := map[string]string{"TESTACCESSKEY": "TESTSECRETKEY"}
+	const region = "us-east-1"
+	const service = "s3db"
+
+	rewriteSignedHeaders := func(req *http.Request, newList string) {
+		ah := req.Header.Get("Authorization")
+		parts := strings.Split(ah, ", ")
+		require.Len(t, parts, 3)
+		parts[1] = "SignedHeaders=" + newList
+		req.Header.Set("Authorization", strings.Join(parts, ", "))
+	}
+
+	tests := []struct {
+		name       string
+		signedList string
+		wantErrSub string
+	}{
+		{
+			name:       "missing host rejected",
+			signedList: "x-amz-date",
+			wantErrSub: "host",
+		},
+		{
+			name:       "missing x-amz-date rejected",
+			signedList: "host",
+			wantErrSub: "x-amz-date",
+		},
+		{
+			name:       "neither present rejected",
+			signedList: "content-type",
+			wantErrSub: "host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/v1/get/test-table/test-key", nil)
+			req.Host = "localhost:6660"
+			ts := time.Now().UTC().Format(auth.TimeFormat)
+			require.NoError(t, auth.GenerateAuthHeaderReq("TESTACCESSKEY", "TESTSECRETKEY", ts, region, service, req))
+			rewriteSignedHeaders(req, tt.signedList)
+
+			_, err := ValidateSignatureHTTP(req, credentials, region, service)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrSub)
 		})
 	}
 }

--- a/s3db/server.go
+++ b/s3db/server.go
@@ -717,6 +717,9 @@ func ValidateSignatureHTTP(r *http.Request, credentials map[string]string, regio
 	// Build canonical headers
 	// Note: Go's net/http moves Host header to r.Host, not r.Header
 	headers := strings.Split(signedHeaders, ";")
+	if err := auth.RequireSignedHeaders(headers); err != nil {
+		return "", err
+	}
 	sort.Strings(headers)
 
 	canonicalHeaders := ""


### PR DESCRIPTION
AWS SDKs always sign both host and x-amz-date. Accepting a SigV4 request that omits either lets a captured Authorization header replay against a different vhost or outside the X-Amz-Date skew window.

Adds auth.RequireSignedHeaders and applies it in the s3 HTTP server and s3db ValidateSignatureHTTP after parsing the SignedHeaders list.