### PR TITLE
fix: refuse to start s3db with no credentials configured

### DIFF
--- a/s3/server.go
+++ b/s3/server.go
@@ -320,6 +320,11 @@ func (s *Server) launchDBServers() []*s3db.Server {
 		}
 	}
 
+	if len(credentials) == 0 {
+		slog.Error("No s3db credentials configured; refusing to launch database servers (set credentials on [[db]] or [[auth]])")
+		return nil
+	}
+
 	// Determine which nodes to launch
 	var nodesToLaunch []s3db.DBNodeConfig
 	if s.nodeID > 0 {

--- a/s3db/server.go
+++ b/s3db/server.go
@@ -86,6 +86,12 @@ func NewServer(config *ServerConfig) (*Server, error) {
 		return nil, fmt.Errorf("cluster config is required")
 	}
 
+	// Fail closed: an empty credentials map would otherwise grant unauthenticated
+	// access to the Raft-backed IAM mutation endpoints under /v1/*.
+	if len(config.Credentials) == 0 {
+		return nil, fmt.Errorf("s3db: no credentials configured; refusing to start (set credentials on [[db]] or [[auth]])")
+	}
+
 	// Initialize Raft node
 	node, err := NewRaftNode(config.ClusterConfig)
 	if err != nil {
@@ -141,12 +147,6 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Skip auth for health and status endpoints
 		if r.URL.Path == "/health" || r.URL.Path == "/status" {
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		// Skip auth if no credentials configured
-		if len(s.config.Credentials) == 0 {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/s3db/server_test.go
+++ b/s3db/server_test.go
@@ -1,0 +1,62 @@
+package s3db
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewServer_RejectsEmptyCredentials verifies the constructor fails closed
+// when no credentials are configured. The previous behaviour silently bypassed
+// the SigV4 middleware in this state, granting unauthenticated access to the
+// Raft-backed IAM mutation endpoints.
+func TestNewServer_RejectsEmptyCredentials(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	clusterCfg := DefaultClusterConfig()
+	clusterCfg.NodeID = 1
+	clusterCfg.DataDir = tmpDir
+	clusterCfg.Bootstrap = true
+	clusterCfg.Nodes = []DBNodeConfig{
+		{ID: 1, Host: "127.0.0.1", Port: 16670, RaftPort: 17670, Path: filepath.Join(tmpDir, "node-1")},
+	}
+
+	cases := []struct {
+		name        string
+		credentials map[string]string
+	}{
+		{name: "nil map", credentials: nil},
+		{name: "empty map", credentials: map[string]string{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &ServerConfig{
+				Addr:          "127.0.0.1:0",
+				Credentials:   tc.credentials,
+				ClusterConfig: clusterCfg,
+			}
+
+			server, err := NewServer(cfg)
+			require.Error(t, err)
+			assert.Nil(t, server)
+			assert.Contains(t, err.Error(), "no credentials configured")
+		})
+	}
+}
+
+// TestNewServer_RejectsMissingClusterConfig keeps coverage on the existing
+// nil-cluster-config guard so the credentials check above can't accidentally
+// shadow it in future refactors.
+func TestNewServer_RejectsMissingClusterConfig(t *testing.T) {
+	cfg := &ServerConfig{
+		Credentials: map[string]string{"key": "secret"},
+	}
+
+	server, err := NewServer(cfg)
+	require.Error(t, err)
+	assert.Nil(t, server)
+	assert.Contains(t, err.Error(), "cluster config is required")
+}


### PR DESCRIPTION
## Summary

- `s3db.NewServer` now returns an error when `Credentials` is empty, instead of silently bypassing SigV4 in the auth middleware.
- `s3.launchDBServers` aborts (with an error log) before spawning Raft goroutines when neither `[[db]]` nor `[[auth]]` provides any credentials, so misconfiguration surfaces at startup.
- Removed the now-unreachable empty-credentials bypass branch from `authMiddleware`.

## Why

The previous behaviour granted unauthenticated full access to the Raft-backed IAM mutation endpoints (`/v1/put`, `/v1/delete`, `/v1/join`) when the credentials map was empty — typically the result of a misconfigured deployment. Failing closed at boot is louder than failing per-request and matches the security posture of the main S3 path and gateway.

Tracked in mulgadc/mulga#14 (private). Original report flagged five findings; the other four were already fixed on `dev` (`61e174c`, `f87432f`, `8f48b0d`, `4984c8e`).

## Test plan

- [x] `make preflight` passes (lint, govulncheck, race tests)
- [x] New `TestNewServer_RejectsEmptyCredentials` covers nil and empty-map cases
- [x] `TestNewServer_RejectsMissingClusterConfig` retained for the existing guard
- [x] Reviewer sanity-check: confirm no production caller intentionally relies on anonymous s3db access (audit shows `launchDefaultDB` always seeds `predastore:predastore`, and `launchDBServers` is the only other constructor path)