### PR TITLE
feat: TLS 1.3 minimum + PQ encryption

### DIFF
--- a/internal/tlsconfig/curves.go
+++ b/internal/tlsconfig/curves.go
@@ -11,16 +11,21 @@ package tlsconfig
 
 import "crypto/tls"
 
-// Curves is the fixed PQ-only TLS 1.3 curve allowlist:
+// Curves is the fixed TLS 1.3 curve allowlist:
 //
 //   - X25519MLKEM768     — Cat 3 ML-KEM hybrid, wins under Go 1.26 stdlib filter
-//   - SecP384r1MLKEM1024 — Cat 5 ML-KEM hybrid, Cat 5 fallback for peers that prefer it
+//   - SecP384r1MLKEM1024 — Cat 5 ML-KEM hybrid, fallback for peers that prefer it
+//   - X25519             — classical TLS 1.3 fallback for SDKs without ML-KEM (aws CLI v2 today)
+//   - CurveP384          — classical TLS 1.3 fallback (Java/.NET enterprise SDKs)
 //
-// Classical curves (X25519, P-384, P-256, P-521) and the weak hybrid
-// SecP256r1MLKEM768 are intentionally excluded so they cannot be advertised.
-// Pairing this allowlist with tls.VersionTLS13 minimum closes the HNDL gap
-// absolutely: every handshake is ML-KEM hybrid, no classical key exchange,
-// no TLS 1.2.
+// PQ-capable peers (browsers since 2024, Go aws-sdk v2 with Go 1.24+) always
+// negotiate the hybrid first; classical fallback only triggers for peers that
+// cannot do ML-KEM. Those connections still get TLS 1.3 + AES-256-GCM but
+// remain HNDL-exposed — accepted trade-off until AWS CLI v2 / bundled
+// OpenSSL ships ML-KEM (currently lagging upstream OpenSSL 3.5).
+//
+// Weak/niche entries from the Go stdlib default (SecP256r1MLKEM768, P-256,
+// P-521) are intentionally excluded so they cannot be advertised.
 //
 // Go 1.26 stdlib treats tls.Config.CurvePreferences as an allowlist filter
 // applied to the stdlib default order, not as a user-supplied order.
@@ -30,4 +35,6 @@ import "crypto/tls"
 var Curves = []tls.CurveID{
 	tls.X25519MLKEM768,
 	tls.SecP384r1MLKEM1024,
+	tls.X25519,
+	tls.CurveP384,
 }

--- a/internal/tlsconfig/curves.go
+++ b/internal/tlsconfig/curves.go
@@ -1,0 +1,33 @@
+// Package tlsconfig pins the cluster-wide TLS 1.3 curve preference list.
+//
+// The list is hardcoded because mixed classification on a single cluster is
+// not supported and the certified FIPS build is itself the per-deployment
+// choice. A typo in a config string would silently downgrade where a missing
+// constant cannot.
+//
+// Mirror of spinifex/internal/tlsconfig/curves.go. Duplication is cheaper
+// than threading a shared dependency across module boundaries.
+package tlsconfig
+
+import "crypto/tls"
+
+// Curves is the fixed PQ-only TLS 1.3 curve allowlist:
+//
+//   - X25519MLKEM768     — Cat 3 ML-KEM hybrid, wins under Go 1.26 stdlib filter
+//   - SecP384r1MLKEM1024 — Cat 5 ML-KEM hybrid, Cat 5 fallback for peers that prefer it
+//
+// Classical curves (X25519, P-384, P-256, P-521) and the weak hybrid
+// SecP256r1MLKEM768 are intentionally excluded so they cannot be advertised.
+// Pairing this allowlist with tls.VersionTLS13 minimum closes the HNDL gap
+// absolutely: every handshake is ML-KEM hybrid, no classical key exchange,
+// no TLS 1.2.
+//
+// Go 1.26 stdlib treats tls.Config.CurvePreferences as an allowlist filter
+// applied to the stdlib default order, not as a user-supplied order.
+//
+// Callers must not mutate this slice. Assign it directly to
+// tls.Config.CurvePreferences; do not append to it.
+var Curves = []tls.CurveID{
+	tls.X25519MLKEM768,
+	tls.SecP384r1MLKEM1024,
+}

--- a/internal/tlsconfig/curves_test.go
+++ b/internal/tlsconfig/curves_test.go
@@ -25,23 +25,23 @@ func TestCurves_OnlyApprovedEntries(t *testing.T) {
 	want := []tls.CurveID{
 		tls.X25519MLKEM768,
 		tls.SecP384r1MLKEM1024,
+		tls.X25519,
+		tls.CurveP384,
 	}
 	if !slices.Equal(tlsconfig.Curves, want) {
 		t.Errorf("Curves = %v, want %v", tlsconfig.Curves, want)
 	}
 }
 
-func TestCurves_ExcludesClassicalAndWeakPrimitives(t *testing.T) {
+func TestCurves_ExcludesWeakPrimitives(t *testing.T) {
 	forbidden := []tls.CurveID{
 		tls.SecP256r1MLKEM768,
-		tls.X25519,
 		tls.CurveP256,
-		tls.CurveP384,
 		tls.CurveP521,
 	}
 	for _, c := range forbidden {
 		if slices.Contains(tlsconfig.Curves, c) {
-			t.Errorf("Curves includes forbidden curve %v (PQ-only policy)", c)
+			t.Errorf("Curves includes forbidden curve %v", c)
 		}
 	}
 }

--- a/internal/tlsconfig/curves_test.go
+++ b/internal/tlsconfig/curves_test.go
@@ -1,0 +1,160 @@
+package tlsconfig_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore/internal/tlsconfig"
+)
+
+func TestCurves_OnlyApprovedEntries(t *testing.T) {
+	want := []tls.CurveID{
+		tls.X25519MLKEM768,
+		tls.SecP384r1MLKEM1024,
+	}
+	if !slices.Equal(tlsconfig.Curves, want) {
+		t.Errorf("Curves = %v, want %v", tlsconfig.Curves, want)
+	}
+}
+
+func TestCurves_ExcludesClassicalAndWeakPrimitives(t *testing.T) {
+	forbidden := []tls.CurveID{
+		tls.SecP256r1MLKEM768,
+		tls.X25519,
+		tls.CurveP256,
+		tls.CurveP384,
+		tls.CurveP521,
+	}
+	for _, c := range forbidden {
+		if slices.Contains(tlsconfig.Curves, c) {
+			t.Errorf("Curves includes forbidden curve %v (PQ-only policy)", c)
+		}
+	}
+}
+
+func TestIntegration_NegotiatesPQHybrid(t *testing.T) {
+	cert := selfSignedCert(t)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	srv.TLS = &tls.Config{
+		Certificates:     []tls.Certificate{cert},
+		MinVersion:       tls.VersionTLS13,
+		CurvePreferences: tlsconfig.Curves,
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:          pool,
+				CurvePreferences: tlsconfig.Curves,
+			},
+		},
+	}
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("https get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	state := resp.TLS
+	if state == nil {
+		t.Fatal("response has no TLS state")
+	}
+	if state.Version != tls.VersionTLS13 {
+		t.Errorf("negotiated version = 0x%x, want TLS 1.3 (0x%x)", state.Version, tls.VersionTLS13)
+	}
+	pqHybrids := []tls.CurveID{tls.X25519MLKEM768, tls.SecP384r1MLKEM1024}
+	if !slices.Contains(pqHybrids, state.CurveID) {
+		t.Errorf("negotiated curve = %v, want one of %v (PQ hybrid)", state.CurveID, pqHybrids)
+	}
+}
+
+func TestIntegration_TLS12ClientRejected(t *testing.T) {
+	cert := selfSignedCert(t)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	srv.TLS = &tls.Config{
+		Certificates:     []tls.Certificate{cert},
+		MinVersion:       tls.VersionTLS13,
+		CurvePreferences: tlsconfig.Curves,
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    pool,
+				MinVersion: tls.VersionTLS12,
+				MaxVersion: tls.VersionTLS12,
+			},
+		},
+	}
+	_, err := client.Get(srv.URL)
+	if err == nil {
+		t.Fatal("TLS 1.2-pinned client succeeded; MinVersion not enforced")
+	}
+	if !strings.Contains(err.Error(), "protocol version") &&
+		!strings.Contains(err.Error(), "tls:") {
+		t.Errorf("expected protocol-version handshake error, got: %v", err)
+	}
+}
+
+func selfSignedCert(t *testing.T) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "tlsconfig-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	pair, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("X509KeyPair: %v", err)
+	}
+	return pair
+}

--- a/quic/quicclient/quicclient.go
+++ b/quic/quicclient/quicclient.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/mulgadc/predastore/internal/tlsconfig"
 	"github.com/mulgadc/predastore/quic/quicconf"
 	"github.com/mulgadc/predastore/quic/quicproto"
 	"github.com/mulgadc/predastore/quic/quicserver"
@@ -46,6 +47,8 @@ func Dial(ctx context.Context, addr string) (*Client, error) {
 	tlsConf := &tls.Config{
 		InsecureSkipVerify: true, // demo only. Use mTLS with your CA in prod.
 		NextProtos:         []string{alpn},
+		MinVersion:         tls.VersionTLS13,
+		CurvePreferences:   tlsconfig.Curves,
 	}
 	conn, err := quic.DialAddr(ctx, addr, tlsConf, &quic.Config{
 		HandshakeIdleTimeout: 5 * time.Second,

--- a/quic/quicserver/server.go
+++ b/quic/quicserver/server.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/mulgadc/predastore/internal/masterkey"
+	"github.com/mulgadc/predastore/internal/tlsconfig"
 	"github.com/mulgadc/predastore/quic/quicconf"
 	"github.com/mulgadc/predastore/quic/quicproto"
 	"github.com/mulgadc/predastore/store"
@@ -425,5 +426,9 @@ func makeServerTLSConfig() (*tls.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &tls.Config{Certificates: []tls.Certificate{cert}}, nil
+	return &tls.Config{
+		Certificates:     []tls.Certificate{cert},
+		MinVersion:       tls.VersionTLS13,
+		CurvePreferences: tlsconfig.Curves,
+	}, nil
 }

--- a/s3/httpserver.go
+++ b/s3/httpserver.go
@@ -29,6 +29,7 @@ import (
 	"github.com/mulgadc/predastore/auth"
 	"github.com/mulgadc/predastore/backend"
 	"github.com/mulgadc/predastore/backend/distributed"
+	"github.com/mulgadc/predastore/internal/tlsconfig"
 	"github.com/mulgadc/predastore/ratelimit"
 	"github.com/mulgadc/predastore/s3/chunked"
 )
@@ -930,19 +931,9 @@ func (s *HTTP2Server) ListenAndServe(addr, certFile, keyFile string) error {
 		Certificates: []tls.Certificate{cert},
 		// NextProtos enables ALPN for HTTP/2 negotiation
 		// "h2" = HTTP/2, "http/1.1" = HTTP/1.1 fallback
-		NextProtos: []string{"h2", "http/1.1"},
-		MinVersion: tls.VersionTLS12,
-		// Optimized cipher suites for performance
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-		},
-		// Session resumption for faster reconnects
-		SessionTicketsDisabled: false,
+		NextProtos:       []string{"h2", "http/1.1"},
+		MinVersion:       tls.VersionTLS13,
+		CurvePreferences: tlsconfig.Curves,
 	}
 
 	s.server = &http.Server{

--- a/s3db/client.go
+++ b/s3db/client.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/mulgadc/predastore/internal/tlsconfig"
 )
 
 // Client provides access to the distributed database cluster
@@ -72,6 +74,8 @@ func NewClient(config *ClientConfig) *Client {
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: config.InsecureSkipVerify,
 			NextProtos:         []string{"h2", "http/1.1"},
+			MinVersion:         tls.VersionTLS13,
+			CurvePreferences:   tlsconfig.Curves,
 		},
 		ForceAttemptHTTP2: true,
 	}

--- a/s3db/server.go
+++ b/s3db/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/mulgadc/predastore/auth"
+	"github.com/mulgadc/predastore/internal/tlsconfig"
 )
 
 // maxAuthBodySize bounds the request body read during SigV4 validation to
@@ -518,19 +519,9 @@ func (s *Server) Start() error {
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		// NextProtos enables ALPN for HTTP/2 negotiation
-		NextProtos: []string{"h2", "http/1.1"},
-		MinVersion: tls.VersionTLS12,
-		// Optimized cipher suites for performance
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-		},
-		// Session resumption for faster reconnects
-		SessionTicketsDisabled: false,
+		NextProtos:       []string{"h2", "http/1.1"},
+		MinVersion:       tls.VersionTLS13,
+		CurvePreferences: tlsconfig.Curves,
 	}
 
 	s.server = &http.Server{


### PR DESCRIPTION
Every predastore TLS surface (s3 HTTP/2 server, s3db server + client, QUIC server + client) now pins MinVersion: tls.VersionTLS13 and CurvePreferences: {X25519MLKEM768, SecP384r1MLKEM1024, X25519, CP384}.