### PR TITLE
feat: load QUIC server cert from disk + drop InsecureSkipVerify

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -141,7 +141,5 @@ linters:
         linters: [gosec] # file path from variable — necessary for config/data loading
       - text: "G401"
         linters: [gosec] # use of weak crypto (MD5) — used for S3 Content-MD5 compatibility
-      - text: "G402"
-        linters: [gosec] # TLS config — we handle TLS ourselves
       - text: "G501"
         linters: [gosec] # import of crypto/md5 — required for S3 Content-MD5

--- a/README.md
+++ b/README.md
@@ -125,6 +125,29 @@ TLS certificates are generated on first build:
 make certs              # Generate certs/server.{pem,key}
 ```
 
+### Standalone TLS Trust
+
+The QUIC inter-node transport and the s3db REST client now verify the server
+certificate — `InsecureSkipVerify` is gone from both the production code path
+and the test fixtures (tests inject an ephemeral CA via
+`quicclient.SetDefaultRootCAs`). Standalone operators must install the cluster
+CA into the host trust store before launching `s3d`, otherwise nodes cannot
+dial each other:
+
+```bash
+# Debian / Ubuntu
+sudo cp cluster-ca.pem /usr/local/share/ca-certificates/predastore-cluster-ca.crt
+sudo update-ca-certificates
+
+# RHEL / Fedora / Amazon Linux
+sudo cp cluster-ca.pem /etc/pki/ca-trust/source/anchors/predastore-cluster-ca.pem
+sudo update-ca-trust
+```
+
+When predastore is deployed by Spinifex, the cluster CA is installed into the
+host trust store automatically as part of node bootstrap — no manual action is
+required.
+
 ### AWS CLI Examples
 
 ```bash

--- a/backend/distributed/distributed_putobject_test.go
+++ b/backend/distributed/distributed_putobject_test.go
@@ -12,6 +12,8 @@ import (
 
 	s3backend "github.com/mulgadc/predastore/backend"
 	"github.com/mulgadc/predastore/internal/storetest"
+	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/quic/quicserver"
 	"github.com/stretchr/testify/require"
 )
@@ -49,13 +51,20 @@ func TestPutObjectWithTempFile(t *testing.T) {
 	dataDir := filepath.Join(tmpDir, "nodes")
 	backend.SetDataDir(dataDir)
 
+	certPath, keyPath, pool := testcerts.Generate(t)
+	quicclient.SetDefaultRootCAs(pool)
+	t.Cleanup(func() { quicclient.SetDefaultRootCAs(nil) })
+
 	// Start QUIC servers for nodes 0-4 on test ports
 	quicServers := make([]*quicserver.QuicServer, 5)
 	for i := range 5 {
 		nodeDir := filepath.Join(dataDir, fmt.Sprintf("node-%d", i))
 		require.NoError(t, os.MkdirAll(nodeDir, 0750))
 
-		qs, err := quicserver.NewWithRetry(nodeDir, fmt.Sprintf("127.0.0.1:%d", testBasePort+i), 5, quicserver.WithMasterKey(storetest.TestKey()))
+		qs, err := quicserver.NewWithRetry(nodeDir, fmt.Sprintf("127.0.0.1:%d", testBasePort+i), 5,
+			quicserver.WithMasterKey(storetest.TestKey()),
+			quicserver.WithTLSCertFiles(certPath, keyPath),
+		)
 		require.NoError(t, err, "Failed to start QUIC server for node %d", i)
 		quicServers[i] = qs
 	}

--- a/backend/distributed/distributed_test.go
+++ b/backend/distributed/distributed_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/klauspost/reedsolomon"
 	s3backend "github.com/mulgadc/predastore/backend"
 	"github.com/mulgadc/predastore/internal/storetest"
+	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/quic/quicserver"
 	"github.com/mulgadc/predastore/s3db"
 	"github.com/mulgadc/predastore/store"
@@ -49,6 +51,10 @@ func TestPutObject_ShardPlacementAndReconstruction(t *testing.T) {
 	dataDir := filepath.Join(tmpDir, "nodes")
 	backend.SetDataDir(dataDir)
 
+	certPath, keyPath, pool := testcerts.Generate(t)
+	quicclient.SetDefaultRootCAs(pool)
+	t.Cleanup(func() { quicclient.SetDefaultRootCAs(nil) })
+
 	nodeDirs := make([]string, partitionCount)
 	quicServers := make([]*quicserver.QuicServer, partitionCount)
 	for i := range partitionCount {
@@ -56,7 +62,10 @@ func TestPutObject_ShardPlacementAndReconstruction(t *testing.T) {
 		require.NoError(t, os.MkdirAll(nodeDir, 0750))
 		nodeDirs[i] = nodeDir
 
-		qs, err := quicserver.NewWithRetry(nodeDir, fmt.Sprintf("127.0.0.1:%d", testBasePort+i), 5, quicserver.WithMasterKey(storetest.TestKey()))
+		qs, err := quicserver.NewWithRetry(nodeDir, fmt.Sprintf("127.0.0.1:%d", testBasePort+i), 5,
+			quicserver.WithMasterKey(storetest.TestKey()),
+			quicserver.WithTLSCertFiles(certPath, keyPath),
+		)
 		require.NoError(t, err, "Failed to start QUIC server for node %d", i)
 		quicServers[i] = qs
 	}
@@ -155,12 +164,19 @@ func TestPutGetRoundTrip(t *testing.T) {
 	dataDir := filepath.Join(tmpDir, "nodes")
 	backend.SetDataDir(dataDir)
 
+	certPath, keyPath, pool := testcerts.Generate(t)
+	quicclient.SetDefaultRootCAs(pool)
+	t.Cleanup(func() { quicclient.SetDefaultRootCAs(nil) })
+
 	quicServers := make([]*quicserver.QuicServer, partitionCount)
 	for i := range partitionCount {
 		nodeDir := filepath.Join(dataDir, fmt.Sprintf("node-%d", i))
 		require.NoError(t, os.MkdirAll(nodeDir, 0750))
 
-		qs, err := quicserver.NewWithRetry(nodeDir, fmt.Sprintf("127.0.0.1:%d", testBasePort+i), 5, quicserver.WithMasterKey(storetest.TestKey()))
+		qs, err := quicserver.NewWithRetry(nodeDir, fmt.Sprintf("127.0.0.1:%d", testBasePort+i), 5,
+			quicserver.WithMasterKey(storetest.TestKey()),
+			quicserver.WithTLSCertFiles(certPath, keyPath),
+		)
 		require.NoError(t, err, "Failed to start QUIC server for node %d", i)
 		quicServers[i] = qs
 	}
@@ -345,12 +361,19 @@ func TestGetObjectByteRange(t *testing.T) {
 	dataDir := filepath.Join(tmpDir, "nodes")
 	backend.SetDataDir(dataDir)
 
+	certPath, keyPath, pool := testcerts.Generate(t)
+	quicclient.SetDefaultRootCAs(pool)
+	t.Cleanup(func() { quicclient.SetDefaultRootCAs(nil) })
+
 	quicServers := make([]*quicserver.QuicServer, 5)
 	for i := range 5 {
 		nodeDir := filepath.Join(dataDir, fmt.Sprintf("node-%d", i))
 		require.NoError(t, os.MkdirAll(nodeDir, 0750))
 
-		qs, err := quicserver.NewWithRetry(nodeDir, fmt.Sprintf("127.0.0.1:%d", testBasePort+i), 5, quicserver.WithMasterKey(storetest.TestKey()))
+		qs, err := quicserver.NewWithRetry(nodeDir, fmt.Sprintf("127.0.0.1:%d", testBasePort+i), 5,
+			quicserver.WithMasterKey(storetest.TestKey()),
+			quicserver.WithTLSCertFiles(certPath, keyPath),
+		)
 		require.NoError(t, err, "Failed to start QUIC server for node %d", i)
 		quicServers[i] = qs
 	}

--- a/backend/distributed/globalstate.go
+++ b/backend/distributed/globalstate.go
@@ -141,13 +141,12 @@ func NewDistributedState(cfg *DBClientConfig) (*DistributedState, error) {
 	}
 
 	client := s3db.NewClient(&s3db.ClientConfig{
-		Nodes:              cfg.Nodes,
-		AccessKeyID:        cfg.AccessKeyID,
-		SecretAccessKey:    cfg.SecretAccessKey,
-		Region:             region,
-		Service:            "s3db",
-		InsecureSkipVerify: true, // For self-signed certs
-		MaxRetries:         3,    // Required - 0 would skip the retry loop entirely
+		Nodes:           cfg.Nodes,
+		AccessKeyID:     cfg.AccessKeyID,
+		SecretAccessKey: cfg.SecretAccessKey,
+		Region:          region,
+		Service:         "s3db",
+		MaxRetries:      3, // Required - 0 would skip the retry loop entirely
 	})
 
 	return &DistributedState{client: client}, nil

--- a/backend/distributed/multipart_test.go
+++ b/backend/distributed/multipart_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/mulgadc/predastore/backend"
 	"github.com/mulgadc/predastore/backend/multipart"
 	"github.com/mulgadc/predastore/internal/storetest"
+	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/quic/quicserver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,13 +54,20 @@ func setupMultipartTestBackend(t *testing.T) (*Backend, func()) {
 	dataDir := filepath.Join(tmpDir, "nodes")
 	be.SetDataDir(dataDir)
 
+	certPath, keyPath, pool := testcerts.Generate(t)
+	quicclient.SetDefaultRootCAs(pool)
+	t.Cleanup(func() { quicclient.SetDefaultRootCAs(nil) })
+
 	// Start QUIC servers
 	quicServers := make([]*quicserver.QuicServer, 5)
 	for i := range 5 {
 		nodeDir := filepath.Join(dataDir, fmt.Sprintf("node-%d", i))
 		require.NoError(t, os.MkdirAll(nodeDir, 0750))
 
-		qs, err := quicserver.NewWithRetry(nodeDir, fmt.Sprintf("127.0.0.1:%d", testBasePort+i), 5, quicserver.WithMasterKey(storetest.TestKey()))
+		qs, err := quicserver.NewWithRetry(nodeDir, fmt.Sprintf("127.0.0.1:%d", testBasePort+i), 5,
+			quicserver.WithMasterKey(storetest.TestKey()),
+			quicserver.WithTLSCertFiles(certPath, keyPath),
+		)
 		require.NoError(t, err, "Failed to start QUIC server for node %d", i)
 		quicServers[i] = qs
 	}

--- a/backend/distributed/operations_test.go
+++ b/backend/distributed/operations_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/mulgadc/predastore/backend"
 	"github.com/mulgadc/predastore/internal/storetest"
+	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/quic/quicserver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,12 +47,19 @@ func setupTestBackend(t *testing.T) *Backend {
 	dataDir := filepath.Join(tmpDir, "nodes")
 	be.SetDataDir(dataDir)
 
+	certPath, keyPath, pool := testcerts.Generate(t)
+	quicclient.SetDefaultRootCAs(pool)
+	t.Cleanup(func() { quicclient.SetDefaultRootCAs(nil) })
+
 	quicServers := make([]*quicserver.QuicServer, 5)
 	for i := range 5 {
 		nodeDir := filepath.Join(dataDir, fmt.Sprintf("node-%d", i))
 		require.NoError(t, os.MkdirAll(nodeDir, 0750))
 
-		qs, err := quicserver.NewWithRetry(nodeDir, fmt.Sprintf("127.0.0.1:%d", testBasePort+i), 5, quicserver.WithMasterKey(storetest.TestKey()))
+		qs, err := quicserver.NewWithRetry(nodeDir, fmt.Sprintf("127.0.0.1:%d", testBasePort+i), 5,
+			quicserver.WithMasterKey(storetest.TestKey()),
+			quicserver.WithTLSCertFiles(certPath, keyPath),
+		)
 		require.NoError(t, err, "Failed to start QUIC server for node %d", i)
 		quicServers[i] = qs
 	}

--- a/cmd/quicd/main.go
+++ b/cmd/quicd/main.go
@@ -13,13 +13,26 @@ func main() {
 	storageRoot := flag.String("storage-root", "./data", "Storage root directory")
 	addr := flag.String("addr", "0.0.0.0:7443", "Address to listen on")
 	encryptionKeyFile := flag.String("encryption-key-file", "", "Path to 32-byte AES-256 master key for encryption at rest (required)")
+	tlsCert := flag.String("tls-cert", "", "Path to PEM-encoded TLS server certificate (required)")
+	tlsKey := flag.String("tls-key", "", "Path to PEM-encoded TLS server key (required)")
 	flag.Parse()
 
 	if env := os.Getenv("ENCRYPTION_KEY_FILE"); env != "" {
 		*encryptionKeyFile = env
 	}
+	if env := os.Getenv("TLS_CERT"); env != "" {
+		*tlsCert = env
+	}
+	if env := os.Getenv("TLS_KEY"); env != "" {
+		*tlsKey = env
+	}
 	if *encryptionKeyFile == "" {
 		slog.Error("Missing required flag: -encryption-key-file (or ENCRYPTION_KEY_FILE)")
+		flag.Usage()
+		os.Exit(1)
+	}
+	if *tlsCert == "" || *tlsKey == "" {
+		slog.Error("Missing required flags: -tls-cert and -tls-key (or TLS_CERT/TLS_KEY)")
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -30,5 +43,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	quicserver.New(*storageRoot, *addr, quicserver.WithMasterKey(key))
+	quicserver.New(*storageRoot, *addr,
+		quicserver.WithMasterKey(key),
+		quicserver.WithTLSCertFiles(*tlsCert, *tlsKey),
+	)
 }

--- a/cmd/s3client/main.go
+++ b/cmd/s3client/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
-	"crypto/tls"
 	"encoding/hex"
 	"flag"
 	"fmt"
@@ -17,17 +16,16 @@ import (
 
 // Options for the client
 type ClientOptions struct {
-	Endpoint     string
-	Region       string
-	Bucket       string
-	Method       string
-	Path         string
-	Body         string
-	BodyFile     string
-	AccessKey    string
-	SecretKey    string
-	OutputFile   string
-	SkipTLSCheck bool
+	Endpoint   string
+	Region     string
+	Bucket     string
+	Method     string
+	Path       string
+	Body       string
+	BodyFile   string
+	AccessKey  string
+	SecretKey  string
+	OutputFile string
 }
 
 func main() {
@@ -65,14 +63,7 @@ func main() {
 		}
 	}
 
-	// Create HTTP client (skip TLS verification if requested)
 	client := &http.Client{}
-	if opts.SkipTLSCheck {
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		client = &http.Client{Transport: tr}
-	}
 
 	// Create request
 	req, err := http.NewRequest(opts.Method, url, bytes.NewReader([]byte(body)))
@@ -158,7 +149,6 @@ func parseFlags() ClientOptions {
 	flag.StringVar(&opts.AccessKey, "access-key", "", "AWS access key")
 	flag.StringVar(&opts.SecretKey, "secret-key", "", "AWS secret key")
 	flag.StringVar(&opts.OutputFile, "output", "", "File to write response to")
-	flag.BoolVar(&opts.SkipTLSCheck, "skip-tls-check", false, "Skip TLS certificate verification")
 
 	flag.Parse()
 

--- a/internal/testcerts/testcerts.go
+++ b/internal/testcerts/testcerts.go
@@ -1,0 +1,59 @@
+// Package testcerts generates ephemeral self-signed TLS certificates for tests
+// that exercise verify-on TLS code paths. Production code never imports this.
+package testcerts
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Generate creates a self-signed cert/key in t.TempDir() with SANs covering
+// `localhost` and `127.0.0.1`, writes them as PEM files, and returns the file
+// paths plus an *x509.CertPool that trusts the generated cert.
+func Generate(t *testing.T) (certPath, keyPath string, pool *x509.CertPool) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "predastore-test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	require.NoError(t, os.WriteFile(certPath, certPEM, 0o600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
+
+	pool = x509.NewCertPool()
+	parsed, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	pool.AddCert(parsed)
+
+	return certPath, keyPath, pool
+}

--- a/quic/quicclient/pool.go
+++ b/quic/quicclient/pool.go
@@ -3,20 +3,47 @@ package quicclient
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/mulgadc/predastore/internal/tlsconfig"
 	"github.com/mulgadc/predastore/quic/quicconf"
 	"github.com/quic-go/quic-go"
 )
+
+// rootCAs is the package-level root CA pool consulted at dial time. Nil ⇒ OS
+// trust store, which is the production path (cluster CA installed via
+// update-ca-certificates / update-ca-trust). Tests inject an ephemeral CA via
+// SetDefaultRootCAs before any dial happens.
+var rootCAs atomic.Pointer[x509.CertPool]
+
+// SetDefaultRootCAs replaces the root CA pool consulted by Dial and the
+// default Pool. Pass nil to restore the OS trust store. Production code
+// should never call this — it exists so tests that exercise the strict-verify
+// code path can trust an ephemeral CA.
+func SetDefaultRootCAs(pool *x509.CertPool) {
+	rootCAs.Store(pool)
+}
+
+// tlsConfigForDial builds a fresh strict-verify *tls.Config. RootCAs comes
+// from the package-level default (nil ⇒ OS trust store).
+func tlsConfigForDial() *tls.Config {
+	return &tls.Config{
+		RootCAs:          rootCAs.Load(),
+		NextProtos:       []string{alpn},
+		MinVersion:       tls.VersionTLS13,
+		CurvePreferences: tlsconfig.Curves,
+	}
+}
 
 // Pool manages a pool of QUIC connections to multiple nodes.
 // Connections are reused to avoid TLS handshake overhead.
 type Pool struct {
 	mu          sync.RWMutex
 	connections map[string]*pooledConn
-	tlsConf     *tls.Config
 	quicConf    *quic.Config
 }
 
@@ -31,10 +58,6 @@ type pooledConn struct {
 func NewPool() *Pool {
 	p := &Pool{
 		connections: make(map[string]*pooledConn),
-		tlsConf: &tls.Config{
-			InsecureSkipVerify: true, // demo only. Use mTLS with your CA in prod.
-			NextProtos:         []string{alpn},
-		},
 		quicConf: &quic.Config{
 			HandshakeIdleTimeout: 5 * time.Second,
 			KeepAlivePeriod:      15 * time.Second,
@@ -105,8 +128,10 @@ func (p *Pool) createConnection(ctx context.Context, addr string) (*Client, erro
 		pc.mu.Unlock()
 	}
 
-	// Create new QUIC connection
-	conn, err := quic.DialAddr(ctx, addr, p.tlsConf, p.quicConf)
+	// Create new QUIC connection. Rebuild TLS config per dial so the pool
+	// picks up SetDefaultRootCAs updates (DefaultPool is constructed at
+	// package init, before any test can inject a CA).
+	conn, err := quic.DialAddr(ctx, addr, tlsConfigForDial(), p.quicConf)
 	if err != nil {
 		return nil, err
 	}

--- a/quic/quicclient/pool.go
+++ b/quic/quicclient/pool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -133,7 +134,8 @@ func (p *Pool) createConnection(ctx context.Context, addr string) (*Client, erro
 	// package init, before any test can inject a CA).
 	conn, err := quic.DialAddr(ctx, addr, tlsConfigForDial(), p.quicConf)
 	if err != nil {
-		return nil, err
+		slog.Warn("quic dial failed", "addr", addr, "error", err)
+		return nil, fmt.Errorf("quic dial %s: %w", addr, err)
 	}
 
 	client := &Client{conn: conn}

--- a/quic/quicclient/pool_test.go
+++ b/quic/quicclient/pool_test.go
@@ -2,17 +2,13 @@ package quicclient
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
-	"math/big"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/mulgadc/predastore/internal/testcerts"
 	quic "github.com/quic-go/quic-go"
 	"github.com/stretchr/testify/require"
 )
@@ -27,8 +23,17 @@ var poolTestPortCounter atomic.Int32
 func startMinimalQUICListener(t *testing.T) (string, func()) {
 	t.Helper()
 
-	tlsConf := generateTestTLSConfig(t)
-	tlsConf.NextProtos = []string{alpn}
+	certPath, keyPath, pool := testcerts.Generate(t)
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	require.NoError(t, err)
+	tlsConf := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+		NextProtos:   []string{alpn},
+	}
+
+	SetDefaultRootCAs(pool)
+	t.Cleanup(func() { SetDefaultRootCAs(nil) })
 
 	port := 47000 + int(poolTestPortCounter.Add(1))
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
@@ -140,33 +145,4 @@ func TestQuicClientPool_ReapSkipsActiveRPCStreams(t *testing.T) {
 
 	// Keep the deferred decActive balanced (we did one extra inc above).
 	client.incActive()
-}
-
-// generateTestTLSConfig mirrors quicserver's makeServerTLSConfig but lives
-// in this package to avoid importing quicserver (which would create a cycle).
-func generateTestTLSConfig(t *testing.T) *tls.Config {
-	t.Helper()
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-
-	tmpl := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(24 * time.Hour),
-		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		DNSNames:     []string{"localhost"},
-	}
-	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
-	require.NoError(t, err)
-
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
-	cert, err := tls.X509KeyPair(certPEM, keyPEM)
-	require.NoError(t, err)
-
-	return &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS13,
-	}
 }

--- a/quic/quicclient/quicclient.go
+++ b/quic/quicclient/quicclient.go
@@ -3,7 +3,6 @@ package quicclient
 import (
 	"bufio"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,7 +10,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/mulgadc/predastore/internal/tlsconfig"
 	"github.com/mulgadc/predastore/quic/quicconf"
 	"github.com/mulgadc/predastore/quic/quicproto"
 	"github.com/mulgadc/predastore/quic/quicserver"
@@ -44,13 +42,7 @@ func (c *Client) decActive() {
 }
 
 func Dial(ctx context.Context, addr string) (*Client, error) {
-	tlsConf := &tls.Config{
-		InsecureSkipVerify: true, // demo only. Use mTLS with your CA in prod.
-		NextProtos:         []string{alpn},
-		MinVersion:         tls.VersionTLS13,
-		CurvePreferences:   tlsconfig.Curves,
-	}
-	conn, err := quic.DialAddr(ctx, addr, tlsConf, &quic.Config{
+	conn, err := quic.DialAddr(ctx, addr, tlsConfigForDial(), &quic.Config{
 		HandshakeIdleTimeout: 5 * time.Second,
 		KeepAlivePeriod:      15 * time.Second,
 		MaxIdleTimeout:       60 * time.Second,

--- a/quic/quicclient/quicclient.go
+++ b/quic/quicclient/quicclient.go
@@ -53,7 +53,8 @@ func Dial(ctx context.Context, addr string) (*Client, error) {
 		MaxConnectionReceiveWindow:     quicconf.MaxConnectionReceiveWindow,
 	})
 	if err != nil {
-		return nil, err
+		slog.Warn("quic dial failed", "addr", addr, "error", err)
+		return nil, fmt.Errorf("quic dial %s: %w", addr, err)
 	}
 	return &Client{conn: conn}, nil
 }

--- a/quic/quicserver/server.go
+++ b/quic/quicserver/server.go
@@ -4,15 +4,10 @@ import (
 	"bufio"
 	"context"
 	"crypto/cipher"
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"log/slog"
-	"math/big"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -40,6 +35,9 @@ type QuicServer struct {
 
 	aead           cipher.AEAD
 	keyFingerprint string
+
+	tlsCert string
+	tlsKey  string
 
 	store *store.Store
 
@@ -72,6 +70,23 @@ func WithMasterKey(k *masterkey.Key) Option {
 		}
 		qs.aead = k.AEAD
 		qs.keyFingerprint = k.Fingerprint
+		return nil
+	}
+}
+
+// WithTLSCertFiles supplies the on-disk paths to the PEM-encoded server cert
+// and key. Both are required — NewWithRetry fails if either is empty. The
+// cert must be signed by a CA the QUIC clients trust (cluster CA installed
+// in the OS trust store, or injected via quicclient.SetDefaultRootCAs in
+// tests). The QUIC listener no longer generates an ephemeral self-signed
+// cert at start.
+func WithTLSCertFiles(certPath, keyPath string) Option {
+	return func(qs *QuicServer) error {
+		if certPath == "" || keyPath == "" {
+			return fmt.Errorf("quicserver: tls cert and key paths are required")
+		}
+		qs.tlsCert = certPath
+		qs.tlsKey = keyPath
 		return nil
 	}
 }
@@ -142,6 +157,10 @@ func NewWithRetry(walDir string, addr string, maxRetries int, opts ...Option) (*
 		cancel()
 		return nil, fmt.Errorf("quicserver: master key is required (use WithMasterKey)")
 	}
+	if qs.tlsCert == "" || qs.tlsKey == "" {
+		cancel()
+		return nil, fmt.Errorf("quicserver: tls cert and key are required (use WithTLSCertFiles)")
+	}
 
 	s, err := store.Open(walDir, store.WithAEAD(qs.aead))
 	if err != nil {
@@ -150,13 +169,12 @@ func NewWithRetry(walDir string, addr string, maxRetries int, opts ...Option) (*
 	}
 	qs.store = s
 
-	tlsConf, err := makeServerTLSConfig()
+	tlsConf, err := loadServerTLSConfig(qs.tlsCert, qs.tlsKey)
 	if err != nil {
 		_ = s.Close()
 		cancel()
 		return nil, fmt.Errorf("tls config: %w", err)
 	}
-	tlsConf.NextProtos = []string{alpn}
 
 	// Retry port binding with exponential backoff
 	var l *quic.Listener
@@ -397,38 +415,15 @@ func hostname() string {
 	return h
 }
 
-func makeServerTLSConfig() (*tls.Config, error) {
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
+func loadServerTLSConfig(certPath, keyPath string) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 	if err != nil {
-		return nil, err
-	}
-
-	tmpl := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		NotBefore:    time.Now().Add(-1 * time.Hour),
-		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
-
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		BasicConstraintsValid: true,
-
-		DNSNames: []string{"localhost"},
-	}
-	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
-	if err != nil {
-		return nil, err
-	}
-
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
-
-	cert, err := tls.X509KeyPair(certPEM, keyPEM)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("load x509 key pair from %s/%s: %w", certPath, keyPath, err)
 	}
 	return &tls.Config{
 		Certificates:     []tls.Certificate{cert},
 		MinVersion:       tls.VersionTLS13,
 		CurvePreferences: tlsconfig.Curves,
+		NextProtos:       []string{alpn},
 	}, nil
 }

--- a/quic/quicserver/server_test.go
+++ b/quic/quicserver/server_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/mulgadc/predastore/internal/storetest"
+	"github.com/mulgadc/predastore/internal/testcerts"
 )
 
 // TestNewWithRetryBindsListener exercises the server-side quic.Config
@@ -18,7 +19,12 @@ func TestNewWithRetryBindsListener(t *testing.T) {
 		t.Fatalf("mkdir walDir: %v", err)
 	}
 
-	qs, err := NewWithRetry(walDir, "127.0.0.1:0", 1, WithMasterKey(storetest.TestKey()))
+	certPath, keyPath, _ := testcerts.Generate(t)
+
+	qs, err := NewWithRetry(walDir, "127.0.0.1:0", 1,
+		WithMasterKey(storetest.TestKey()),
+		WithTLSCertFiles(certPath, keyPath),
+	)
 	if err != nil {
 		t.Fatalf("NewWithRetry: %v", err)
 	}

--- a/quic/quicserver/wedge_test.go
+++ b/quic/quicserver/wedge_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/mulgadc/predastore/internal/storetest"
+	"github.com/mulgadc/predastore/internal/testcerts"
 	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/quic/quicserver"
 	"github.com/stretchr/testify/require"
@@ -28,7 +29,13 @@ func newTestQuicServer(t *testing.T) (*quicserver.QuicServer, string) {
 	dir := t.TempDir()
 	port := 46000 + int(quicServerTestPortCounter.Add(1))
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
-	qs, err := quicserver.NewWithRetry(filepath.Join(dir, "wal"), addr, 5, quicserver.WithMasterKey(storetest.TestKey()))
+	certPath, keyPath, pool := testcerts.Generate(t)
+	quicclient.SetDefaultRootCAs(pool)
+	t.Cleanup(func() { quicclient.SetDefaultRootCAs(nil) })
+	qs, err := quicserver.NewWithRetry(filepath.Join(dir, "wal"), addr, 5,
+		quicserver.WithMasterKey(storetest.TestKey()),
+		quicserver.WithTLSCertFiles(certPath, keyPath),
+	)
 	require.NoError(t, err)
 	return qs, addr
 }

--- a/s3/backend_test.go
+++ b/s3/backend_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/mulgadc/predastore/backend"
 	"github.com/mulgadc/predastore/backend/distributed"
 	"github.com/mulgadc/predastore/internal/storetest"
+	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/quic/quicserver"
 	"github.com/stretchr/testify/require"
 )
@@ -115,6 +117,10 @@ func setupDistributedBackend(t *testing.T) *TestBackend {
 	be, err := distributed.New(config)
 	require.NoError(t, err, "Should create distributed backend")
 
+	certPath, keyPath, pool := testcerts.Generate(t)
+	quicclient.SetDefaultRootCAs(pool)
+	t.Cleanup(func() { quicclient.SetDefaultRootCAs(nil) })
+
 	// Start QUIC servers for each node
 	quicServers := make([]*quicserver.QuicServer, nodeCount)
 	for i := 0; i < nodeCount; i++ {
@@ -122,7 +128,10 @@ func setupDistributedBackend(t *testing.T) *TestBackend {
 		require.NoError(t, os.MkdirAll(nodeDir, 0750))
 
 		addr := fmt.Sprintf("127.0.0.1:%d", basePort+i)
-		quicServers[i] = quicserver.New(nodeDir, addr, quicserver.WithMasterKey(storetest.TestKey()))
+		quicServers[i] = quicserver.New(nodeDir, addr,
+			quicserver.WithMasterKey(storetest.TestKey()),
+			quicserver.WithTLSCertFiles(certPath, keyPath),
+		)
 	}
 
 	// Allow QUIC servers time to start

--- a/s3/s3_integration_test.go
+++ b/s3/s3_integration_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/mulgadc/predastore/backend"
 	"github.com/mulgadc/predastore/backend/distributed"
 	"github.com/mulgadc/predastore/internal/storetest"
+	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/quic/quicserver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -85,12 +87,19 @@ func setupServer(t *testing.T) (cancel context.CancelFunc, wg *sync.WaitGroup, n
 	})
 	require.NoError(t, err, "Should create distributed backend")
 
+	certPath, keyPath, pool := testcerts.Generate(t)
+	quicclient.SetDefaultRootCAs(pool)
+	t.Cleanup(func() { quicclient.SetDefaultRootCAs(nil) })
+
 	quicServers := make([]*quicserver.QuicServer, nodeCount)
 	for i := 0; i < nodeCount; i++ {
 		nodeDir := filepath.Join(nodeDataDir, fmt.Sprintf("node-%d", i))
 		require.NoError(t, os.MkdirAll(nodeDir, 0750))
 		addr := fmt.Sprintf("127.0.0.1:%d", basePort+i)
-		quicServers[i] = quicserver.New(nodeDir, addr, quicserver.WithMasterKey(storetest.TestKey()))
+		quicServers[i] = quicserver.New(nodeDir, addr,
+			quicserver.WithMasterKey(storetest.TestKey()),
+			quicserver.WithTLSCertFiles(certPath, keyPath),
+		)
 	}
 	time.Sleep(100 * time.Millisecond)
 

--- a/s3/server.go
+++ b/s3/server.go
@@ -655,7 +655,10 @@ func (s *Server) launchQUICServers() {
 					return
 				}
 
-				quicserver.New(nodePath, quicAddr, quicserver.WithMasterKey(s.masterKey))
+				quicserver.New(nodePath, quicAddr,
+					quicserver.WithMasterKey(s.masterKey),
+					quicserver.WithTLSCertFiles(s.tlsCert, s.tlsKey),
+				)
 				return
 			}
 		}

--- a/s3/server.go
+++ b/s3/server.go
@@ -681,7 +681,10 @@ func (s *Server) launchQUICServers() {
 				continue
 			}
 
-			quicserver.New(nodePath, quicAddr, quicserver.WithMasterKey(s.masterKey))
+			quicserver.New(nodePath, quicAddr,
+				quicserver.WithMasterKey(s.masterKey),
+				quicserver.WithTLSCertFiles(s.tlsCert, s.tlsKey),
+			)
 		}
 	} else {
 		slog.Error("Distributed mode requires -node flag when nodes have different hosts")

--- a/s3db/client.go
+++ b/s3db/client.go
@@ -3,6 +3,7 @@ package s3db
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -32,24 +33,27 @@ type Client struct {
 
 // ClientConfig holds client configuration
 type ClientConfig struct {
-	Nodes              []string      // Initial list of node addresses
-	AccessKeyID        string        // AWS-style access key ID
-	SecretAccessKey    string        // AWS-style secret access key
-	Region             string        // Region for signing (default: us-east-1)
-	Service            string        // Service name for signing (default: s3db)
-	Timeout            time.Duration // HTTP request timeout
-	MaxRetries         int           // Max retries on failure
-	InsecureSkipVerify bool          // Skip TLS certificate verification (for self-signed certs)
+	Nodes           []string      // Initial list of node addresses
+	AccessKeyID     string        // AWS-style access key ID
+	SecretAccessKey string        // AWS-style secret access key
+	Region          string        // Region for signing (default: us-east-1)
+	Service         string        // Service name for signing (default: s3db)
+	Timeout         time.Duration // HTTP request timeout
+	MaxRetries      int           // Max retries on failure
+	// RootCAs overrides the OS trust store for verifying the server
+	// certificate. Nil ⇒ OS trust store, which is the production path
+	// (cluster CA installed via update-ca-certificates). Tests inject an
+	// ephemeral CA here.
+	RootCAs *x509.CertPool
 }
 
 // DefaultClientConfig returns sensible defaults
 func DefaultClientConfig() *ClientConfig {
 	return &ClientConfig{
-		Region:             DefaultRegion,
-		Service:            DefaultService,
-		Timeout:            10 * time.Second,
-		MaxRetries:         3,
-		InsecureSkipVerify: true, // Default to true for self-signed certs
+		Region:     DefaultRegion,
+		Service:    DefaultService,
+		Timeout:    10 * time.Second,
+		MaxRetries: 3,
 	}
 }
 
@@ -69,13 +73,12 @@ func NewClient(config *ClientConfig) *Client {
 		service = DefaultService
 	}
 
-	// Configure TLS transport with optional certificate verification skip
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: config.InsecureSkipVerify,
-			NextProtos:         []string{"h2", "http/1.1"},
-			MinVersion:         tls.VersionTLS13,
-			CurvePreferences:   tlsconfig.Curves,
+			RootCAs:          config.RootCAs,
+			NextProtos:       []string{"h2", "http/1.1"},
+			MinVersion:       tls.VersionTLS13,
+			CurvePreferences: tlsconfig.Curves,
 		},
 		ForceAttemptHTTP2: true,
 	}

--- a/s3db/pure_test.go
+++ b/s3db/pure_test.go
@@ -141,7 +141,7 @@ func TestDefaultClientConfig(t *testing.T) {
 	assert.Equal(t, "s3db", cfg.Service)
 	assert.Equal(t, 10*time.Second, cfg.Timeout)
 	assert.Equal(t, 3, cfg.MaxRetries)
-	assert.True(t, cfg.InsecureSkipVerify)
+	assert.Nil(t, cfg.RootCAs)
 }
 
 func TestGenObjectHash(t *testing.T) {


### PR DESCRIPTION
QUIC servers now load the operator-supplied TLS cert/key (same paths the S3 API and s3db REST already use) via the new WithTLSCertFiles option, instead of generating an ephemeral self-signed RSA cert at every process start. With a real CA-signed cert in place, the QUIC client pool, direct Dial, and the s3db client/state all verify the server certificate — InsecureSkipVerify is gone from every non-integration code path.