### PR TITLE
feat: TLS-wrap the Raft transport with the s3db cert

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1154,7 +1154,10 @@ scan.
 
 All communication uses TLS:
 - s3db server uses HTTPS with configurable certificates
-- Client connections skip certificate verification for self-signed certs (configurable)
+- The Raft transport (`raft_port`) is TLS-wrapped using the same cert/key
+  pair; peers verify the server cert against the OS trust store
+- The QUIC RPC transport between s3d and shard nodes verifies the server
+  cert against the OS trust store (no `InsecureSkipVerify`)
 - Certificate paths: `-tls-cert` and `-tls-key` flags
 
 ## Authentication
@@ -1278,7 +1281,14 @@ Each database node uses two ports:
 | Port | Purpose | Default |
 |------|---------|---------|
 | `port` | HTTPS REST API for client requests | 6660 |
-| `raft_port` | TCP for Raft consensus (leader election, log replication) | `port + 1000` (e.g., 7660) |
+| `raft_port` | TLS-wrapped TCP for Raft consensus (leader election, log replication) | `port + 1000` (e.g., 7660) |
+
+The Raft transport is TLS-protected using the same `-tls-cert` / `-tls-key`
+pair as the HTTPS S3 API and s3db REST listener. Peers verify the server
+cert against the OS trust store (cluster CA installed via
+`update-ca-certificates`); s3db refuses to start without a cert/key pair —
+there is no plaintext fallback. Mutual TLS (peer client-cert auth) is
+deferred to a follow-up bead.
 
 ### Bind vs Advertise Address
 

--- a/s3db/config.go
+++ b/s3db/config.go
@@ -25,6 +25,12 @@ type ClusterConfig struct {
 	DataDir   string         // Base data directory
 	Bootstrap bool           // Whether to bootstrap a new cluster
 
+	// TLS material for the Raft transport. Populated programmatically by
+	// s3db.NewServer from ServerConfig.TLS{Cert,Key} — not from cluster.toml.
+	// NewRaftNode refuses to start if either is empty.
+	TLSCert string
+	TLSKey  string
+
 	// Raft tuning
 	HeartbeatTimeout   time.Duration
 	ElectionTimeout    time.Duration

--- a/s3db/raft.go
+++ b/s3db/raft.go
@@ -36,6 +36,12 @@ func NewRaftNode(config *ClusterConfig) (*RaftNode, error) {
 		return nil, fmt.Errorf("node ID %d not found in cluster config", config.NodeID)
 	}
 
+	// Fail closed: the Raft transport carries committed log entries (object
+	// metadata, IAM state). There is no plaintext fallback. Mirrors quicd.
+	if config.TLSCert == "" || config.TLSKey == "" {
+		return nil, fmt.Errorf("s3db raft: TLS cert and key are required; refusing to start without transport encryption")
+	}
+
 	// Create data directories
 	dataDir := config.DataDir
 	if err := os.MkdirAll(dataDir, 0750); err != nil {
@@ -87,13 +93,24 @@ func NewRaftNode(config *ClusterConfig) (*RaftNode, error) {
 	}
 
 	slog.Info("Setting up Raft transport", "bindAddr", bindAddr, "advertiseAddr", advertiseAddr)
-	node.transport, err = raft.NewTCPTransport(bindAddr, tcpAddr, 3, 10*time.Second, os.Stderr)
+	rawListener, err := net.Listen("tcp", bindAddr)
 	if err != nil {
 		if cerr := node.badgerDB.Close(); cerr != nil {
 			slog.Debug("Failed to close badger during cleanup", "error", cerr)
 		}
-		return nil, fmt.Errorf("failed to create transport: %w", err)
+		return nil, fmt.Errorf("failed to listen on raft bind %s: %w", bindAddr, err)
 	}
+	streamLayer, err := newTLSStreamLayer(rawListener, tcpAddr, config.TLSCert, config.TLSKey)
+	if err != nil {
+		if cerr := rawListener.Close(); cerr != nil {
+			slog.Debug("Failed to close raft listener during cleanup", "error", cerr)
+		}
+		if cerr := node.badgerDB.Close(); cerr != nil {
+			slog.Debug("Failed to close badger during cleanup", "error", cerr)
+		}
+		return nil, fmt.Errorf("failed to create raft TLS stream layer: %w", err)
+	}
+	node.transport = raft.NewNetworkTransport(streamLayer, 3, 10*time.Second, os.Stderr)
 
 	// Setup log store and stable store (BoltDB)
 	boltDBPath := filepath.Join(dataDir, "raft.db")

--- a/s3db/raft_streamlayer.go
+++ b/s3db/raft_streamlayer.go
@@ -1,0 +1,90 @@
+package s3db
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/mulgadc/predastore/internal/tlsconfig"
+)
+
+// streamLayerRootCAs is the package-level root CA pool consulted by the Raft
+// dialer. Nil ⇒ OS trust store, which is the production path (cluster CA
+// installed via update-ca-certificates / update-ca-trust). Tests inject an
+// ephemeral CA via setStreamLayerRootCAs before any dial happens. Mirrors
+// quicclient.SetDefaultRootCAs.
+var streamLayerRootCAs atomic.Pointer[x509.CertPool]
+
+// setStreamLayerRootCAs replaces the root CA pool consulted by the Raft TLS
+// dialer. Pass nil to restore the OS trust store. Production code never calls
+// this — it exists so tests that exercise the strict-verify code path can
+// trust an ephemeral CA.
+func setStreamLayerRootCAs(pool *x509.CertPool) {
+	streamLayerRootCAs.Store(pool)
+}
+
+// tlsStreamLayer implements raft.StreamLayer over a TLS-wrapped TCP listener.
+// Server side: tls.NewListener wraps the bind listener with the cluster cert.
+// Client side: tls.DialWithDialer with strict-verify against the OS trust
+// store (or the package-level test pool).
+type tlsStreamLayer struct {
+	advertise net.Addr
+	listener  net.Listener
+}
+
+var _ raft.StreamLayer = (*tlsStreamLayer)(nil)
+
+// newTLSStreamLayer wraps the given bind listener with a TLS server config
+// loaded from certPath/keyPath. The advertise address is what other peers are
+// told to dial. The caller is responsible for closing the returned layer
+// (which closes the wrapped listener).
+func newTLSStreamLayer(listener net.Listener, advertise net.Addr, certPath, keyPath string) (*tlsStreamLayer, error) {
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("load raft tls cert/key (%s, %s): %w", certPath, keyPath, err)
+	}
+	serverCfg := &tls.Config{
+		Certificates:     []tls.Certificate{cert},
+		MinVersion:       tls.VersionTLS13,
+		CurvePreferences: tlsconfig.Curves,
+	}
+	return &tlsStreamLayer{
+		advertise: advertise,
+		listener:  tls.NewListener(listener, serverCfg),
+	}, nil
+}
+
+// Dial implements raft.StreamLayer. tls.DialWithDialer derives ServerName
+// from the host portion of address when the config leaves it empty; for IP
+// hosts (the common case for cluster.toml advertise addresses) verification
+// falls back to IP SAN matching.
+func (s *tlsStreamLayer) Dial(address raft.ServerAddress, timeout time.Duration) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: timeout}
+	clientCfg := &tls.Config{
+		RootCAs:          streamLayerRootCAs.Load(),
+		MinVersion:       tls.VersionTLS13,
+		CurvePreferences: tlsconfig.Curves,
+	}
+	return tls.DialWithDialer(dialer, "tcp", string(address), clientCfg)
+}
+
+func (s *tlsStreamLayer) Accept() (net.Conn, error) {
+	return s.listener.Accept()
+}
+
+func (s *tlsStreamLayer) Close() error {
+	return s.listener.Close()
+}
+
+// Addr returns the advertise address so raft hands peers the externally
+// reachable endpoint rather than the bind address (which may be 0.0.0.0).
+func (s *tlsStreamLayer) Addr() net.Addr {
+	if s.advertise != nil {
+		return s.advertise
+	}
+	return s.listener.Addr()
+}

--- a/s3db/raft_streamlayer.go
+++ b/s3db/raft_streamlayer.go
@@ -12,25 +12,16 @@ import (
 	"github.com/mulgadc/predastore/internal/tlsconfig"
 )
 
-// streamLayerRootCAs is the package-level root CA pool consulted by the Raft
-// dialer. Nil ⇒ OS trust store, which is the production path (cluster CA
-// installed via update-ca-certificates / update-ca-trust). Tests inject an
-// ephemeral CA via setStreamLayerRootCAs before any dial happens. Mirrors
-// quicclient.SetDefaultRootCAs.
+// streamLayerRootCAs is the root CA pool consulted by the Raft dialer.
+// Nil ⇒ OS trust store (production path). Tests inject an ephemeral CA via
+// setStreamLayerRootCAs.
 var streamLayerRootCAs atomic.Pointer[x509.CertPool]
 
-// setStreamLayerRootCAs replaces the root CA pool consulted by the Raft TLS
-// dialer. Pass nil to restore the OS trust store. Production code never calls
-// this — it exists so tests that exercise the strict-verify code path can
-// trust an ephemeral CA.
+// setStreamLayerRootCAs is a test hook. Production code never calls this.
 func setStreamLayerRootCAs(pool *x509.CertPool) {
 	streamLayerRootCAs.Store(pool)
 }
 
-// tlsStreamLayer implements raft.StreamLayer over a TLS-wrapped TCP listener.
-// Server side: tls.NewListener wraps the bind listener with the cluster cert.
-// Client side: tls.DialWithDialer with strict-verify against the OS trust
-// store (or the package-level test pool).
 type tlsStreamLayer struct {
 	advertise net.Addr
 	listener  net.Listener
@@ -38,10 +29,6 @@ type tlsStreamLayer struct {
 
 var _ raft.StreamLayer = (*tlsStreamLayer)(nil)
 
-// newTLSStreamLayer wraps the given bind listener with a TLS server config
-// loaded from certPath/keyPath. The advertise address is what other peers are
-// told to dial. The caller is responsible for closing the returned layer
-// (which closes the wrapped listener).
 func newTLSStreamLayer(listener net.Listener, advertise net.Addr, certPath, keyPath string) (*tlsStreamLayer, error) {
 	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 	if err != nil {
@@ -58,10 +45,8 @@ func newTLSStreamLayer(listener net.Listener, advertise net.Addr, certPath, keyP
 	}, nil
 }
 
-// Dial implements raft.StreamLayer. tls.DialWithDialer derives ServerName
-// from the host portion of address when the config leaves it empty; for IP
-// hosts (the common case for cluster.toml advertise addresses) verification
-// falls back to IP SAN matching.
+// Dial leaves ServerName empty so tls.DialWithDialer derives it from the
+// address host — IP SAN matching for IP-literal advertise addresses.
 func (s *tlsStreamLayer) Dial(address raft.ServerAddress, timeout time.Duration) (net.Conn, error) {
 	dialer := &net.Dialer{Timeout: timeout}
 	clientCfg := &tls.Config{
@@ -80,8 +65,8 @@ func (s *tlsStreamLayer) Close() error {
 	return s.listener.Close()
 }
 
-// Addr returns the advertise address so raft hands peers the externally
-// reachable endpoint rather than the bind address (which may be 0.0.0.0).
+// Addr returns the advertise address — bind may be 0.0.0.0, peers need a
+// reachable endpoint.
 func (s *tlsStreamLayer) Addr() net.Addr {
 	if s.advertise != nil {
 		return s.advertise

--- a/s3db/raft_test.go
+++ b/s3db/raft_test.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/raft"
 	"github.com/mulgadc/predastore/internal/testcerts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -464,6 +466,45 @@ func TestNewRaftNode_RequiresTLS(t *testing.T) {
 			assert.Contains(t, err.Error(), "TLS cert and key are required")
 		})
 	}
+}
+
+// TestRaftTLSStreamLayer_RejectsUnknownCA pins the verify-on TLS posture: the
+// dialer must reject a peer whose cert is not signed by a trusted CA. Without
+// this, a future regression that adds InsecureSkipVerify=true or widens
+// RootCAs would pass every other test in this file silently.
+func TestRaftTLSStreamLayer_RejectsUnknownCA(t *testing.T) {
+	// Server presents serverCert; dialer trusts only otherPool (which does
+	// not contain serverCert). Two independent testcerts.Generate calls
+	// yield two unrelated self-signed CAs.
+	serverCert, serverKey, _ := testcerts.Generate(t)
+	_, _, otherPool := testcerts.Generate(t)
+	setStreamLayerRootCAs(otherPool)
+	t.Cleanup(func() { setStreamLayerRootCAs(nil) })
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	advertise, err := net.ResolveTCPAddr("tcp", ln.Addr().String())
+	require.NoError(t, err)
+
+	layer, err := newTLSStreamLayer(ln, advertise, serverCert, serverKey)
+	require.NoError(t, err)
+	defer layer.Close()
+
+	// Drive the server-side accept so the handshake actually runs and the
+	// dial returns rather than hanging on connect.
+	go func() {
+		conn, aerr := layer.Accept()
+		if aerr != nil {
+			return
+		}
+		_, _ = conn.Read(make([]byte, 1))
+		_ = conn.Close()
+	}()
+
+	_, derr := layer.Dial(raft.ServerAddress(ln.Addr().String()), 2*time.Second)
+	require.Error(t, derr)
+	assert.Contains(t, strings.ToLower(derr.Error()), "certificate",
+		"dial error should mention cert verification, got: %v", derr)
 }
 
 // TestNewTLSStreamLayer_BadCertPath verifies the stream layer surfaces a

--- a/s3db/raft_test.go
+++ b/s3db/raft_test.go
@@ -2,23 +2,40 @@ package s3db
 
 import (
 	"fmt"
+	"net"
 	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/mulgadc/predastore/internal/testcerts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// installTestTLS wires the unexported Raft TLS test hooks: generates an
+// ephemeral self-signed cert (with `localhost` + `127.0.0.1` SANs) and
+// installs the matching root CA as the package-level dialer trust pool.
+// Returns the cert + key paths that callers wire into ClusterConfig.
+func installTestTLS(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+	certPath, keyPath, pool := testcerts.Generate(t)
+	setStreamLayerRootCAs(pool)
+	t.Cleanup(func() { setStreamLayerRootCAs(nil) })
+	return certPath, keyPath
+}
+
 // TestSingleNodeRaft tests basic operations on a single Raft node
 func TestSingleNodeRaft(t *testing.T) {
 	tmpDir := t.TempDir()
+	certPath, keyPath := installTestTLS(t)
 
 	config := DefaultClusterConfig()
 	config.NodeID = 1
 	config.DataDir = tmpDir
 	config.Bootstrap = true
+	config.TLSCert = certPath
+	config.TLSKey = keyPath
 	config.Nodes = []DBNodeConfig{
 		{ID: 1, Host: "127.0.0.1", Port: 16661, RaftPort: 17661, Path: filepath.Join(tmpDir, "node-1")},
 	}
@@ -84,11 +101,14 @@ func TestSingleNodeRaft(t *testing.T) {
 // TestMultipleTablesIsolation tests that tables are isolated from each other
 func TestMultipleTablesIsolation(t *testing.T) {
 	tmpDir := t.TempDir()
+	certPath, keyPath := installTestTLS(t)
 
 	config := DefaultClusterConfig()
 	config.NodeID = 1
 	config.DataDir = tmpDir
 	config.Bootstrap = true
+	config.TLSCert = certPath
+	config.TLSKey = keyPath
 	config.Nodes = []DBNodeConfig{
 		{ID: 1, Host: "127.0.0.1", Port: 16662, RaftPort: 17662, Path: filepath.Join(tmpDir, "node-1")},
 	}
@@ -135,6 +155,7 @@ func TestThreeNodeCluster(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
+	certPath, keyPath := installTestTLS(t)
 
 	// Create 3-node cluster config
 	nodes := []DBNodeConfig{
@@ -151,6 +172,8 @@ func TestThreeNodeCluster(t *testing.T) {
 		config.NodeID = nodeConfig.ID
 		config.DataDir = nodeConfig.Path
 		config.Bootstrap = (i == 0) // Only first node bootstraps
+		config.TLSCert = certPath
+		config.TLSKey = keyPath
 		config.Nodes = nodes
 
 		node, err := NewRaftNode(config)
@@ -201,6 +224,7 @@ func TestLeaderFailover(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
+	certPath, keyPath := installTestTLS(t)
 
 	// Create 3-node cluster config
 	nodes := []DBNodeConfig{
@@ -218,6 +242,8 @@ func TestLeaderFailover(t *testing.T) {
 		config.NodeID = nodeConfig.ID
 		config.DataDir = nodeConfig.Path
 		config.Bootstrap = (i == 0)
+		config.TLSCert = certPath
+		config.TLSKey = keyPath
 		config.Nodes = nodes
 		// Faster timeouts for testing
 		config.HeartbeatTimeout = 200 * time.Millisecond
@@ -300,11 +326,14 @@ func TestLeaderFailover(t *testing.T) {
 // TestConcurrentWrites tests concurrent writes to the cluster
 func TestConcurrentWrites(t *testing.T) {
 	tmpDir := t.TempDir()
+	certPath, keyPath := installTestTLS(t)
 
 	config := DefaultClusterConfig()
 	config.NodeID = 1
 	config.DataDir = tmpDir
 	config.Bootstrap = true
+	config.TLSCert = certPath
+	config.TLSKey = keyPath
 	config.Nodes = []DBNodeConfig{
 		{ID: 1, Host: "127.0.0.1", Port: 16691, RaftPort: 17691, Path: filepath.Join(tmpDir, "node-1")},
 	}
@@ -361,11 +390,14 @@ func TestConcurrentWrites(t *testing.T) {
 // TestLargeValues tests storing large values
 func TestLargeValues(t *testing.T) {
 	tmpDir := t.TempDir()
+	certPath, keyPath := installTestTLS(t)
 
 	config := DefaultClusterConfig()
 	config.NodeID = 1
 	config.DataDir = tmpDir
 	config.Bootstrap = true
+	config.TLSCert = certPath
+	config.TLSKey = keyPath
 	config.Nodes = []DBNodeConfig{
 		{ID: 1, Host: "127.0.0.1", Port: 16692, RaftPort: 17692, Path: filepath.Join(tmpDir, "node-1")},
 	}
@@ -397,4 +429,55 @@ func TestLargeValues(t *testing.T) {
 			assert.Equal(t, data, value)
 		})
 	}
+}
+
+// TestNewRaftNode_RequiresTLS verifies the transport refuses to start without
+// a cert/key pair, mirroring quicd's fail-closed posture.
+func TestNewRaftNode_RequiresTLS(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cases := []struct {
+		name string
+		cert string
+		key  string
+	}{
+		{"both empty", "", ""},
+		{"cert only", "cert.pem", ""},
+		{"key only", "", "key.pem"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := DefaultClusterConfig()
+			config.NodeID = 1
+			config.DataDir = filepath.Join(tmpDir, tc.name)
+			config.Bootstrap = true
+			config.TLSCert = tc.cert
+			config.TLSKey = tc.key
+			config.Nodes = []DBNodeConfig{
+				{ID: 1, Host: "127.0.0.1", Port: 16693, RaftPort: 17693, Path: config.DataDir},
+			}
+
+			node, err := NewRaftNode(config)
+			require.Error(t, err)
+			assert.Nil(t, node)
+			assert.Contains(t, err.Error(), "TLS cert and key are required")
+		})
+	}
+}
+
+// TestNewTLSStreamLayer_BadCertPath verifies the stream layer surfaces a
+// load error instead of silently falling back to plaintext.
+func TestNewTLSStreamLayer_BadCertPath(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	advertise, err := net.ResolveTCPAddr("tcp", ln.Addr().String())
+	require.NoError(t, err)
+
+	layer, err := newTLSStreamLayer(ln, advertise, "/nonexistent/cert.pem", "/nonexistent/key.pem")
+	require.Error(t, err)
+	assert.Nil(t, layer)
+	assert.Contains(t, err.Error(), "load raft tls cert/key")
 }

--- a/s3db/server.go
+++ b/s3db/server.go
@@ -93,6 +93,11 @@ func NewServer(config *ServerConfig) (*Server, error) {
 		return nil, fmt.Errorf("s3db: no credentials configured; refusing to start (set credentials on [[db]] or [[auth]])")
 	}
 
+	// Plumb the same cert/key used by the s3db HTTPS REST listener into the
+	// Raft transport. NewRaftNode fails closed if either is empty.
+	config.ClusterConfig.TLSCert = config.TLSCert
+	config.ClusterConfig.TLSKey = config.TLSKey
+
 	// Initialize Raft node
 	node, err := NewRaftNode(config.ClusterConfig)
 	if err != nil {

--- a/s3db/server_test.go
+++ b/s3db/server_test.go
@@ -60,3 +60,47 @@ func TestNewServer_RejectsMissingClusterConfig(t *testing.T) {
 	assert.Nil(t, server)
 	assert.Contains(t, err.Error(), "cluster config is required")
 }
+
+// TestNewServer_RejectsEmptyTLS pins the Raft transport's cert plumb-through
+// in NewServer. The empty-string check itself lives one layer down in
+// NewRaftNode, but exercising it through NewServer guards against a future
+// refactor that drops the plumb-through and silently bypasses transport
+// encryption on the Raft port.
+func TestNewServer_RejectsEmptyTLS(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cases := []struct {
+		name string
+		cert string
+		key  string
+	}{
+		{"both empty", "", ""},
+		{"cert only", "/nonexistent/cert.pem", ""},
+		{"key only", "", "/nonexistent/key.pem"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clusterCfg := DefaultClusterConfig()
+			clusterCfg.NodeID = 1
+			clusterCfg.DataDir = filepath.Join(tmpDir, tc.name)
+			clusterCfg.Bootstrap = true
+			clusterCfg.Nodes = []DBNodeConfig{
+				{ID: 1, Host: "127.0.0.1", Port: 16694, RaftPort: 17694, Path: clusterCfg.DataDir},
+			}
+
+			cfg := &ServerConfig{
+				Addr:          "127.0.0.1:0",
+				Credentials:   map[string]string{"key": "secret"},
+				ClusterConfig: clusterCfg,
+				TLSCert:       tc.cert,
+				TLSKey:        tc.key,
+			}
+
+			server, err := NewServer(cfg)
+			require.Error(t, err)
+			assert.Nil(t, server)
+			assert.Contains(t, err.Error(), "TLS cert and key are required")
+		})
+	}
+}


### PR DESCRIPTION
NewRaftNode now replaces NewTCPTransport with NewNetworkTransport over a TLS StreamLayer that reuses the same cert/key pair as the s3db HTTPS REST listener (and the QUIC RPC plane). Peers verify against the OS trust store via tls.DialWithDialer; tests inject an ephemeral CA through the package-level setStreamLayerRootCAs hook, mirroring quicclient.

s3db is fail-closed: missing TLSCert or TLSKey on ClusterConfig refuses to start the Raft node — no plaintext fallback. ServerConfig copies its existing TLS{Cert,Key} into ClusterConfig before NewRaftNode, so both the standalone embedded-DB path and cluster mode pick up the new transport with no flag changes.

Closes the SC.L1-3.13.1 confidentiality + integrity gap on the Raft sister-port; AC.L1-3.1.1 peer identity (mutual TLS) is deferred.