### PR TITLE
fix(auth): correct Verify re-signing for transport-added headers + content-length + missing SHA

### DIFF
--- a/auth/sigv4.go
+++ b/auth/sigv4.go
@@ -222,7 +222,7 @@ func (req *Request) Verify(
 	}
 
 	// The SDK signer derives SignedHeaders from whatever's on the request,
-	// so any transport-added headers (Accept-Encoding, Content-Length, ...)
+	// so any transport-added headers (Accept-Encoding, User-Agent, ...)
 	// would make the re-signed Authorization diverge from the wire one.
 	// Stash them, sign, restore — Host is read from req.Host, not the
 	// header map; Authorization is always deleted+restored separately.
@@ -238,6 +238,19 @@ func (req *Request) Verify(
 		}
 	}
 
+	// content-length is special: the SDK signer auto-adds it to
+	// SignedHeaders from req.ContentLength (not req.Header), so
+	// stashing the header doesn't suppress it. Zero ContentLength
+	// across the re-sign when the client didn't sign it; restore
+	// after. boto3/aws-cli don't sign content-length, only the Go SDK.
+	var stashedContentLength int64
+	contentLengthStashed := false
+	if _, ok := req.signedHeaders["content-length"]; !ok && req.ContentLength > 0 {
+		stashedContentLength = req.ContentLength
+		req.ContentLength = 0
+		contentLengthStashed = true
+	}
+
 	req.Header.Del(authHeaderKey)
 	signErr := v4.NewSigner().SignHTTP(
 		context.Background(),
@@ -247,6 +260,9 @@ func (req *Request) Verify(
 	expected := req.Header.Get(authHeaderKey)
 	req.Header.Set(authHeaderKey, req.authHeader)
 	maps.Copy(req.Header, stash)
+	if contentLengthStashed {
+		req.ContentLength = stashedContentLength
+	}
 	if signErr != nil {
 		return fmt.Errorf("re-sign for verify: %w", signErr)
 	}

--- a/auth/sigv4.go
+++ b/auth/sigv4.go
@@ -76,11 +76,14 @@ func WithTime(t time.Time) func(*Options) {
 // is constant-time-compared against the wire X-Amz-Content-Sha256
 // header. SigV4 payload sentinels in the header (UNSIGNED-PAYLOAD and
 // the STREAMING-AWS4-HMAC-SHA256-PAYLOAD[-TRAILER] family) skip the
-// check — the header is not a hash in those modes.
+// check — the header is not a hash in those modes. When the header is
+// absent (non-S3 SDK clients omit it), the supplied hash is used as the
+// payload hash for re-signing instead — body integrity is then enforced
+// implicitly via the signature comparison.
 //
-// Opt-in. Verify without WithBodyHash trusts the header verbatim,
-// matching default SignHTTP semantics where the payload hash is the
-// caller's responsibility.
+// Opt-in. Verify without WithBodyHash trusts the header verbatim and
+// requires it to be present, matching default SignHTTP semantics where
+// the payload hash is the caller's responsibility.
 func WithBodyHash(hex string) func(*Options) {
 	return func(o *Options) { o.bodyHash = hex }
 }
@@ -199,7 +202,13 @@ func (req *Request) Verify(
 
 	payloadHash := req.Header.Get("X-Amz-Content-Sha256")
 	if payloadHash == "" {
-		return ErrMissingContentSHA
+		// Only S3 SDK clients emit X-Amz-Content-Sha256; EC2/IAM/ELBv2/etc.
+		// put the payload hash in the canonical request without a header.
+		// Fall back to the caller's server-computed hash when supplied.
+		if o.bodyHash == "" {
+			return ErrMissingContentSHA
+		}
+		payloadHash = o.bodyHash
 	}
 
 	// Opt-in body-hash gate. Runs before the SDK re-sign so a body-swap

--- a/auth/sigv4.go
+++ b/auth/sigv4.go
@@ -11,6 +11,7 @@ import (
 	"crypto/subtle"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"regexp"
 	"strings"
@@ -107,7 +108,8 @@ type Request struct {
 	Region      string
 	Service     string
 
-	authHeader string // verbatim Authorization header, for verify-side compare
+	authHeader    string              // verbatim Authorization header, for verify-side compare
+	signedHeaders map[string]struct{} // lowercase header names from the Authorization SignedHeaders field
 }
 
 // SignReq signs r in place per the SigV4 header scheme via
@@ -147,22 +149,19 @@ func ParseReq(r *http.Request) (*Request, error) {
 		return nil, ErrInvalidAuthFormat
 	}
 
-	// Required SignedHeaders entries per SigV4 spec; surfacing these as
-	// ErrMissingSignedHeader preserves S3's AuthorizationHeaderMalformed
-	// error code instead of falling through to a signature mismatch.
-	hasHost, hasDate := false, false
+	// Build the signed-headers set. Required entries per SigV4 spec
+	// (host, x-amz-date) surface as ErrMissingSignedHeader to preserve
+	// S3's AuthorizationHeaderMalformed error code instead of falling
+	// through to a signature mismatch. The set is also consulted in
+	// Verify to strip transport-added headers before re-signing.
+	signedHeaders := make(map[string]struct{})
 	for h := range strings.SplitSeq(m[5], ";") {
-		switch strings.ToLower(strings.TrimSpace(h)) {
-		case "host":
-			hasHost = true
-		case "x-amz-date":
-			hasDate = true
-		}
+		signedHeaders[strings.ToLower(h)] = struct{}{}
 	}
-	if !hasHost {
+	if _, ok := signedHeaders["host"]; !ok {
 		return nil, fmt.Errorf("%w: host", ErrMissingSignedHeader)
 	}
-	if !hasDate {
+	if _, ok := signedHeaders["x-amz-date"]; !ok {
 		return nil, fmt.Errorf("%w: x-amz-date", ErrMissingSignedHeader)
 	}
 
@@ -176,12 +175,13 @@ func ParseReq(r *http.Request) (*Request, error) {
 	}
 
 	return &Request{
-		Request:     r,
-		AccessKeyID: m[1],
-		SignedTime:  time,
-		Region:      m[3],
-		Service:     m[4],
-		authHeader:  hdr,
+		Request:       r,
+		AccessKeyID:   m[1],
+		SignedTime:    time,
+		Region:        m[3],
+		Service:       m[4],
+		authHeader:    hdr,
+		signedHeaders: signedHeaders,
 	}, nil
 }
 
@@ -221,10 +221,23 @@ func (req *Request) Verify(
 		}
 	}
 
-	// The SDK signs in place. Strip the wire Authorization so the SDK
-	// doesn't see it, capture the freshly produced header, then restore
-	// the wire value so downstream middleware observes the request
-	// unchanged. signErr is captured first so the restore always runs.
+	// The SDK signer derives SignedHeaders from whatever's on the request,
+	// so any transport-added headers (Accept-Encoding, Content-Length, ...)
+	// would make the re-signed Authorization diverge from the wire one.
+	// Stash them, sign, restore — Host is read from req.Host, not the
+	// header map; Authorization is always deleted+restored separately.
+	stash := make(http.Header)
+	for name, values := range req.Header {
+		lc := strings.ToLower(name)
+		if lc == "authorization" || lc == "host" {
+			continue
+		}
+		if _, ok := req.signedHeaders[lc]; !ok {
+			stash[name] = values
+			req.Header.Del(name)
+		}
+	}
+
 	req.Header.Del(authHeaderKey)
 	signErr := v4.NewSigner().SignHTTP(
 		context.Background(),
@@ -233,6 +246,7 @@ func (req *Request) Verify(
 	)
 	expected := req.Header.Get(authHeaderKey)
 	req.Header.Set(authHeaderKey, req.authHeader)
+	maps.Copy(req.Header, stash)
 	if signErr != nil {
 		return fmt.Errorf("re-sign for verify: %w", signErr)
 	}

--- a/auth/sigv4_test.go
+++ b/auth/sigv4_test.go
@@ -165,6 +165,9 @@ func TestProp_TamperingFailsVerification(t *testing.T) {
 			auth.WithTime(signTime),
 		))
 
+		// Headers added post-signing (Accept-Encoding, Content-Length, ...)
+		// are tolerated by Verify per TestVerify_TransportAddedHeaders, so
+		// "add-header" is not a tampering mutation.
 		mutation := rapid.SampledFrom([]string{
 			"flip-signature",
 			"change-method",
@@ -172,7 +175,6 @@ func TestProp_TamperingFailsVerification(t *testing.T) {
 			"tamper-query",
 			"tamper-host",
 			"tamper-content-sha",
-			"add-header",
 			"drop-host-from-signed-headers",
 		}).Draw(t, "mutation")
 
@@ -206,9 +208,6 @@ func TestProp_TamperingFailsVerification(t *testing.T) {
 			// All-zero hash will never match a real body hash (2^-256 collision).
 			req.Header.Set("X-Amz-Content-Sha256",
 				"0000000000000000000000000000000000000000000000000000000000000000")
-		case "add-header":
-			// Header name was filtered out of random gen, so this is always new.
-			req.Header.Set("X-Tamper-Probe", "1")
 		case "drop-host-from-signed-headers":
 			// Remove the "host" entry from the wire Authorization's
 			// SignedHeaders list. Hits ErrMissingSignedHeader via ParseReq.
@@ -392,4 +391,41 @@ func TestVerify_MissingContentSHAFallback(t *testing.T) {
 			auth.WithBodyHash(strings.Repeat("0", 64)))
 		require.ErrorIs(t, err, auth.ErrSignatureMismatch)
 	})
+}
+
+// TestVerify_TransportAddedHeaders pins the contract that headers
+// added after signing by the HTTP transport (Accept-Encoding,
+// Content-Length, ...) must not cause re-signing to over-include
+// them in SignedHeaders. boto3/aws-cli sign content-type;host;
+// x-amz-date but the wire request gains Accept-Encoding etc. before
+// the server reads it.
+func TestVerify_TransportAddedHeaders(t *testing.T) {
+	body := []byte("Action=DescribeInstances")
+	sum := sha256.Sum256(body)
+	bodyHashHex := hex.EncodeToString(sum[:])
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	req.Host = "ec2.amazonaws.com"
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	require.NoError(t, v4.NewSigner().SignHTTP(
+		context.Background(),
+		aws.Credentials{AccessKeyID: exAccessKeyID, SecretAccessKey: exSecret},
+		req, bodyHashHex, "ec2", exRegion, exTime,
+	))
+
+	// Simulate transport-added headers post-signing.
+	req.Header.Set("Accept-Encoding", "identity")
+	req.Header.Set("Content-Length", "23")
+	req.Header.Set("User-Agent", "aws-cli/2.0")
+
+	sig, err := auth.ParseReq(req)
+	require.NoError(t, err)
+	require.NoError(t, sig.Verify(exSecret, "ec2", exRegion,
+		auth.WithTime(exTime),
+		auth.WithBodyHash(bodyHashHex)))
+
+	// Transport-added headers must still be on the request after Verify.
+	require.Equal(t, "identity", req.Header.Get("Accept-Encoding"))
+	require.Equal(t, "23", req.Header.Get("Content-Length"))
+	require.Equal(t, "aws-cli/2.0", req.Header.Get("User-Agent"))
 }

--- a/auth/sigv4_test.go
+++ b/auth/sigv4_test.go
@@ -395,10 +395,13 @@ func TestVerify_MissingContentSHAFallback(t *testing.T) {
 
 // TestVerify_TransportAddedHeaders pins the contract that headers
 // added after signing by the HTTP transport (Accept-Encoding,
-// Content-Length, ...) must not cause re-signing to over-include
-// them in SignedHeaders. boto3/aws-cli sign content-type;host;
-// x-amz-date but the wire request gains Accept-Encoding etc. before
-// the server reads it.
+// User-Agent, ...) must not cause re-signing to over-include them
+// in SignedHeaders. boto3/aws-cli sign content-type;host;x-amz-date
+// but the wire request gains Accept-Encoding etc. before the server
+// reads it. Content-Length is a separate auto-add path (sourced
+// from req.ContentLength, not req.Header) — exercised here by
+// signing with ContentLength=0 to mirror boto3 semantics, then
+// restoring the body length to mirror the wire state.
 func TestVerify_TransportAddedHeaders(t *testing.T) {
 	body := []byte("Action=DescribeInstances")
 	sum := sha256.Sum256(body)
@@ -407,15 +410,16 @@ func TestVerify_TransportAddedHeaders(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
 	req.Host = "ec2.amazonaws.com"
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.ContentLength = 0 // suppress SDK's auto-content-length to match boto3
 	require.NoError(t, v4.NewSigner().SignHTTP(
 		context.Background(),
 		aws.Credentials{AccessKeyID: exAccessKeyID, SecretAccessKey: exSecret},
 		req, bodyHashHex, "ec2", exRegion, exTime,
 	))
 
-	// Simulate transport-added headers post-signing.
+	// Wire state: body length is back, transport added unsigned headers.
+	req.ContentLength = int64(len(body))
 	req.Header.Set("Accept-Encoding", "identity")
-	req.Header.Set("Content-Length", "23")
 	req.Header.Set("User-Agent", "aws-cli/2.0")
 
 	sig, err := auth.ParseReq(req)
@@ -424,8 +428,8 @@ func TestVerify_TransportAddedHeaders(t *testing.T) {
 		auth.WithTime(exTime),
 		auth.WithBodyHash(bodyHashHex)))
 
-	// Transport-added headers must still be on the request after Verify.
+	// Wire state must survive Verify untouched.
 	require.Equal(t, "identity", req.Header.Get("Accept-Encoding"))
-	require.Equal(t, "23", req.Header.Get("Content-Length"))
 	require.Equal(t, "aws-cli/2.0", req.Header.Get("User-Agent"))
+	require.Equal(t, int64(len(body)), req.ContentLength)
 }

--- a/auth/sigv4_test.go
+++ b/auth/sigv4_test.go
@@ -2,6 +2,7 @@ package auth_test
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"net/http"
@@ -10,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/mulgadc/predastore/auth"
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
@@ -340,4 +343,53 @@ func TestVerify_WithBodyHash(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestVerify_MissingContentSHAFallback exercises the non-S3 SDK path:
+// EC2/IAM/ELBv2 clients sign with a payload hash in the canonical
+// request but omit X-Amz-Content-Sha256 from the wire. Verify must
+// accept these when WithBodyHash supplies the same hash, and still
+// reject when no bodyHash is provided.
+func TestVerify_MissingContentSHAFallback(t *testing.T) {
+	body := []byte("Action=DescribeInstances&Version=2016-11-15")
+	sum := sha256.Sum256(body)
+	bodyHashHex := hex.EncodeToString(sum[:])
+
+	// Sign without setting X-Amz-Content-Sha256 to mirror non-S3 SDK
+	// clients (EC2 etc.): the SDK passes payloadHash into the canonical
+	// request but does not emit it as a wire header.
+	signNoHeader := func() *http.Request {
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+		req.Host = "ec2.amazonaws.com"
+		require.NoError(t, v4.NewSigner().SignHTTP(
+			context.Background(),
+			aws.Credentials{AccessKeyID: exAccessKeyID, SecretAccessKey: exSecret},
+			req, bodyHashHex, "ec2", exRegion, exTime,
+		))
+		require.Empty(t, req.Header.Get("X-Amz-Content-Sha256"))
+		return req
+	}
+
+	t.Run("accepts when WithBodyHash supplies the hash", func(t *testing.T) {
+		sig, err := auth.ParseReq(signNoHeader())
+		require.NoError(t, err)
+		require.NoError(t, sig.Verify(exSecret, "ec2", exRegion,
+			auth.WithTime(exTime), auth.WithBodyHash(bodyHashHex)))
+	})
+
+	t.Run("rejects when no bodyHash is supplied", func(t *testing.T) {
+		sig, err := auth.ParseReq(signNoHeader())
+		require.NoError(t, err)
+		err = sig.Verify(exSecret, "ec2", exRegion, auth.WithTime(exTime))
+		require.ErrorIs(t, err, auth.ErrMissingContentSHA)
+	})
+
+	t.Run("rejects when bodyHash diverges from what client signed", func(t *testing.T) {
+		sig, err := auth.ParseReq(signNoHeader())
+		require.NoError(t, err)
+		err = sig.Verify(exSecret, "ec2", exRegion,
+			auth.WithTime(exTime),
+			auth.WithBodyHash(strings.Repeat("0", 64)))
+		require.ErrorIs(t, err, auth.ErrSignatureMismatch)
+	})
 }


### PR DESCRIPTION
## Summary

Three Verify-side fixes on top of the v2 signer passthrough (already on dev).
Without these, every signed request from a stock aws-sdk-go v1 client fails
with AccessDenied because Verify re-derives SignedHeaders from request
state contaminated by transport-added headers / content-length / etc.

- 8992b20 fix(auth): accept missing X-Amz-Content-Sha256 when WithBodyHash supplied
- ab6ec8b fix(auth): strip transport-added headers before re-signing in Verify
- b06eb73 fix(auth): zero req.ContentLength across re-sign when content-length unsigned

Blocks spinifex dev (Build and Test / Race Detection / Single-Node E2E
all failing on \`TestIntegration_LargeFile\` SigV4 mismatch with
\`SignedHeaders=accept-encoding;...\` vs client \`SignedHeaders=...\`).
Pairs with spinifex PR #246 — predastore must merge first so spinifex
dev's branch-name clone picks up these fixes.

## Test plan

- [x] \`make preflight\` green (unit + property tests on \`auth/sigv4_test.go\` already cover the cases).
- [ ] After merge: spinifex dev next-push CI green (Build and Test + E2E).
- [ ] After merge: spinifex PR #246 re-run green and ready to merge.