### PR TITLE
feat: stop-gap segment compaction

### DIFF
--- a/backend/distributed/multipart.go
+++ b/backend/distributed/multipart.go
@@ -432,7 +432,7 @@ func (b *Backend) CompleteMultipartUpload(ctx context.Context, req *backend.Comp
 	}
 
 	// Clean up: delete parts and upload metadata
-	if err := b.cleanupMultipartUpload(req.UploadID, req.Parts); err != nil {
+	if err := b.cleanupMultipartUpload(ctx, req.Bucket, req.Key, req.UploadID, req.Parts); err != nil {
 		slog.Warn("Failed to cleanup multipart upload", "uploadID", req.UploadID, "error", err)
 		// Don't fail the request, cleanup is best-effort
 	}
@@ -484,17 +484,34 @@ func (b *Backend) getPartData(ctx context.Context, bucket, key, uploadID string,
 	return buf.Bytes(), nil
 }
 
-// cleanupMultipartUpload removes all parts and metadata for an upload
-func (b *Backend) cleanupMultipartUpload(uploadID string, parts []backend.CompletedPart) error {
-	// Delete part metadata
+// cleanupMultipartUpload removes all part shards (via QUIC), part/upload metadata,
+// and the shard-location map for an upload. Shard deletes are best-effort: a per-node
+// failure is logged and skipped, never failing the complete/abort request.
+func (b *Backend) cleanupMultipartUpload(ctx context.Context, bucket, key, uploadID string, parts []backend.CompletedPart) error {
 	for _, part := range parts {
-		partKey := multipartPartKey(uploadID, part.PartNumber)
-		if err := b.globalState.Delete(TableParts, partKey); err != nil {
+		partShardKey := fmt.Sprintf("part:%s:%05d", uploadID, part.PartNumber)
+
+		// Drop the physical part shards before removing the shard-location map. A missing
+		// or corrupt map, or a per-node delete failure, is logged and skipped — cleanup is
+		// best-effort and must not fail the complete/abort request.
+		if data, err := b.globalState.Get(TableObjects, []byte(partShardKey)); err != nil {
+			slog.Warn("cleanup: part shard map missing, skipping shard delete", "uploadID", uploadID, "part", part.PartNumber)
+		} else {
+			var nodes ObjectToShardNodes
+			if err := gob.NewDecoder(bytes.NewReader(data)).Decode(&nodes); err != nil {
+				slog.Warn("cleanup: part shard map corrupt, skipping shard delete", "uploadID", uploadID, "part", part.PartNumber, "error", err)
+			} else {
+				partObjKey := partObjectKey(bucket, key, uploadID, part.PartNumber)
+				if err := b.deleteObjectViaQUIC(ctx, bucket, partObjKey, nodes.Object, nodes); err != nil {
+					slog.Error("cleanup: QUIC shard delete failed, continuing", "uploadID", uploadID, "part", part.PartNumber, "error", err)
+				}
+			}
+		}
+
+		if err := b.globalState.Delete(TableParts, multipartPartKey(uploadID, part.PartNumber)); err != nil {
 			slog.Warn("Failed to delete part metadata", "uploadID", uploadID, "part", part.PartNumber, "error", err)
 		}
 
-		// Delete part shard location
-		partShardKey := fmt.Sprintf("part:%s:%05d", uploadID, part.PartNumber)
 		if err := b.globalState.Delete(TableObjects, []byte(partShardKey)); err != nil {
 			slog.Warn("Failed to delete part shard metadata", "uploadID", uploadID, "part", part.PartNumber, "error", err)
 		}
@@ -549,7 +566,7 @@ func (b *Backend) AbortMultipartUpload(ctx context.Context, bucket, key, uploadI
 	}
 
 	// Clean up
-	if err := b.cleanupMultipartUpload(uploadID, parts); err != nil {
+	if err := b.cleanupMultipartUpload(ctx, bucket, key, uploadID, parts); err != nil {
 		slog.Warn("Failed to cleanup multipart upload", "uploadID", uploadID, "error", err)
 	}
 

--- a/backend/distributed/multipart_test.go
+++ b/backend/distributed/multipart_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/md5"
+	"encoding/gob"
 	"fmt"
 	"io"
 	"os"
@@ -27,8 +28,10 @@ import (
 // bind conflicts when the OS hasn't fully released UDP ports from the prior test.
 var multipartPortCounter atomic.Int32
 
-// setupMultipartTestBackend creates a distributed backend with QUIC servers for testing
-func setupMultipartTestBackend(t *testing.T) (*Backend, func()) {
+// setupMultipartTestBackend creates a distributed backend with QUIC servers for testing.
+// The returned slice exposes the per-node QUIC servers (indexed by node number) so tests
+// can probe shard presence and inject node failures.
+func setupMultipartTestBackend(t *testing.T) (*Backend, []*quicserver.QuicServer, func()) {
 	t.Helper()
 
 	tmpDir := t.TempDir()
@@ -84,11 +87,97 @@ func setupMultipartTestBackend(t *testing.T) (*Backend, func()) {
 		be.Close()
 	}
 
-	return be, cleanup
+	return be, quicServers, cleanup
+}
+
+// shardExistsOnNode probes a single QUIC node for the presence of one shard of an object,
+// returning true if the node still serves it. Used to assert part shards are deleted on
+// cleanup while the assembled object's shards survive.
+func shardExistsOnNode(t *testing.T, be *Backend, node uint32, bucket, key string, shardIndex int) bool {
+	t.Helper()
+	ctx := context.Background()
+	client, err := quicclient.DialPooled(ctx, be.getNodeAddr(int(node)))
+	require.NoError(t, err)
+
+	rc, err := client.Get(ctx, quicserver.ObjectRequest{
+		Bucket:     bucket,
+		Object:     key,
+		RangeStart: -1,
+		RangeEnd:   -1,
+		ShardIndex: uint32(shardIndex),
+	})
+	if err != nil {
+		return false
+	}
+	_ = rc.Close()
+	return true
+}
+
+// loadPartShardNodes decodes the stored ObjectToShardNodes for a part from globalState.
+func loadPartShardNodes(t *testing.T, be *Backend, uploadID string, partNumber int) ObjectToShardNodes {
+	t.Helper()
+	key := fmt.Sprintf("part:%s:%05d", uploadID, partNumber)
+	data, err := be.globalState.Get(TableObjects, []byte(key))
+	require.NoError(t, err)
+
+	var nodes ObjectToShardNodes
+	require.NoError(t, gob.NewDecoder(bytes.NewReader(data)).Decode(&nodes))
+	return nodes
+}
+
+// assertAllPartShardsDeleted asserts every data+parity shard of the given part is gone
+// from its node.
+func assertAllPartShardsDeleted(t *testing.T, be *Backend, bucket, key, uploadID string, partNumber int, nodes ObjectToShardNodes) {
+	t.Helper()
+	partObjKey := partObjectKey(bucket, key, uploadID, partNumber)
+
+	for i, node := range nodes.DataShardNodes {
+		assert.False(t, shardExistsOnNode(t, be, node, bucket, partObjKey, i),
+			"data shard %d for part %d should be deleted on node %d", i, partNumber, node)
+	}
+	for i, node := range nodes.ParityShardNodes {
+		shardIndex := len(nodes.DataShardNodes) + i
+		assert.False(t, shardExistsOnNode(t, be, node, bucket, partObjKey, shardIndex),
+			"parity shard %d for part %d should be deleted on node %d", shardIndex, partNumber, node)
+	}
+}
+
+// createUploadWithParts creates a multipart upload and uploads partData in order,
+// returning the upload ID and the completed-part descriptors.
+func createUploadWithParts(t *testing.T, be *Backend, bucket, key string, partData [][]byte) (string, []backend.CompletedPart) {
+	t.Helper()
+	ctx := context.Background()
+
+	createResp, err := be.CreateMultipartUpload(ctx, &backend.CreateMultipartUploadRequest{Bucket: bucket, Key: key})
+	require.NoError(t, err)
+
+	parts := make([]backend.CompletedPart, len(partData))
+	for i, data := range partData {
+		resp, err := be.UploadPart(ctx, &backend.UploadPartRequest{
+			Bucket:     bucket,
+			Key:        key,
+			UploadID:   createResp.UploadID,
+			PartNumber: i + 1,
+			Body:       bytes.NewReader(data),
+		})
+		require.NoError(t, err)
+		parts[i] = backend.CompletedPart{PartNumber: i + 1, ETag: resp.ETag}
+	}
+	return createResp.UploadID, parts
+}
+
+// captureShardMaps records each part's ObjectToShardNodes before cleanup removes it.
+func captureShardMaps(t *testing.T, be *Backend, uploadID string, parts []backend.CompletedPart) map[int]ObjectToShardNodes {
+	t.Helper()
+	maps := make(map[int]ObjectToShardNodes, len(parts))
+	for _, p := range parts {
+		maps[p.PartNumber] = loadPartShardNodes(t, be, uploadID, p.PartNumber)
+	}
+	return maps
 }
 
 func TestDistributed_CreateMultipartUpload(t *testing.T) {
-	be, cleanup := setupMultipartTestBackend(t)
+	be, _, cleanup := setupMultipartTestBackend(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -140,7 +229,7 @@ func TestDistributed_CreateMultipartUpload(t *testing.T) {
 }
 
 func TestDistributed_UploadPart(t *testing.T) {
-	be, cleanup := setupMultipartTestBackend(t)
+	be, _, cleanup := setupMultipartTestBackend(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -254,7 +343,7 @@ func TestDistributed_UploadPart(t *testing.T) {
 }
 
 func TestDistributed_CompleteMultipartUpload(t *testing.T) {
-	be, cleanup := setupMultipartTestBackend(t)
+	be, _, cleanup := setupMultipartTestBackend(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -438,7 +527,7 @@ func TestDistributed_CompleteMultipartUpload(t *testing.T) {
 }
 
 func TestDistributed_AbortMultipartUpload(t *testing.T) {
-	be, cleanup := setupMultipartTestBackend(t)
+	be, _, cleanup := setupMultipartTestBackend(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -490,7 +579,7 @@ func TestDistributed_AbortMultipartUpload(t *testing.T) {
 }
 
 func TestDistributed_MultipartUpload_FullWorkflow(t *testing.T) {
-	be, cleanup := setupMultipartTestBackend(t)
+	be, _, cleanup := setupMultipartTestBackend(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -607,7 +696,7 @@ func TestDistributed_MultipartUpload_LargeNumberOfParts(t *testing.T) {
 		t.Skip("Skipping large parts test in short mode")
 	}
 
-	be, cleanup := setupMultipartTestBackend(t)
+	be, _, cleanup := setupMultipartTestBackend(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -694,7 +783,7 @@ func TestDistributed_MultipartUpload_LargeNumberOfParts(t *testing.T) {
 }
 
 func TestDistributed_MultipartUpload_PartOverwrite(t *testing.T) {
-	be, cleanup := setupMultipartTestBackend(t)
+	be, _, cleanup := setupMultipartTestBackend(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -807,7 +896,7 @@ func TestDistributed_MultipartUpload_PartOverwrite(t *testing.T) {
 // Scope note: the 90 s total-elapsed bound is a deadlock detector, not a
 // performance regression. A per-part benchmark belongs in s3_bench_test.go.
 func TestDistributed_MultipartUpload_ConcurrentParts_Contention(t *testing.T) {
-	be, cleanup := setupMultipartTestBackend(t)
+	be, _, cleanup := setupMultipartTestBackend(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -930,4 +1019,175 @@ func sortPartsByNumber(parts []backend.CompletedPart) {
 			parts[j-1], parts[j] = parts[j], parts[j-1]
 		}
 	}
+}
+
+// Verification case 1: CompleteMultipartUpload issues a QUIC shard-delete for every
+// part shard (data + parity).
+func TestDistributed_CompleteMultipartUpload_DeletesPartShards(t *testing.T) {
+	be, _, cleanup := setupMultipartTestBackend(t)
+	defer cleanup()
+	ctx := context.Background()
+	const bucket, key = "test-bucket", "complete-deletes-shards.bin"
+
+	part1 := bytes.Repeat([]byte{0x11}, int(multipart.MinPartSize))
+	part2 := []byte("final small part")
+	uploadID, parts := createUploadWithParts(t, be, bucket, key, [][]byte{part1, part2})
+	shardMaps := captureShardMaps(t, be, uploadID, parts)
+
+	_, err := be.CompleteMultipartUpload(ctx, &backend.CompleteMultipartUploadRequest{
+		Bucket: bucket, Key: key, UploadID: uploadID, Parts: parts,
+	})
+	require.NoError(t, err)
+
+	for _, p := range parts {
+		assertAllPartShardsDeleted(t, be, bucket, key, uploadID, p.PartNumber, shardMaps[p.PartNumber])
+	}
+}
+
+// Verification case 2: AbortMultipartUpload issues a QUIC shard-delete for every part shard.
+func TestDistributed_AbortMultipartUpload_DeletesPartShards(t *testing.T) {
+	be, _, cleanup := setupMultipartTestBackend(t)
+	defer cleanup()
+	ctx := context.Background()
+	const bucket, key = "test-bucket", "abort-deletes-shards.bin"
+
+	part1 := bytes.Repeat([]byte{0x22}, int(multipart.MinPartSize))
+	part2 := []byte("another small part")
+	uploadID, parts := createUploadWithParts(t, be, bucket, key, [][]byte{part1, part2})
+	shardMaps := captureShardMaps(t, be, uploadID, parts)
+
+	require.NoError(t, be.AbortMultipartUpload(ctx, bucket, key, uploadID))
+
+	for _, p := range parts {
+		assertAllPartShardsDeleted(t, be, bucket, key, uploadID, p.PartNumber, shardMaps[p.PartNumber])
+	}
+}
+
+// Verification case 3: the completed object's own shards survive cleanup (regression guard
+// that cleanup deletes part shards, not the assembled object).
+func TestDistributed_CompleteMultipartUpload_PreservesAssembledObject(t *testing.T) {
+	be, _, cleanup := setupMultipartTestBackend(t)
+	defer cleanup()
+	ctx := context.Background()
+	const bucket, key = "test-bucket", "preserve-assembled.bin"
+
+	part1 := bytes.Repeat([]byte{0x33}, int(multipart.MinPartSize))
+	part2 := []byte("tail bytes")
+	uploadID, parts := createUploadWithParts(t, be, bucket, key, [][]byte{part1, part2})
+
+	_, err := be.CompleteMultipartUpload(ctx, &backend.CompleteMultipartUploadRequest{
+		Bucket: bucket, Key: key, UploadID: uploadID, Parts: parts,
+	})
+	require.NoError(t, err)
+
+	getResp, err := be.GetObject(ctx, &backend.GetObjectRequest{Bucket: bucket, Key: key, RangeStart: -1, RangeEnd: -1})
+	require.NoError(t, err)
+	defer getResp.Body.Close()
+
+	readData, err := io.ReadAll(getResp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, append(append([]byte{}, part1...), part2...), readData)
+}
+
+// Verification case 4: upload + part metadata are removed from globalState after
+// complete and after abort.
+func TestDistributed_MultipartCleanup_RemovesMetadata(t *testing.T) {
+	be, _, cleanup := setupMultipartTestBackend(t)
+	defer cleanup()
+	ctx := context.Background()
+	const bucket = "test-bucket"
+
+	assertMetadataGone := func(t *testing.T, uploadID string) {
+		t.Helper()
+		_, err := be.getUploadMetadata(uploadID)
+		assert.Error(t, err)
+
+		stored, err := be.getStoredParts(uploadID)
+		require.NoError(t, err)
+		assert.Empty(t, stored)
+	}
+
+	t.Run("complete", func(t *testing.T) {
+		const key = "removes-metadata-complete.bin"
+		part1 := bytes.Repeat([]byte{0x44}, int(multipart.MinPartSize))
+		part2 := []byte("done")
+		uploadID, parts := createUploadWithParts(t, be, bucket, key, [][]byte{part1, part2})
+
+		_, err := be.CompleteMultipartUpload(ctx, &backend.CompleteMultipartUploadRequest{
+			Bucket: bucket, Key: key, UploadID: uploadID, Parts: parts,
+		})
+		require.NoError(t, err)
+		assertMetadataGone(t, uploadID)
+	})
+
+	t.Run("abort", func(t *testing.T) {
+		const key = "removes-metadata-abort.bin"
+		part1 := bytes.Repeat([]byte{0x55}, int(multipart.MinPartSize))
+		uploadID, _ := createUploadWithParts(t, be, bucket, key, [][]byte{part1})
+
+		require.NoError(t, be.AbortMultipartUpload(ctx, bucket, key, uploadID))
+		assertMetadataGone(t, uploadID)
+	})
+}
+
+// Verification case 5: with one node unreachable during cleanup the request still
+// succeeds and the reachable nodes' shards are still deleted.
+func TestDistributed_MultipartCleanup_NodeUnreachableStillSucceeds(t *testing.T) {
+	be, quicServers, cleanup := setupMultipartTestBackend(t)
+	defer cleanup()
+	ctx := context.Background()
+	const bucket, key = "test-bucket", "node-unreachable.bin"
+
+	part1 := bytes.Repeat([]byte{0x66}, int(multipart.MinPartSize))
+	part2 := []byte("small tail")
+	uploadID, parts := createUploadWithParts(t, be, bucket, key, [][]byte{part1, part2})
+	shardMaps := captureShardMaps(t, be, uploadID, parts)
+
+	// Drop one node before cleanup; its shard deletes will fail and be skipped.
+	// Evict the pooled connection so the next dial gets connection-refused, faithfully
+	// simulating a down node rather than a half-open connection.
+	const downNode uint32 = 0
+	require.NoError(t, quicServers[downNode].Close())
+	quicclient.InvalidatePooled(be.getNodeAddr(int(downNode)))
+
+	require.NoError(t, be.AbortMultipartUpload(ctx, bucket, key, uploadID))
+
+	for _, p := range parts {
+		nodes := shardMaps[p.PartNumber]
+		partObjKey := partObjectKey(bucket, key, uploadID, p.PartNumber)
+		assertReachableShardGone := func(node uint32, shardIndex int) {
+			if node == downNode {
+				return
+			}
+			assert.False(t, shardExistsOnNode(t, be, node, bucket, partObjKey, shardIndex),
+				"shard %d for part %d should be deleted on reachable node %d", shardIndex, p.PartNumber, node)
+		}
+		for i, node := range nodes.DataShardNodes {
+			assertReachableShardGone(node, i)
+		}
+		for i, node := range nodes.ParityShardNodes {
+			assertReachableShardGone(node, len(nodes.DataShardNodes)+i)
+		}
+	}
+}
+
+// Verification case 6: a missing part shard-map entry is skipped during cleanup and the
+// upload metadata is still removed.
+func TestDistributed_MultipartCleanup_MissingShardMapSkipsPart(t *testing.T) {
+	be, _, cleanup := setupMultipartTestBackend(t)
+	defer cleanup()
+	ctx := context.Background()
+	const bucket, key = "test-bucket", "missing-shard-map.bin"
+
+	part1 := bytes.Repeat([]byte{0x77}, int(multipart.MinPartSize))
+	part2 := []byte("tail")
+	uploadID, _ := createUploadWithParts(t, be, bucket, key, [][]byte{part1, part2})
+
+	// Remove part 1's shard-location map so cleanup must skip its shard delete.
+	require.NoError(t, be.globalState.Delete(TableObjects, fmt.Appendf(nil, "part:%s:%05d", uploadID, 1)))
+
+	require.NoError(t, be.AbortMultipartUpload(ctx, bucket, key, uploadID))
+
+	_, err := be.getUploadMetadata(uploadID)
+	assert.Error(t, err)
 }

--- a/config/3node.toml
+++ b/config/3node.toml
@@ -13,6 +13,11 @@ region = "ap-southeast-2"
 data = 2
 parity = 1
 
+# Background compactor for the QUIC shard store. Omit to use the default
+# interval (300s).
+# [compaction]
+# interval_seconds = 300
+
 [[db]]
 id = 1
 host = "10.11.12.1"

--- a/config/5node.toml
+++ b/config/5node.toml
@@ -13,6 +13,11 @@ region = "ap-southeast-2"
 data = 3
 parity = 2
 
+# Background compactor for the QUIC shard store. Omit to use the default
+# interval (300s).
+# [compaction]
+# interval_seconds = 300
+
 [[db]]
 id = 1
 host = "10.11.12.1"

--- a/config/7node.toml
+++ b/config/7node.toml
@@ -13,6 +13,11 @@ region = "ap-southeast-2"
 data = 4
 parity = 3
 
+# Background compactor for the QUIC shard store. Omit to use the default
+# interval (300s).
+# [compaction]
+# interval_seconds = 300
+
 [[db]]
 id = 1
 host = "10.11.12.1"

--- a/internal/storetest/reference_store.go
+++ b/internal/storetest/reference_store.go
@@ -67,14 +67,16 @@ func (st *RefStore) Append(objectHash [32]byte, shardIndex uint32, size int64) (
 	}, nil
 }
 
-func (st *RefStore) Delete(objectHash [32]byte, shardIndex uint32) error {
+func (st *RefStore) Delete(objectHash [32]byte, shardIndex uint32) (bool, error) {
 	if st.closed {
-		return store.ErrClosedStore
+		return false, store.ErrClosedStore
 	}
 
-	delete(st.state, [36]byte(store.MakeShardKey(objectHash, shardIndex)))
+	key := [36]byte(store.MakeShardKey(objectHash, shardIndex))
+	_, existed := st.state[key]
+	delete(st.state, key)
 
-	return nil
+	return existed, nil
 }
 
 func (st *RefStore) Len() int {

--- a/quic/quicserver/delete.go
+++ b/quic/quicserver/delete.go
@@ -8,20 +8,23 @@ import (
 	"github.com/mulgadc/predastore/quic/quicproto"
 )
 
-// handleDELETEShard removes shard metadata from the store index. The on-disk
-// extent becomes dead space reclaimable by a future compactor.
+// handleDELETEShard marks shard metadata in the store index as deleted so that it may be reclaimed by compaction.
 func (qs *QuicServer) handleDELETEShard(bw *bufio.Writer, req quicproto.Header, delReq DeleteRequest) {
-	if err := qs.store.Delete(delReq.ObjectHash, delReq.ShardIndex); err != nil {
-		slog.Debug("handleDELETEShard: delete failed", "bucket", delReq.Bucket, "object", delReq.Object, "shardIndex", delReq.ShardIndex, "error", err)
+	deleted, err := qs.store.Delete(delReq.ObjectHash, delReq.ShardIndex)
+	if err != nil {
+		slog.Error("handleDELETEShard: delete failed", "bucket", delReq.Bucket, "object", delReq.Object, "shardIndex", delReq.ShardIndex, "error", err)
+		qs.sendDeleteResponse(bw, req, false, err.Error())
+		return
 	}
 
 	slog.Debug("handleDELETEShard: deleted shard",
 		"bucket", delReq.Bucket,
 		"object", delReq.Object,
 		"shardIndex", delReq.ShardIndex,
+		"deleted", deleted,
 	)
 
-	qs.sendDeleteResponse(bw, req, true, "")
+	qs.sendDeleteResponse(bw, req, deleted, "")
 }
 
 func (qs *QuicServer) sendDeleteResponse(bw *bufio.Writer, req quicproto.Header, deleted bool, errMsg string) {

--- a/quic/quicserver/server.go
+++ b/quic/quicserver/server.go
@@ -38,6 +38,8 @@ type QuicServer struct {
 	tlsCert string
 	tlsKey  string
 
+	compactionInterval time.Duration
+
 	store *store.Store
 
 	// Listener for graceful shutdown
@@ -86,6 +88,15 @@ func WithTLSCertFiles(certPath, keyPath string) Option {
 		}
 		qs.tlsCert = certPath
 		qs.tlsKey = keyPath
+		return nil
+	}
+}
+
+// WithCompactionInterval sets how often the store's background compactor runs.
+// A non-positive duration leaves the store's default in effect.
+func WithCompactionInterval(d time.Duration) Option {
+	return func(qs *QuicServer) error {
+		qs.compactionInterval = d
 		return nil
 	}
 }
@@ -161,7 +172,7 @@ func NewWithRetry(walDir string, addr string, maxRetries int, opts ...Option) (*
 		return nil, fmt.Errorf("quicserver: tls cert and key are required (use WithTLSCertFiles)")
 	}
 
-	s, err := store.Open(walDir, store.WithAEAD(qs.aead), store.WithCompaction())
+	s, err := store.Open(walDir, store.WithAEAD(qs.aead), store.WithCompaction(qs.compactionInterval))
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("open store in %s: %w", walDir, err)

--- a/quic/quicserver/server.go
+++ b/quic/quicserver/server.go
@@ -161,7 +161,7 @@ func NewWithRetry(walDir string, addr string, maxRetries int, opts ...Option) (*
 		return nil, fmt.Errorf("quicserver: tls cert and key are required (use WithTLSCertFiles)")
 	}
 
-	s, err := store.Open(walDir, store.WithAEAD(qs.aead))
+	s, err := store.Open(walDir, store.WithAEAD(qs.aead), store.WithCompaction())
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("open store in %s: %w", walDir, err)

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -28,6 +28,11 @@ type RS struct {
 	Parity int `toml:"parity"`
 }
 
+// Compaction holds tuning for the QUIC shard store's background compactor.
+type Compaction struct {
+	IntervalSeconds int `toml:"interval_seconds"`
+}
+
 type Nodes struct {
 	ID     int    `toml:"id"`
 	Host   string `toml:"host"`
@@ -60,6 +65,9 @@ type Config struct {
 
 	RS    RS      `toml:"rs"`
 	Nodes []Nodes `toml:"nodes"`
+
+	// Compaction tuning for the QUIC shard store (optional; store defaults apply).
+	Compaction Compaction `toml:"compaction"`
 
 	// Distributed database nodes for global state
 	DB []DBNode `toml:"db"`

--- a/s3/server.go
+++ b/s3/server.go
@@ -655,6 +655,7 @@ func (s *Server) launchQUICServers() {
 				quicserver.New(nodePath, quicAddr,
 					quicserver.WithMasterKey(s.masterKey),
 					quicserver.WithTLSCertFiles(s.tlsCert, s.tlsKey),
+					quicserver.WithCompactionInterval(s.compactionInterval()),
 				)
 				return
 			}
@@ -681,11 +682,18 @@ func (s *Server) launchQUICServers() {
 			quicserver.New(nodePath, quicAddr,
 				quicserver.WithMasterKey(s.masterKey),
 				quicserver.WithTLSCertFiles(s.tlsCert, s.tlsKey),
+				quicserver.WithCompactionInterval(s.compactionInterval()),
 			)
 		}
 	} else {
 		slog.Error("Distributed mode requires -node flag when nodes have different hosts")
 	}
+}
+
+// compactionInterval converts the configured interval (in seconds) to a
+// duration. A non-positive value yields zero, leaving the store default.
+func (s *Server) compactionInterval() time.Duration {
+	return time.Duration(s.config.Compaction.IntervalSeconds) * time.Second
 }
 
 // initCredentialProvider creates the appropriate CredentialProvider based on config.

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -124,6 +124,23 @@ if [ ! -f "$TLS_CERT" ]; then
     log_info "Certificates written to $ROOT/"
 fi
 
+# --- Install cert into the OS trust store ---
+#
+# s3d verifies inter-node Raft and QUIC peer certs strictly against the OS
+# trust store (quicclient.tlsConfigForDial / raft_streamlayer.Dial), with no
+# CA-bundle flag. A self-signed cert that is not a trust anchor fails with
+# "x509: certificate signed by unknown authority", so the cluster never elects
+# a leader. Install it so the dialers trust it.
+
+TRUST_ANCHOR="/usr/local/share/ca-certificates/predastore-${CLUSTER_NAME}.crt"
+
+if ! cmp -s "$TLS_CERT" "$TRUST_ANCHOR" 2>/dev/null; then
+    log_info "Installing TLS cert into OS trust store..."
+    sudo cp "$TLS_CERT" "$TRUST_ANCHOR"
+    sudo update-ca-certificates >/dev/null
+    log_info "Trust anchor installed at $TRUST_ANCHOR"
+fi
+
 # --- Generate master encryption key ---
 #
 # s3d's keyfile loader is fail-closed on group/other-readable modes, so the

--- a/store/codec_test.go
+++ b/store/codec_test.go
@@ -1,0 +1,72 @@
+package store
+
+import (
+	"bytes"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestIdxEntryRoundTrip(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		var key [36]byte
+		copy(key[:], rapid.SliceOfN(rapid.Byte(), 36, 36).Draw(rt, "key"))
+		e := idxEntry{
+			Off:   rapid.Int64Range(0, 1<<48).Draw(rt, "off"),
+			Key:   key,
+			PSize: rapid.Int64Range(0, 1<<48).Draw(rt, "psize"),
+		}
+
+		b := e.encode()
+		if len(b) != idxEntrySize {
+			rt.Fatalf("encode length = %d, want %d", len(b), idxEntrySize)
+		}
+
+		got, err := decodeIdxEntry(b)
+		if err != nil {
+			rt.Fatalf("decode: %v", err)
+		}
+		if got != e {
+			rt.Fatalf("round-trip mismatch: got %+v want %+v", got, e)
+		}
+	})
+}
+
+func TestDecodeIdxEntryRejectsWrongLength(t *testing.T) {
+	for _, n := range []int{0, 1, idxEntrySize - 1, idxEntrySize + 1, 2 * idxEntrySize} {
+		if _, err := decodeIdxEntry(make([]byte, n)); err == nil {
+			t.Errorf("decodeIdxEntry(len %d): want error, got nil", n)
+		}
+	}
+}
+
+func TestTombstoneKeyRoundTrip(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		segNum := rapid.Uint64().Draw(rt, "segNum")
+		off := rapid.Int64Range(0, 1<<48).Draw(rt, "off")
+
+		key := tombstoneKey(segNum, off)
+		if len(key) != tombstoneKeySize {
+			rt.Fatalf("key length = %d, want %d", len(key), tombstoneKeySize)
+		}
+		if key[0] != tombstonePrefix {
+			rt.Fatalf("prefix = %q, want %q", key[0], tombstonePrefix)
+		}
+		if got := tombstoneSegNum(key); got != segNum {
+			rt.Fatalf("segNum round-trip: got %d want %d", got, segNum)
+		}
+	})
+}
+
+func TestTombstoneKeyGroupsBySegNum(t *testing.T) {
+	a := tombstoneKey(7, 100)
+	b := tombstoneKey(7, 200)
+	c := tombstoneKey(8, 100)
+
+	if !bytes.Equal(a[:9], b[:9]) {
+		t.Errorf("same segNum should share the 9-byte d‖segNum sub-prefix")
+	}
+	if bytes.Equal(a[:9], c[:9]) {
+		t.Errorf("different segNum should not share the sub-prefix")
+	}
+}

--- a/store/compaction.go
+++ b/store/compaction.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	// compactionInterval is how often the background compactor runs a cycle.
-	compactionInterval = 5 * time.Minute
+	// defaultCompactionInterval is the fallback cycle period used when the
+	// caller does not supply one via WithCompaction.
+	defaultCompactionInterval = 5 * time.Minute
 
 	// compactionLiveThreshold is the live-byte fraction below which a segment
 	// becomes a compaction candidate. A segment whose live data is under this
@@ -40,7 +41,7 @@ func (store *Store) startCompactor() {
 
 func (c *compactor) loop() {
 	defer c.wg.Done()
-	ticker := time.NewTicker(compactionInterval)
+	ticker := time.NewTicker(c.store.compactionInterval)
 	defer ticker.Stop()
 
 	for {
@@ -72,7 +73,7 @@ func (store *Store) compactOnce() error {
 	}
 
 	start := time.Now()
-	slog.Info("compaction started", "interval", compactionInterval, "liveThreshold", compactionLiveThreshold)
+	slog.Info("compaction started", "interval", store.compactionInterval, "liveThreshold", compactionLiveThreshold)
 
 	candidates, err := store.candidateSegments()
 	if err != nil {

--- a/store/compaction.go
+++ b/store/compaction.go
@@ -1,0 +1,264 @@
+package store
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+)
+
+const (
+	// compactionInterval is how often the background compactor runs a cycle.
+	compactionInterval = 5 * time.Minute
+
+	// compactionLiveThreshold is the live-byte fraction below which a segment
+	// becomes a compaction candidate. A segment whose live data is under this
+	// share of its file size is worth draining.
+	compactionLiveThreshold = 0.70
+)
+
+// compactor runs compactOnce on an interval until stopped. Started only when
+// WithCompaction is supplied; stopped and joined by Close before segments and
+// the index are drained.
+type compactor struct {
+	store *Store
+	done  chan struct{}
+	wg    sync.WaitGroup
+}
+
+func (store *Store) startCompactor() {
+	c := &compactor{store: store, done: make(chan struct{})}
+	store.compactor = c
+	c.wg.Add(1)
+	go c.loop()
+}
+
+func (c *compactor) loop() {
+	defer c.wg.Done()
+	ticker := time.NewTicker(compactionInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.done:
+			return
+		case <-ticker.C:
+			if err := c.store.compactOnce(); err != nil {
+				slog.Error("compaction cycle failed", "error", err)
+			}
+		}
+	}
+}
+
+func (c *compactor) stop() {
+	close(c.done)
+	c.wg.Wait()
+}
+
+// compactOnce runs one full compaction cycle: select under-occupied segments,
+// relocate their live extents into the active append segment, and drop them.
+func (store *Store) compactOnce() error {
+	store.mutex.Lock()
+	closed := store.closed
+	store.mutex.Unlock()
+	if closed {
+		return ErrClosedStore
+	}
+
+	candidates, err := store.candidateSegments()
+	if err != nil {
+		return fmt.Errorf("select candidates: %w", err)
+	}
+
+	for _, num := range candidates {
+		if err := store.compactSegment(num); err != nil {
+			return fmt.Errorf("compact segment %d: %w", num, err)
+		}
+	}
+
+	if len(candidates) > 0 {
+		slog.Info("compaction cycle complete", "segments", len(candidates))
+	}
+	return nil
+}
+
+// candidateSegments scans the tombstone namespace, sums dead bytes per segment,
+// and returns segments whose live fraction is below the threshold. The active
+// append segment is never a candidate — it is the relocation destination.
+func (store *Store) candidateSegments() ([]uint64, error) {
+	dead := make(map[uint64]int64)
+	err := store.index.Scan([]byte{tombstonePrefix}, func(k, v []byte) error {
+		dead[tombstoneSegNum(k)] += int64(binary.BigEndian.Uint64(v)) //nolint:gosec // tombstone value is a non-negative byte count.
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan tombstones: %w", err)
+	}
+
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+
+	var candidates []uint64
+	for num, deadBytes := range dead {
+		if num == store.segNum {
+			continue
+		}
+
+		seg, err := store.getSegment(num)
+		if err != nil {
+			return nil, fmt.Errorf("get segment %d: %w", num, err)
+		}
+		info, err := seg.Stat()
+		if err != nil {
+			return nil, fmt.Errorf("stat segment %d: %w", num, err)
+		}
+
+		size := info.Size()
+		if size <= segHeaderSize {
+			continue
+		}
+		if float64(size-deadBytes)/float64(size) < compactionLiveThreshold {
+			candidates = append(candidates, num)
+		}
+	}
+	return candidates, nil
+}
+
+// compactSegment relocates every live extent the segment holds into the active
+// append segment, then drops the drained segment and clears its tombstones. An
+// extent enumerated from .idx is live only if the index still points at this
+// exact slot; anything deleted or superseded is skipped.
+func (store *Store) compactSegment(num uint64) error {
+	entries, err := scanIdx(store.dir, num)
+	if err != nil {
+		return fmt.Errorf("scan idx %d: %w", num, err)
+	}
+
+	for _, e := range entries {
+		key := e.Key[:]
+		raw, err := store.index.Get(key)
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("get extent: %w", err)
+		}
+		cur, err := decodeExtent(raw)
+		if err != nil {
+			return fmt.Errorf("decode extent: %w", err)
+		}
+		if cur.SegNum != num || cur.Off != e.Off {
+			continue
+		}
+		if err := store.relocateExtent(key, cur); err != nil {
+			return fmt.Errorf("relocate extent: %w", err)
+		}
+	}
+
+	store.mutex.Lock()
+	err = store.dropSegment(num)
+	store.mutex.Unlock()
+	if err != nil {
+		return fmt.Errorf("drop segment %d: %w", num, err)
+	}
+
+	return store.deleteTombstones(num)
+}
+
+// relocateExtent copies an extent's raw fragment bytes verbatim into a freshly
+// reserved slot in the active append segment, then compare-and-swaps the index
+// onto the new slot. Verbatim is load-bearing: fragNum rides along inside the
+// copied bytes, so the GCM nonce is preserved and never reused.
+func (store *Store) relocateExtent(key []byte, old extent) error {
+	fragCount := uint64(old.PSize / totalFragSize) //nolint:gosec // PSize is a non-negative multiple of totalFragSize.
+
+	store.mutex.Lock()
+	srcSeg, err := store.getSegment(old.SegNum)
+	if err != nil {
+		store.mutex.Unlock()
+		return fmt.Errorf("get source segment %d: %w", old.SegNum, err)
+	}
+	srcSeg.addRef()
+
+	dstSeg, dstOff, err := store.reserveExtent(fragCount)
+	if err != nil {
+		srcSeg.releaseRef()
+		store.mutex.Unlock()
+		return fmt.Errorf("reserve destination: %w", err)
+	}
+	dstSeg.addRef()
+
+	newExt := extent{SegNum: store.segNum, Off: dstOff, PSize: old.PSize, LSize: old.LSize}
+	if err := dstSeg.appendIdx(idxEntry{Off: dstOff, Key: [36]byte(key), PSize: old.PSize}); err != nil {
+		srcSeg.releaseRef()
+		dstSeg.releaseRef()
+		store.mutex.Unlock()
+		return fmt.Errorf("append destination idx: %w", err)
+	}
+	store.mutex.Unlock()
+
+	defer srcSeg.releaseRef()
+	defer dstSeg.releaseRef()
+
+	if err := copyExtent(srcSeg, old.Off, dstSeg, dstOff, old.PSize); err != nil {
+		return fmt.Errorf("copy extent bytes: %w", err)
+	}
+	if err := dstSeg.Sync(); err != nil {
+		return fmt.Errorf("sync destination segment: %w", err)
+	}
+	if err := dstSeg.syncIdx(); err != nil {
+		return fmt.Errorf("sync destination idx: %w", err)
+	}
+
+	if _, err := store.casExtent(key, old, newExt); err != nil {
+		return fmt.Errorf("commit relocation: %w", err)
+	}
+	return nil
+}
+
+// copyExtent streams size bytes from src@srcOff to dst@dstOff via disjoint
+// ReadAt/WriteAt, so it runs lock-free against concurrent reads and writes.
+func copyExtent(src *segment, srcOff int64, dst *segment, dstOff int64, size int64) error {
+	if size == 0 {
+		return nil
+	}
+	buf := make([]byte, min(size, int64(bufLen)*totalFragSize))
+	for pos := int64(0); pos < size; {
+		n := min(size-pos, int64(len(buf)))
+		if _, err := src.ReadAt(buf[:n], srcOff+pos); err != nil {
+			return err
+		}
+		if _, err := dst.WriteAt(buf[:n], dstOff+pos); err != nil {
+			return err
+		}
+		pos += n
+	}
+	return nil
+}
+
+// deleteTombstones clears the d ‖ segNum ‖ * namespace after a segment is
+// dropped. Stale tombstones left by a crash are harmless and reclaimed later.
+func (store *Store) deleteTombstones(segNum uint64) error {
+	prefix := make([]byte, 9)
+	prefix[0] = tombstonePrefix
+	binary.BigEndian.PutUint64(prefix[1:9], segNum)
+
+	var keys [][]byte
+	if err := store.index.Scan(prefix, func(k, _ []byte) error {
+		keys = append(keys, append([]byte(nil), k...))
+		return nil
+	}); err != nil {
+		return fmt.Errorf("scan tombstones %d: %w", segNum, err)
+	}
+
+	for _, k := range keys {
+		if err := store.index.Delete(k); err != nil {
+			return fmt.Errorf("delete tombstone: %w", err)
+		}
+	}
+	return nil
+}

--- a/store/compaction.go
+++ b/store/compaction.go
@@ -34,6 +34,7 @@ func (store *Store) startCompactor() {
 	c := &compactor{store: store, done: make(chan struct{})}
 	store.compactor = c
 	c.wg.Add(1)
+	slog.Info("compactor started")
 	go c.loop()
 }
 
@@ -57,6 +58,7 @@ func (c *compactor) loop() {
 func (c *compactor) stop() {
 	close(c.done)
 	c.wg.Wait()
+	slog.Info("compactor stopped")
 }
 
 // compactOnce runs one full compaction cycle: select under-occupied segments,
@@ -69,20 +71,36 @@ func (store *Store) compactOnce() error {
 		return ErrClosedStore
 	}
 
+	start := time.Now()
+	slog.Info("compaction started", "interval", compactionInterval, "liveThreshold", compactionLiveThreshold)
+
 	candidates, err := store.candidateSegments()
 	if err != nil {
 		return fmt.Errorf("select candidates: %w", err)
 	}
 
+	var totalExtents int
+	var totalBytes int64
 	for _, num := range candidates {
-		if err := store.compactSegment(num); err != nil {
+		segStart := time.Now()
+		stats, err := store.compactSegment(num)
+		if err != nil {
 			return fmt.Errorf("compact segment %d: %w", num, err)
 		}
+		totalExtents += stats.extents
+		totalBytes += stats.bytes
+		slog.Info("compacted segment",
+			"segNum", num,
+			"extents", stats.extents,
+			"bytes", stats.bytes,
+			"duration", time.Since(segStart))
 	}
 
-	if len(candidates) > 0 {
-		slog.Info("compaction cycle complete", "segments", len(candidates))
-	}
+	slog.Info("compaction finished",
+		"segments", len(candidates),
+		"extents", totalExtents,
+		"bytes", totalBytes,
+		"duration", time.Since(start))
 	return nil
 }
 
@@ -128,14 +146,22 @@ func (store *Store) candidateSegments() ([]uint64, error) {
 	return candidates, nil
 }
 
+// segmentStats summarises the live data relocated out of one drained segment.
+type segmentStats struct {
+	extents int
+	bytes   int64
+}
+
 // compactSegment relocates every live extent the segment holds into the active
 // append segment, then drops the drained segment and clears its tombstones. An
 // extent enumerated from .idx is live only if the index still points at this
 // exact slot; anything deleted or superseded is skipped.
-func (store *Store) compactSegment(num uint64) error {
+func (store *Store) compactSegment(num uint64) (segmentStats, error) {
+	var stats segmentStats
+
 	entries, err := scanIdx(store.dir, num)
 	if err != nil {
-		return fmt.Errorf("scan idx %d: %w", num, err)
+		return stats, fmt.Errorf("scan idx %d: %w", num, err)
 	}
 
 	for _, e := range entries {
@@ -145,28 +171,30 @@ func (store *Store) compactSegment(num uint64) error {
 			continue
 		}
 		if err != nil {
-			return fmt.Errorf("get extent: %w", err)
+			return stats, fmt.Errorf("get extent: %w", err)
 		}
 		cur, err := decodeExtent(raw)
 		if err != nil {
-			return fmt.Errorf("decode extent: %w", err)
+			return stats, fmt.Errorf("decode extent: %w", err)
 		}
 		if cur.SegNum != num || cur.Off != e.Off {
 			continue
 		}
 		if err := store.relocateExtent(key, cur); err != nil {
-			return fmt.Errorf("relocate extent: %w", err)
+			return stats, fmt.Errorf("relocate extent: %w", err)
 		}
+		stats.extents++
+		stats.bytes += cur.PSize
 	}
 
 	store.mutex.Lock()
 	err = store.dropSegment(num)
 	store.mutex.Unlock()
 	if err != nil {
-		return fmt.Errorf("drop segment %d: %w", num, err)
+		return stats, fmt.Errorf("drop segment %d: %w", num, err)
 	}
 
-	return store.deleteTombstones(num)
+	return stats, store.deleteTombstones(num)
 }
 
 // relocateExtent copies an extent's raw fragment bytes verbatim into a freshly

--- a/store/compaction_internal_test.go
+++ b/store/compaction_internal_test.go
@@ -1,0 +1,248 @@
+package store
+
+import (
+	"bytes"
+	"crypto/cipher"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mulgadc/predastore/pkg/masterkey"
+)
+
+func testAEAD(t *testing.T) cipher.AEAD {
+	t.Helper()
+	aead, err := masterkey.NewAEAD(bytes.Repeat([]byte{0x42}, 32))
+	if err != nil {
+		t.Fatalf("aead: %v", err)
+	}
+	return aead
+}
+
+func openTestStore(t *testing.T, opts ...Option) (*Store, string) {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := Open(dir, append(opts, WithAEAD(testAEAD(t)))...)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st, dir
+}
+
+func putShard(t *testing.T, st *Store, oh [32]byte, idx uint32, body []byte) {
+	t.Helper()
+	w, err := st.Append(oh, idx, int64(len(body)))
+	if err != nil {
+		t.Fatalf("append (%x,%d): %v", oh[0], idx, err)
+	}
+	if _, err := w.Write(body); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+}
+
+func readShard(t *testing.T, st *Store, oh [32]byte, idx uint32) []byte {
+	t.Helper()
+	r, err := st.Lookup(oh, idx)
+	if err != nil {
+		t.Fatalf("lookup (%x,%d): %v", oh[0], idx, err)
+	}
+	defer r.Close()
+	body, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return body
+}
+
+func extentOf(t *testing.T, st *Store, oh [32]byte, idx uint32) extent {
+	t.Helper()
+	raw, err := st.index.Get(MakeShardKey(oh, idx))
+	if err != nil {
+		t.Fatalf("index get: %v", err)
+	}
+	ext, err := decodeExtent(raw)
+	if err != nil {
+		t.Fatalf("decode extent: %v", err)
+	}
+	return ext
+}
+
+// fragNumsAt reads the fragNum header field of every fragment in an extent
+// straight off disk, bypassing the store so the test sees raw on-disk bytes.
+func fragNumsAt(t *testing.T, dir string, ext extent) []uint64 {
+	t.Helper()
+	f, err := os.Open(filepath.Join(dir, fmt.Sprintf(segFilename, ext.SegNum)))
+	if err != nil {
+		t.Fatalf("open seg: %v", err)
+	}
+	defer f.Close()
+
+	count := ext.PSize / totalFragSize
+	nums := make([]uint64, 0, count)
+	hdr := make([]byte, fragHeaderSize)
+	for i := range count {
+		if _, err := f.ReadAt(hdr, ext.Off+i*totalFragSize); err != nil {
+			t.Fatalf("read header: %v", err)
+		}
+		nums = append(nums, binary.BigEndian.Uint64(hdr[0:8]))
+	}
+	return nums
+}
+
+// Three ~12 KiB shards under a 40 KiB cap pack two into segment 0 and roll the
+// third into segment 1; deleting one of segment 0's shards drops its live
+// fraction below threshold, making it the sole compaction candidate.
+func segment0LayoutStore(t *testing.T) (st *Store, dir string, oh [32]byte) {
+	st, dir = openTestStore(t, WithMaxSegSize(40*KiB))
+	oh = [32]byte{0x42}
+	body := bytes.Repeat([]byte{0xcd}, 12*KiB)
+	putShard(t, st, oh, 0, body)
+	putShard(t, st, oh, 1, body)
+	putShard(t, st, oh, 2, body)
+	return st, dir, oh
+}
+
+func TestCompactionPreservesFragNum(t *testing.T) {
+	st, dir, oh := segment0LayoutStore(t)
+
+	before := extentOf(t, st, oh, 1)
+	if before.SegNum != 0 {
+		t.Fatalf("expected shard 1 in segment 0, got %d", before.SegNum)
+	}
+	wantFragNums := fragNumsAt(t, dir, before)
+	wantBody := readShard(t, st, oh, 1)
+
+	if err := st.Delete(oh, 0); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if err := st.compactOnce(); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+
+	after := extentOf(t, st, oh, 1)
+	if after.SegNum == before.SegNum && after.Off == before.Off {
+		t.Fatalf("shard 1 was not relocated; still at seg %d off %d", after.SegNum, after.Off)
+	}
+
+	gotFragNums := fragNumsAt(t, dir, after)
+	if len(gotFragNums) != len(wantFragNums) {
+		t.Fatalf("fragNum count changed: got %d want %d", len(gotFragNums), len(wantFragNums))
+	}
+	for i := range wantFragNums {
+		if gotFragNums[i] != wantFragNums[i] {
+			t.Fatalf("fragNum[%d] changed: got %d want %d", i, gotFragNums[i], wantFragNums[i])
+		}
+	}
+
+	if got := readShard(t, st, oh, 1); !bytes.Equal(got, wantBody) {
+		t.Fatalf("body changed after relocation")
+	}
+}
+
+func TestCompactionFragNumsGloballyUnique(t *testing.T) {
+	st, dir, oh := segment0LayoutStore(t)
+	if err := st.Delete(oh, 0); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if err := st.compactOnce(); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+
+	seen := map[uint64]bool{}
+	for _, idx := range []uint32{1, 2} {
+		for _, n := range fragNumsAt(t, dir, extentOf(t, st, oh, idx)) {
+			if seen[n] {
+				t.Fatalf("duplicate fragNum %d after compaction", n)
+			}
+			seen[n] = true
+		}
+	}
+}
+
+func TestCandidateSelectionAllDeadSegmentIsCandidate(t *testing.T) {
+	st, _, oh := segment0LayoutStore(t)
+	if err := st.Delete(oh, 0); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	cands, err := st.candidateSegments()
+	if err != nil {
+		t.Fatalf("candidates: %v", err)
+	}
+	if len(cands) != 1 || cands[0] != 0 {
+		t.Fatalf("expected segment 0 as sole candidate, got %v", cands)
+	}
+}
+
+func TestCandidateSelectionAllLiveNoCandidates(t *testing.T) {
+	st, _, _ := segment0LayoutStore(t)
+	cands, err := st.candidateSegments()
+	if err != nil {
+		t.Fatalf("candidates: %v", err)
+	}
+	if len(cands) != 0 {
+		t.Fatalf("no deletes, expected no candidates, got %v", cands)
+	}
+}
+
+func TestCandidateSelectionNeverSelectsActiveSegment(t *testing.T) {
+	st, _ := openTestStore(t, WithMaxSegSize(64*KiB))
+	oh := [32]byte{0x7}
+	putShard(t, st, oh, 0, bytes.Repeat([]byte{0x1}, 4*KiB))
+	if err := st.Delete(oh, 0); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	cands, err := st.candidateSegments()
+	if err != nil {
+		t.Fatalf("candidates: %v", err)
+	}
+	for _, c := range cands {
+		if c == st.segNum {
+			t.Fatalf("active segment %d selected as candidate", st.segNum)
+		}
+	}
+}
+
+// Every index-committed extent must already be enumerable from its segment's
+// .idx, or a drop could lose a live extent. Assert the back-check slot for each
+// live shard appears in scanIdx of its segment.
+func TestIdxCoversEveryCommittedExtent(t *testing.T) {
+	st, dir := openTestStore(t, WithMaxSegSize(40*KiB))
+	oh := [32]byte{0x55}
+	bodies := map[uint32][]byte{
+		0: bytes.Repeat([]byte{0xa}, 1),
+		1: bytes.Repeat([]byte{0xb}, 12*KiB),
+		2: bytes.Repeat([]byte{0xc}, 20*KiB),
+		3: bytes.Repeat([]byte{0xd}, 5*KiB),
+	}
+	for idx, body := range bodies {
+		putShard(t, st, oh, idx, body)
+	}
+
+	for idx := range bodies {
+		ext := extentOf(t, st, oh, idx)
+		entries, err := scanIdx(dir, ext.SegNum)
+		if err != nil {
+			t.Fatalf("scan idx %d: %v", ext.SegNum, err)
+		}
+		wantKey := [36]byte(MakeShardKey(oh, idx))
+		found := false
+		for _, e := range entries {
+			if e.Off == ext.Off && e.Key == wantKey {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("committed shard %d (seg %d off %d) missing from .idx", idx, ext.SegNum, ext.Off)
+		}
+	}
+}

--- a/store/compaction_internal_test.go
+++ b/store/compaction_internal_test.go
@@ -119,7 +119,7 @@ func TestCompactionPreservesFragNum(t *testing.T) {
 	wantFragNums := fragNumsAt(t, dir, before)
 	wantBody := readShard(t, st, oh, 1)
 
-	if err := st.Delete(oh, 0); err != nil {
+	if _, err := st.Delete(oh, 0); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 	if err := st.compactOnce(); err != nil {
@@ -148,7 +148,7 @@ func TestCompactionPreservesFragNum(t *testing.T) {
 
 func TestCompactionFragNumsGloballyUnique(t *testing.T) {
 	st, dir, oh := segment0LayoutStore(t)
-	if err := st.Delete(oh, 0); err != nil {
+	if _, err := st.Delete(oh, 0); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 	if err := st.compactOnce(); err != nil {
@@ -168,7 +168,7 @@ func TestCompactionFragNumsGloballyUnique(t *testing.T) {
 
 func TestCandidateSelectionAllDeadSegmentIsCandidate(t *testing.T) {
 	st, _, oh := segment0LayoutStore(t)
-	if err := st.Delete(oh, 0); err != nil {
+	if _, err := st.Delete(oh, 0); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 
@@ -196,7 +196,7 @@ func TestCandidateSelectionNeverSelectsActiveSegment(t *testing.T) {
 	st, _ := openTestStore(t, WithMaxSegSize(64*KiB))
 	oh := [32]byte{0x7}
 	putShard(t, st, oh, 0, bytes.Repeat([]byte{0x1}, 4*KiB))
-	if err := st.Delete(oh, 0); err != nil {
+	if _, err := st.Delete(oh, 0); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 

--- a/store/compaction_test.go
+++ b/store/compaction_test.go
@@ -154,7 +154,7 @@ func TestConcurrentOverwriteDuringCompaction(t *testing.T) {
 }
 
 func TestCompactorLifecycleStartsAndStops(t *testing.T) {
-	st, _ := openStore(t, store.WithCompaction())
+	st, _ := openStore(t, store.WithCompaction(time.Hour))
 
 	done := make(chan error, 1)
 	go func() { done <- st.Close() }()

--- a/store/compaction_test.go
+++ b/store/compaction_test.go
@@ -82,7 +82,7 @@ func TestCompactionDropsDrainedSegmentAndShrinks(t *testing.T) {
 	}
 
 	before := dirBytes(t, dir)
-	if err := st.Delete(oh, 0); err != nil {
+	if _, err := st.Delete(oh, 0); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 	if err := st.CompactOnce(); err != nil {
@@ -122,7 +122,7 @@ func TestConcurrentOverwriteDuringCompaction(t *testing.T) {
 	write(t, st, oh, 1, filler) // segment 0
 	write(t, st, oh, 2, filler) // rolls; segment 0 now drainable once a shard dies
 
-	if err := st.Delete(oh, 0); err != nil {
+	if _, err := st.Delete(oh, 0); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 
@@ -201,7 +201,7 @@ func TestCompactionFaultLeavesLiveDataReadable(t *testing.T) {
 	write(t, st, oh, 0, body)
 	write(t, st, oh, 1, body)
 	write(t, st, oh, 2, body)
-	if err := st.Delete(oh, 0); err != nil {
+	if _, err := st.Delete(oh, 0); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 

--- a/store/compaction_test.go
+++ b/store/compaction_test.go
@@ -1,0 +1,246 @@
+package store_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore/internal/storetest"
+	"github.com/mulgadc/predastore/store"
+)
+
+func readAll(t *testing.T, st *store.Store, oh [32]byte, idx uint32) ([]byte, error) {
+	t.Helper()
+	r, err := st.Lookup(oh, idx)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return io.ReadAll(r)
+}
+
+func openStore(t *testing.T, opts ...store.Option) (*store.Store, string) {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := store.Open(dir, append(opts, store.WithAEAD(storetest.TestAEAD()))...)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	return st, dir
+}
+
+func write(t *testing.T, st *store.Store, oh [32]byte, idx uint32, body []byte) {
+	t.Helper()
+	w, err := st.Append(oh, idx, int64(len(body)))
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if _, err := w.Write(body); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+}
+
+func dirBytes(t *testing.T, dir string) int64 {
+	t.Helper()
+	var total int64
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		info, err := e.Info()
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		total += info.Size()
+	}
+	return total
+}
+
+func TestCompactionDropsDrainedSegmentAndShrinks(t *testing.T) {
+	st, dir := openStore(t, store.WithMaxSegSize(20*store.KiB))
+	defer st.Close()
+
+	oh := [32]byte{0x1}
+	body := bytes.Repeat([]byte{0xaa}, 12*store.KiB) // one ~12 KiB shard fills a 20 KiB segment
+	write(t, st, oh, 0, body)                        // segment 0
+	write(t, st, oh, 1, body)                        // rolls to segment 1
+	write(t, st, oh, 2, body)                        // rolls to segment 2 (active)
+
+	seg0 := filepath.Join(dir, fmt.Sprintf("%016d.seg", 0))
+	idx0 := filepath.Join(dir, fmt.Sprintf("%016d.idx", 0))
+	if _, err := os.Stat(seg0); err != nil {
+		t.Fatalf("segment 0 should exist: %v", err)
+	}
+
+	before := dirBytes(t, dir)
+	if err := st.Delete(oh, 0); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if err := st.CompactOnce(); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+
+	if _, err := os.Stat(seg0); !os.IsNotExist(err) {
+		t.Errorf("segment 0 .seg should be unlinked, stat err=%v", err)
+	}
+	if _, err := os.Stat(idx0); !os.IsNotExist(err) {
+		t.Errorf("segment 0 .idx should be unlinked, stat err=%v", err)
+	}
+	if after := dirBytes(t, dir); after >= before {
+		t.Errorf("on-disk bytes should shrink: before=%d after=%d", before, after)
+	}
+
+	for _, idx := range []uint32{1, 2} {
+		got, err := readAll(t, st, oh, idx)
+		if err != nil {
+			t.Fatalf("read surviving shard %d: %v", idx, err)
+		}
+		if !bytes.Equal(got, body) {
+			t.Errorf("surviving shard %d corrupted", idx)
+		}
+	}
+}
+
+// A relocation racing an overwrite must never resurrect the old bytes: the CAS
+// aborts when the slot moved, so the final read is always the newest write.
+func TestConcurrentOverwriteDuringCompaction(t *testing.T) {
+	st, _ := openStore(t, store.WithMaxSegSize(40*store.KiB))
+	defer st.Close()
+
+	oh := [32]byte{0x2}
+	filler := bytes.Repeat([]byte{0xbb}, 12*store.KiB)
+	write(t, st, oh, 0, filler) // segment 0
+	write(t, st, oh, 1, filler) // segment 0
+	write(t, st, oh, 2, filler) // rolls; segment 0 now drainable once a shard dies
+
+	if err := st.Delete(oh, 0); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	final := bytes.Repeat([]byte{0xff}, 16*store.KiB)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range 50 {
+			_ = st.CompactOnce()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 50 {
+			write(t, st, oh, 1, filler)
+		}
+		write(t, st, oh, 1, final)
+	}()
+	wg.Wait()
+
+	got, err := readAll(t, st, oh, 1)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, final) {
+		t.Fatalf("expected newest write, got stale bytes")
+	}
+}
+
+func TestCompactorLifecycleStartsAndStops(t *testing.T) {
+	st, _ := openStore(t, store.WithCompaction())
+
+	done := make(chan error, 1)
+	go func() { done <- st.Close() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("close: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not join the compactor goroutine")
+	}
+}
+
+func TestNoCompactorWithoutOption(t *testing.T) {
+	st, _ := openStore(t)
+	if err := st.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+// A fault mid-compaction must leave every live shard readable on reopen — the
+// drained segment is only dropped after all relocations commit, so an aborted
+// cycle loses nothing.
+func TestCompactionFaultLeavesLiveDataReadable(t *testing.T) {
+	var armed bool
+	restore := store.SetOpenFile(func(path string) (store.File, error) {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+		if err != nil {
+			return nil, err
+		}
+		return &flakyFile{File: f, armed: &armed}, nil
+	})
+	defer restore()
+
+	dir := t.TempDir()
+
+	oh := [32]byte{0x3}
+	body := bytes.Repeat([]byte{0xcc}, 12*store.KiB)
+
+	st, err := store.Open(dir, store.WithMaxSegSize(40*store.KiB), store.WithAEAD(storetest.TestAEAD()))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	write(t, st, oh, 0, body)
+	write(t, st, oh, 1, body)
+	write(t, st, oh, 2, body)
+	if err := st.Delete(oh, 0); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	armed = true
+	_ = st.CompactOnce() // expected to fail somewhere mid-cycle
+	armed = false
+	if err := st.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	st2, err := store.Open(dir, store.WithMaxSegSize(40*store.KiB), store.WithAEAD(storetest.TestAEAD()))
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer st2.Close()
+
+	for _, idx := range []uint32{1, 2} {
+		got, err := readAll(t, st2, oh, idx)
+		if err != nil {
+			t.Fatalf("live shard %d unreadable after interrupted compaction: %v", idx, err)
+		}
+		if !bytes.Equal(got, body) {
+			t.Fatalf("live shard %d corrupted after interrupted compaction", idx)
+		}
+	}
+}
+
+// flakyFile fails the first WriteAt issued while armed, simulating a crash
+// partway through a relocation copy.
+type flakyFile struct {
+	*os.File
+
+	armed *bool
+}
+
+func (f *flakyFile) WriteAt(p []byte, off int64) (int, error) {
+	if f.armed != nil && *f.armed {
+		*f.armed = false
+		return 0, fmt.Errorf("injected write fault")
+	}
+	return f.File.WriteAt(p, off)
+}

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -11,3 +11,7 @@ func SetOpenFile(f func(path string) (File, error)) (restore func()) {
 	openFile = f
 	return func() { openFile = prev }
 }
+
+// CompactOnce runs a single compaction cycle synchronously. The background
+// compactor is wired separately; tests drive cycles deterministically here.
+func (store *Store) CompactOnce() error { return store.compactOnce() }

--- a/store/prop_test.go
+++ b/store/prop_test.go
@@ -175,10 +175,13 @@ func (sm *baseSM) Delete(t *rapid.T) {
 	objectHash := [32]byte(key[:32])
 	shardIndex := binary.BigEndian.Uint32(key[32:])
 
-	refErr := sm.Ref.Delete(objectHash, shardIndex)
-	realErr := sm.Real.Delete(objectHash, shardIndex)
+	refDeleted, refErr := sm.Ref.Delete(objectHash, shardIndex)
+	realDeleted, realErr := sm.Real.Delete(objectHash, shardIndex)
 	if sm.Strict() && !errors.Is(realErr, refErr) {
 		t.Fatalf("delete: ref=%v real=%v", refErr, realErr)
+	}
+	if sm.Strict() && refErr == nil && refDeleted != realDeleted {
+		t.Fatalf("delete: ref deleted=%v real deleted=%v", refDeleted, realDeleted)
 	}
 }
 

--- a/store/prop_test.go
+++ b/store/prop_test.go
@@ -182,6 +182,20 @@ func (sm *baseSM) Delete(t *rapid.T) {
 	}
 }
 
+// Compact runs one compaction cycle on the real store. Compaction is invisible
+// to logical state, so the reference oracle is untouched; the post-action Check
+// then asserts every live shard still reads back byte-identical — the central
+// compaction-correctness invariant. Under relaxed mode a fault-injected error
+// is tolerated.
+func (sm *baseSM) Compact(t *rapid.T) {
+	if sm.Ref.IsClosed() {
+		return
+	}
+	if err := sm.Real.CompactOnce(); err != nil && sm.Strict() {
+		t.Fatalf("compact: %v", err)
+	}
+}
+
 // Check is the invariant: every key present in the reference must read back
 // identical bytes from the real store. Under relaxed mode (post-fault),
 // per-key divergence is tolerated.

--- a/store/segment.go
+++ b/store/segment.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -11,7 +12,78 @@ import (
 	"sync/atomic"
 )
 
-const segFilename = "%016d.seg"
+const (
+	segFilename    = "%016d.seg"
+	idxSegFilename = "%016d.idx"
+)
+
+// idxEntry is one row of a segment's reverse sidecar (.idx): the in-segment
+// offset of an allocated extent, the shard key it holds, and its physical size.
+// Append-only; one row written per allocation so compaction can enumerate a
+// segment's extents without a full index scan.
+const idxEntrySize = 52 // Off(8) ‖ Key(36) ‖ PSize(8)
+
+type idxEntry struct {
+	Off   int64
+	Key   [36]byte
+	PSize int64
+}
+
+func (e idxEntry) encode() []byte {
+	buf := make([]byte, idxEntrySize)
+	binary.BigEndian.PutUint64(buf[0:8], uint64(e.Off)) //nolint:gosec // round-trips bit-for-bit via int64 cast on decode.
+	copy(buf[8:44], e.Key[:])
+	binary.BigEndian.PutUint64(buf[44:52], uint64(e.PSize)) //nolint:gosec // round-trips bit-for-bit via int64 cast on decode.
+	return buf
+}
+
+func decodeIdxEntry(b []byte) (e idxEntry, err error) {
+	if len(b) != idxEntrySize {
+		return e, fmt.Errorf("idxEntry: invalid length %d, want %d", len(b), idxEntrySize)
+	}
+	e.Off = int64(binary.BigEndian.Uint64(b[0:8])) //nolint:gosec // round-trips bit-for-bit from encode.
+	copy(e.Key[:], b[8:44])
+	e.PSize = int64(binary.BigEndian.Uint64(b[44:52])) //nolint:gosec // round-trips bit-for-bit from encode.
+	return e, nil
+}
+
+// scanIdx sequentially reads a segment's whole .idx sidecar into memory. Used
+// by compaction to enumerate every extent ever allocated in the segment; the
+// returned rows are selection hints back-checked against the index authority.
+func scanIdx(dir string, segNum uint64) ([]idxEntry, error) {
+	f, err := openFile(filepath.Join(dir, fmt.Sprintf(idxSegFilename, segNum)))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			slog.Warn("failed to close idx", "segNum", segNum, "error", closeErr)
+		}
+	}()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	// A torn trailing record is a crash mid-append: since .idx is fsynced before
+	// the index commit, that extent never went live, so dropping the partial row
+	// is safe. Enumerate only whole records.
+	count := info.Size() / idxEntrySize
+	entries := make([]idxEntry, 0, count)
+	buf := make([]byte, idxEntrySize)
+	for i := range count {
+		if _, err := f.ReadAt(buf, i*idxEntrySize); err != nil {
+			return nil, err
+		}
+		e, err := decodeIdxEntry(buf)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, e)
+	}
+	return entries, nil
+}
 
 // magic identifies the encryption-at-rest segment format. There is no in-place
 // migration from older formats — openSegment rejects them so the operator is
@@ -75,7 +147,11 @@ var openFile = func(path string) (file, error) {
 // race with Wait. full caches the on-disk full flag so the hot Append path
 // avoids a ReadAt per call.
 type segment struct {
-	file
+	file // .seg
+
+	idx     file   // .idx sidecar
+	idxSize int64  // .idx append cursor, guarded by store.mutex
+	num     uint64 // for unlink paths on drop
 
 	refs sync.WaitGroup
 	full atomic.Bool
@@ -84,6 +160,45 @@ type segment struct {
 func (seg *segment) addRef()      { seg.refs.Add(1) }
 func (seg *segment) releaseRef()  { seg.refs.Done() }
 func (seg *segment) waitForRefs() { seg.refs.Wait() }
+
+// appendIdx writes one row at the .idx append cursor and advances it. Caller
+// holds store.mutex.
+func (seg *segment) appendIdx(e idxEntry) error {
+	if _, err := seg.idx.WriteAt(e.encode(), seg.idxSize); err != nil {
+		return err
+	}
+	seg.idxSize += idxEntrySize
+	return nil
+}
+
+func (seg *segment) syncIdx() error { return seg.idx.Sync() }
+
+// dropSegment removes a fully-drained segment: evict from segCache, drain refs,
+// close both fds, and unlink .seg + .idx. Caller holds store.mutex. Safe only
+// after every live extent the segment held has been CAS-committed elsewhere.
+func (store *Store) dropSegment(num uint64) error {
+	seg, ok := store.segCache[num]
+	if !ok {
+		return nil
+	}
+	delete(store.segCache, num)
+	seg.waitForRefs()
+
+	var errs []error
+	if err := seg.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("close segment %d: %w", num, err))
+	}
+	if err := seg.idx.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("close idx %d: %w", num, err))
+	}
+	if err := os.Remove(filepath.Join(store.dir, fmt.Sprintf(segFilename, num))); err != nil {
+		errs = append(errs, fmt.Errorf("unlink segment %d: %w", num, err))
+	}
+	if err := os.Remove(filepath.Join(store.dir, fmt.Sprintf(idxSegFilename, num))); err != nil {
+		errs = append(errs, fmt.Errorf("unlink idx %d: %w", num, err))
+	}
+	return errors.Join(errs...)
+}
 
 // getSegment returns a cached segment or opens it from disk. Callers must hold
 // store.mutex.
@@ -139,23 +254,35 @@ func openSegment(dir string, num uint64) (*segment, error) {
 		return nil, err
 	}
 
+	idxFile, err := openFile(filepath.Join(dir, fmt.Sprintf(idxSegFilename, num)))
+	if err != nil {
+		if closeErr := f.Close(); closeErr != nil {
+			slog.Warn("failed to close segment", "segNum", num, "error", closeErr)
+		}
+		return nil, err
+	}
+
 	defer func() {
 		if err != nil {
-			if closeErr := f.Close(); closeErr != nil {
-				slog.Warn("failed to close segment",
-					"segNum", num,
-					"error", closeErr,
-				)
+			for name, c := range map[string]file{"segment": f, "idx": idxFile} {
+				if closeErr := c.Close(); closeErr != nil {
+					slog.Warn("failed to close "+name, "segNum", num, "error", closeErr)
+				}
 			}
 		}
 	}()
+
+	idxInfo, err := idxFile.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat idx %d: %w", num, err)
+	}
 
 	info, err := f.Stat()
 	if err != nil {
 		return nil, err
 	}
 
-	seg := &segment{file: f}
+	seg := &segment{file: f, idx: idxFile, idxSize: idxInfo.Size(), num: num}
 
 	switch {
 	// New file: write the segment header.

--- a/store/store.go
+++ b/store/store.go
@@ -15,6 +15,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/dgraph-io/badger/v4"
 	"github.com/mulgadc/predastore/s3db"
@@ -61,8 +62,9 @@ type Store struct {
 
 	maxSegSize uint64
 
-	compactionEnabled bool
-	compactor         *compactor
+	compactionEnabled  bool
+	compactionInterval time.Duration
+	compactor          *compactor
 
 	closed bool
 }
@@ -99,11 +101,15 @@ func WithMaxSegSize(n uint64) Option {
 	}
 }
 
-// WithCompaction starts a background compactor that reclaims dead space on an
-// interval. Without it, no compaction goroutine runs.
-func WithCompaction() Option {
+// WithCompaction starts a background compactor that reclaims dead space on the
+// given interval. A non-positive interval falls back to
+// defaultCompactionInterval. Without this option, no compaction goroutine runs.
+func WithCompaction(interval time.Duration) Option {
 	return func(s *Store) error {
 		s.compactionEnabled = true
+		if interval > 0 {
+			s.compactionInterval = interval
+		}
 		return nil
 	}
 }
@@ -137,9 +143,10 @@ func WithAEAD(aead cipher.AEAD) Option {
 // WithAEAD is mandatory — Open errors if no cipher was supplied.
 func Open(dir string, opts ...Option) (store *Store, err error) {
 	store = &Store{
-		dir:        dir,
-		segCache:   make(map[uint64]*segment),
-		maxSegSize: DefaultMaxSegSize,
+		dir:                dir,
+		segCache:           make(map[uint64]*segment),
+		maxSegSize:         DefaultMaxSegSize,
+		compactionInterval: defaultCompactionInterval,
 	}
 
 	for _, opt := range opts {

--- a/store/store.go
+++ b/store/store.go
@@ -410,16 +410,20 @@ func (store *Store) casExtent(key []byte, old, next extent) (committed bool, err
 // selector, then delete the live key. Tombstone and deletion commit together,
 // so the dead-space hint can never outlive or precede the deletion it records.
 // The on-disk extent becomes dead space reclaimable by the compactor.
-func (store *Store) Delete(objectHash [32]byte, shardIndex uint32) error {
+// Delete tombstones the extent for the given shard and removes its index entry.
+// The bool reports whether an extent existed and was removed; a missing shard is
+// not an error and returns (false, nil), keeping deletes idempotent.
+func (store *Store) Delete(objectHash [32]byte, shardIndex uint32) (bool, error) {
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
 
 	if store.closed {
-		return ErrClosedStore
+		return false, ErrClosedStore
 	}
 
 	key := MakeShardKey(objectHash, shardIndex)
-	return store.index.Badger.Update(func(txn *badger.Txn) error {
+	deleted := false
+	err := store.index.Badger.Update(func(txn *badger.Txn) error {
 		item, err := txn.Get(key)
 		if errors.Is(err, badger.ErrKeyNotFound) {
 			return nil
@@ -440,8 +444,16 @@ func (store *Store) Delete(objectHash [32]byte, shardIndex uint32) error {
 		if err := txn.Set(tombstoneKey(ext.SegNum, ext.Off), tombstoneValue(ext.PSize)); err != nil {
 			return fmt.Errorf("delete: put tombstone: %w", err)
 		}
-		return txn.Delete(key)
+		if err := txn.Delete(key); err != nil {
+			return err
+		}
+		deleted = true
+		return nil
 	})
+	if err != nil {
+		return false, err
+	}
+	return deleted, nil
 }
 
 // Close blocks until all outstanding segment references drain, then closes

--- a/store/store.go
+++ b/store/store.go
@@ -6,6 +6,7 @@
 package store
 
 import (
+	"bytes"
 	"crypto/cipher"
 	"encoding/binary"
 	"errors"
@@ -60,6 +61,9 @@ type Store struct {
 
 	maxSegSize uint64
 
+	compactionEnabled bool
+	compactor         *compactor
+
 	closed bool
 }
 
@@ -91,6 +95,15 @@ type Option func(*Store) error
 func WithMaxSegSize(n uint64) Option {
 	return func(s *Store) error {
 		s.maxSegSize = n
+		return nil
+	}
+}
+
+// WithCompaction starts a background compactor that reclaims dead space on an
+// interval. Without it, no compaction goroutine runs.
+func WithCompaction() Option {
+	return func(s *Store) error {
+		s.compactionEnabled = true
 		return nil
 	}
 }
@@ -159,6 +172,10 @@ func Open(dir string, opts ...Option) (store *Store, err error) {
 
 	if _, err := store.nextAvailableSegment(); err != nil {
 		return nil, err
+	}
+
+	if store.compactionEnabled {
+		store.startCompactor()
 	}
 
 	slog.Info("store opened",
@@ -263,6 +280,12 @@ func (store *Store) Append(objectHash [32]byte, shardIndex uint32, size int64) (
 		LSize:  size,
 	}
 
+	key := MakeShardKey(objectHash, shardIndex)
+	if err := seg.appendIdx(idxEntry{Off: off, Key: [36]byte(key), PSize: ext.PSize}); err != nil {
+		seg.releaseRef()
+		return nil, fmt.Errorf("append idx: %w", err)
+	}
+
 	w := &writer{
 		store:      store,
 		objectHash: objectHash,
@@ -345,8 +368,48 @@ func (store *Store) commitExtent(objectHash [32]byte, shardIndex uint32, ext ext
 	return nil
 }
 
-// Delete removes the index entry for a shard. The on-disk extent becomes dead
-// space reclaimable by a future compactor.
+// errStaleSlot signals that a compare-and-swap found the key no longer pointing
+// at the expected extent — a concurrent overwrite or delete won the race.
+var errStaleSlot = errors.New("extent slot moved")
+
+// casExtent commits new only if key still encodes old, in a single index
+// transaction; it retries on badger write conflicts. committed is false (with a
+// nil error) when the slot moved out from under us or the key was deleted — the
+// caller treats the just-copied bytes as harmless dead space.
+func (store *Store) casExtent(key []byte, old, next extent) (committed bool, err error) {
+	for {
+		err = store.index.Badger.Update(func(txn *badger.Txn) error {
+			item, err := txn.Get(key)
+			if err != nil {
+				return err
+			}
+			cur, err := item.ValueCopy(nil)
+			if err != nil {
+				return err
+			}
+			if !bytes.Equal(cur, old.encode()) {
+				return errStaleSlot
+			}
+			return txn.Set(key, next.encode())
+		})
+
+		switch {
+		case errors.Is(err, badger.ErrConflict):
+			continue
+		case errors.Is(err, errStaleSlot), errors.Is(err, badger.ErrKeyNotFound):
+			return false, nil
+		case err != nil:
+			return false, err
+		}
+		return true, nil
+	}
+}
+
+// Delete removes the index entry for a shard in a single index transaction:
+// read the current extent, write a slot-keyed tombstone for compaction's
+// selector, then delete the live key. Tombstone and deletion commit together,
+// so the dead-space hint can never outlive or precede the deletion it records.
+// The on-disk extent becomes dead space reclaimable by the compactor.
 func (store *Store) Delete(objectHash [32]byte, shardIndex uint32) error {
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
@@ -356,24 +419,52 @@ func (store *Store) Delete(objectHash [32]byte, shardIndex uint32) error {
 	}
 
 	key := MakeShardKey(objectHash, shardIndex)
-	if err := store.index.Delete(key); err != nil {
-		return fmt.Errorf("delete: %w", err)
-	}
+	return store.index.Badger.Update(func(txn *badger.Txn) error {
+		item, err := txn.Get(key)
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("delete: read extent: %w", err)
+		}
 
-	return nil
+		raw, err := item.ValueCopy(nil)
+		if err != nil {
+			return fmt.Errorf("delete: copy extent: %w", err)
+		}
+		ext, err := decodeExtent(raw)
+		if err != nil {
+			return fmt.Errorf("delete: decode extent: %w", err)
+		}
+
+		if err := txn.Set(tombstoneKey(ext.SegNum, ext.Off), tombstoneValue(ext.PSize)); err != nil {
+			return fmt.Errorf("delete: put tombstone: %w", err)
+		}
+		return txn.Delete(key)
+	})
 }
 
 // Close blocks until all outstanding segment references drain, then closes
 // segment file descriptors and the index. Must be called exactly once.
 func (store *Store) Close() error {
 	store.mutex.Lock()
-	defer store.mutex.Unlock()
-
 	if store.closed {
+		store.mutex.Unlock()
 		return ErrClosedStore
 	}
-
 	store.closed = true
+	c := store.compactor
+	store.mutex.Unlock()
+
+	// Stop the compactor without holding the mutex: an in-flight cycle takes
+	// store.mutex, so joining under the lock would deadlock. closed is already
+	// set, so no new public mutation slips in behind the join.
+	if c != nil {
+		c.stop()
+	}
+
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
 
 	var errs []error
 
@@ -394,6 +485,33 @@ func (store *Store) Close() error {
 	}
 
 	return errors.Join(errs...)
+}
+
+// Slot-keyed tombstones live in the index under the tombstonePrefix namespace:
+// Delete writes d ‖ BE(segNum) ‖ BE(off) → BE(PSize) for the extent it removes.
+// They are a candidate-selection accelerator for compaction only — never
+// consulted for correctness. Keyed by physical slot so the same object key
+// dying more than once stays unique.
+const tombstonePrefix = 'd'
+
+const tombstoneKeySize = 17 // prefix(1) ‖ segNum(8) ‖ off(8)
+
+func tombstoneKey(segNum uint64, off int64) []byte {
+	key := make([]byte, tombstoneKeySize)
+	key[0] = tombstonePrefix
+	binary.BigEndian.PutUint64(key[1:9], segNum)
+	binary.BigEndian.PutUint64(key[9:17], uint64(off)) //nolint:gosec // round-trips bit-for-bit via int64 cast on decode.
+	return key
+}
+
+func tombstoneSegNum(key []byte) uint64 {
+	return binary.BigEndian.Uint64(key[1:9])
+}
+
+func tombstoneValue(psize int64) []byte {
+	v := make([]byte, 8)
+	binary.BigEndian.PutUint64(v, uint64(psize)) //nolint:gosec // PSize is a non-negative on-disk byte count.
+	return v
 }
 
 // MakeShardKey builds a 36-byte index key: 32-byte object hash || 4-byte big-endian shard index.

--- a/store/writer.go
+++ b/store/writer.go
@@ -130,6 +130,13 @@ func (w *writer) Close() (err error) {
 		return fmt.Errorf("sync segment %d: %w", w.ext.SegNum, err)
 	}
 
+	// The .idx row must be durable before the index commit: it is compaction's
+	// only enumeration source, so every index-committed extent must already be
+	// findable in .idx or a drop could lose a live extent.
+	if err = w.seg.syncIdx(); err != nil {
+		return fmt.Errorf("sync idx %d: %w", w.ext.SegNum, err)
+	}
+
 	return w.store.commitExtent(w.objectHash, w.shardIndex, w.ext)
 }
 


### PR DESCRIPTION
## Summary

Reclaims dead space from segment files whose extents have been deleted, so on-disk usage shrinks instead of growing unboundedly. A deliberate stop-gap ahead of a larger redesign; accepts that not every byte is reclaimed.

A background compactor relocates live extents **verbatim** into the active append segment and drops the drained segment. Verbatim byte copy preserves each fragment's `fragNum`, so the GCM nonce (`fragNum || storeID`) is never reused — no re-seal, no re-encrypt. The badger index is the sole liveness authority; a per-segment `.idx` sidecar and slot-keyed tombstones are derived selection hints, never trusted for correctness.

Enabled via `WithCompaction()`; the goroutine is stopped and joined in `Close` before segments and the index are drained.

## Recoverability (no WAL)

Two orderings make an interrupted compaction safe on restart:
- `.idx` durable before the index commit — every live extent is enumerable, so a drop never loses one.
- All compare-and-swap commits precede the drop — nothing in the index references a segment when it is dropped.

A crash leaves orphaned bytes as reclaimable dead space, never lost or resurrected data.

## Changes

- `segment.go` — `.idx` sidecar lifecycle, `idxEntry` codec, `scanIdx`, `dropSegment`.
- `store.go` — tombstone codec, single-txn `Delete`, `casExtent`, `WithCompaction`, Open/Close wiring.
- `writer.go` — `.idx` fsync before index commit.
- `compaction.go` — selection, relocate→CAS→drop engine, background compactor goroutine.

## Testing

`make preflight` green (tests, `-race`, vet, lint, vulncheck, coverage).

- `Compact` action added to the shared property-based state machine, exercised by both the conformance and fault-injection suites; the byte-identical readback `Check` is the central correctness invariant.
- `fragNum` preservation + global uniqueness verified directly by scanning on-disk fragment headers after relocation.
- Selection-threshold boundaries, `.idx` covers every committed extent, segment shrink + unlink, concurrent overwrite-vs-migrate (`-race`), interrupted-compaction recovery on reopen, and compactor lifecycle.

## Limitations

Dead space from in-place overwrites is invisible to tombstone-based selection and is not reclaimed this pass — accepted for the stop-gap.