### PR TITLE
feat: honour inline role policies in S3 assumed-role authz

### DIFF
--- a/s3/auth.go
+++ b/s3/auth.go
@@ -80,9 +80,10 @@ type iamUser struct {
 // trust policy (who may assume the role), not a permission policy, so it is
 // deliberately omitted here.
 type iamRole struct {
-	RoleName         string   `json:"role_name"`
-	AccountID        string   `json:"account_id"`
-	AttachedPolicies []string `json:"attached_policies"` // managed policy ARNs
+	RoleName         string            `json:"role_name"`
+	AccountID        string            `json:"account_id"`
+	AttachedPolicies []string          `json:"attached_policies"` // managed policy ARNs
+	InlinePolicies   map[string]string `json:"inline_policies"`   // policyName → document JSON
 }
 
 // iamPolicy mirrors the spinifex IAM Policy stored in NATS KV.
@@ -646,9 +647,8 @@ func (p *NATSIAMProvider) resolveUserPolicies(accountID, userName string) ([]iam
 }
 
 // resolveRolePolicies resolves an assumed-role session's permissions: load the
-// role record from rolesBucket and resolve its attached managed policies. It
-// mirrors resolveUserPolicies — spinifex roles only ever carry managed policies
-// (no inline role policies exist), so the per-policy resolution is identical.
+// role record from rolesBucket and resolve its attached managed policies plus
+// any embedded inline policies.
 func (p *NATSIAMProvider) resolveRolePolicies(accountID, roleName string) ([]iamPolicyDocument, error) {
 	kvKey := accountID + "." + roleName
 	entry, err := p.rolesBucket.Get(kvKey)
@@ -661,7 +661,18 @@ func (p *NATSIAMProvider) resolveRolePolicies(accountID, roleName string) ([]iam
 		return nil, fmt.Errorf("unmarshal role: %w", err)
 	}
 
-	return p.resolveManagedPolicies(accountID, role.AttachedPolicies)
+	docs, err := p.resolveManagedPolicies(accountID, role.AttachedPolicies)
+	if err != nil {
+		return nil, err
+	}
+	for name, raw := range role.InlinePolicies {
+		var doc iamPolicyDocument
+		if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+			return nil, fmt.Errorf("parse inline policy %s: %w", name, err)
+		}
+		docs = append(docs, doc)
+	}
+	return docs, nil
 }
 
 // resolveManagedPolicies resolves a list of managed-policy ARNs into parsed

--- a/s3/auth.go
+++ b/s3/auth.go
@@ -676,8 +676,8 @@ func (p *NATSIAMProvider) resolveRolePolicies(accountID, roleName string) ([]iam
 }
 
 // resolveManagedPolicies resolves a list of managed-policy ARNs into parsed
-// policy documents from policiesBucket. Shared by the user and role resolvers:
-// both attach only managed policies, so the per-ARN resolution is identical.
+// policy documents from policiesBucket. Shared by the user and role resolvers;
+// the role resolver appends its inline-policy walk separately.
 func (p *NATSIAMProvider) resolveManagedPolicies(accountID string, arns []string) ([]iamPolicyDocument, error) {
 	var docs []iamPolicyDocument
 	for _, arn := range arns {

--- a/s3/auth_test.go
+++ b/s3/auth_test.go
@@ -254,3 +254,76 @@ func TestNewNATSIAMProvider_MissingMasterKeyPath(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "master_key_path is required")
 }
+
+// --- inline role policy resolution (resolveRolePolicies) ---
+
+const inlineTestAccount = "000000000001"
+
+// TestResolveRolePolicies_InlineAllow proves an inline Allow policy embedded in a
+// role resolves and authorizes on the S3 data path, with no managed attachment.
+func TestResolveRolePolicies_InlineAllow(t *testing.T) {
+	roles := map[string][]byte{
+		inlineTestAccount + ".InlineRole": mustMarshal(t, iamRole{
+			RoleName:       "InlineRole",
+			AccountID:      inlineTestAccount,
+			InlinePolicies: map[string]string{"AllowS3": allowAllS3Policy},
+		}),
+	}
+	p := &NATSIAMProvider{
+		rolesBucket:    &fakeKV{data: roles},
+		policiesBucket: &fakeKV{data: map[string][]byte{}},
+	}
+
+	docs, err := p.resolveRolePolicies(inlineTestAccount, "InlineRole")
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	assert.True(t, evaluateS3Access("s3:ListBucket", "arn:aws:s3:::any", docs), "inline Allow must be honoured")
+}
+
+// TestResolveRolePolicies_InlineDenyOverridesManagedAllow proves inline and
+// managed documents are evaluated together: an inline Deny overrides a managed
+// Allow, the standard IAM deny-wins outcome.
+func TestResolveRolePolicies_InlineDenyOverridesManagedAllow(t *testing.T) {
+	roles := map[string][]byte{
+		inlineTestAccount + ".DenyRole": mustMarshal(t, iamRole{
+			RoleName:         "DenyRole",
+			AccountID:        inlineTestAccount,
+			AttachedPolicies: []string{"arn:aws:iam::" + inlineTestAccount + ":policy/AllowAll"},
+			InlinePolicies:   map[string]string{"DenyS3": denyAllS3Policy},
+		}),
+	}
+	policies := map[string][]byte{
+		inlineTestAccount + ".AllowAll": mustMarshal(t, iamPolicy{
+			PolicyName:     "AllowAll",
+			PolicyDocument: allowAllS3Policy,
+		}),
+	}
+	p := &NATSIAMProvider{
+		rolesBucket:    &fakeKV{data: roles},
+		policiesBucket: &fakeKV{data: policies},
+	}
+
+	docs, err := p.resolveRolePolicies(inlineTestAccount, "DenyRole")
+	require.NoError(t, err)
+	require.Len(t, docs, 2, "managed Allow and inline Deny must both resolve")
+	assert.False(t, evaluateS3Access("s3:ListBucket", "arn:aws:s3:::any", docs), "inline Deny must override managed Allow")
+}
+
+// TestResolveRolePolicies_InlineMalformed proves a corrupt inline document fails
+// closed rather than silently resolving to a partial set.
+func TestResolveRolePolicies_InlineMalformed(t *testing.T) {
+	roles := map[string][]byte{
+		inlineTestAccount + ".BadRole": mustMarshal(t, iamRole{
+			RoleName:       "BadRole",
+			AccountID:      inlineTestAccount,
+			InlinePolicies: map[string]string{"Broken": "{not json"},
+		}),
+	}
+	p := &NATSIAMProvider{
+		rolesBucket:    &fakeKV{data: roles},
+		policiesBucket: &fakeKV{data: map[string][]byte{}},
+	}
+
+	_, err := p.resolveRolePolicies(inlineTestAccount, "BadRole")
+	assert.Error(t, err, "a malformed inline document must fail closed")
+}


### PR DESCRIPTION
## Summary

Teach the predastore S3 data path to evaluate **inline** role policies, not just managed attachments, so an inline `Allow`/`Deny` written via spinifex's new `PutRolePolicy` takes effect for assumed-role sessions.

This is the predastore half of the cross-repo `iam-role-inline-policies` plan; spinifex adds the CRUD surface and its own enforcement walk in a companion PR.

## Changes

- `s3/auth.go`: add `InlinePolicies map[string]string` to the `iamRole` mirror struct, and append an inline-document walk to `resolveRolePolicies` (managed first, then parsed inline docs). A malformed inline document fails closed rather than resolving a partial set. Deleted the now-false "no inline role policies exist" comment.
- `s3/auth_test.go`: inline `Allow` honoured; inline `Deny` overrides a managed `Allow` (deny-wins, both docs resolved); malformed inline doc fails closed.