### PR TITLE
feat: honour group-inherited S3 permissions in NATS-IAM authorizer

### DIFF
--- a/s3/auth.go
+++ b/s3/auth.go
@@ -742,7 +742,7 @@ func (p *NATSIAMProvider) resolveGroupPolicies(accountID, userName string, group
 				// Membership to a deleted group is inert (spinifex refuses to
 				// delete a non-empty group), so this is a benign racing-delete
 				// remnant. Skip it; a deleted group carries no grant to drop.
-				slog.Warn("resolveUserPolicies: member references missing group; skipping",
+				slog.Warn("resolveGroupPolicies: member references missing group; skipping",
 					"accountID", accountID, "user", userName, "group", groupName)
 				continue
 			}

--- a/s3/auth.go
+++ b/s3/auth.go
@@ -72,6 +72,7 @@ type iamUser struct {
 	UserName         string   `json:"user_name"`
 	AccountID        string   `json:"account_id"`
 	AttachedPolicies []string `json:"attached_policies"` // policy ARNs
+	Groups           []string `json:"groups"`            // group NAMES the user belongs to (≤10)
 }
 
 // iamRole mirrors the spinifex IAM Role stored in NATS KV (spinifex-iam-roles).
@@ -81,6 +82,17 @@ type iamUser struct {
 // deliberately omitted here.
 type iamRole struct {
 	RoleName         string            `json:"role_name"`
+	AccountID        string            `json:"account_id"`
+	AttachedPolicies []string          `json:"attached_policies"` // managed policy ARNs
+	InlinePolicies   map[string]string `json:"inline_policies"`   // policyName → document JSON
+}
+
+// iamGroup mirrors the spinifex IAM Group stored in NATS KV (spinifex-iam-groups).
+// Membership is canonical on iamUser.Groups, so the group's member list is not
+// replicated here — only the two grant-source fields predastore needs to resolve a
+// member's inherited permissions, exactly like iamRole.
+type iamGroup struct {
+	GroupName        string            `json:"group_name"`
 	AccountID        string            `json:"account_id"`
 	AttachedPolicies []string          `json:"attached_policies"` // managed policy ARNs
 	InlinePolicies   map[string]string `json:"inline_policies"`   // policyName → document JSON
@@ -163,6 +175,12 @@ const (
 	kvBucketRoles    = "spinifex-iam-roles"
 	kvBucketPolicies = "spinifex-iam-policies"
 
+	// kvBucketGroups holds IAM group records. It is opened lazily on its own
+	// readiness flag (like the session bucket) so a missing groups bucket — a
+	// predastore-ahead-of-spinifex rollout window — never disables the
+	// direct-grant IAM path; group resolution is simply skipped until it appears.
+	kvBucketGroups = "spinifex-iam-groups"
+
 	// kvBucketSessionCredentials holds STS-minted ASIA session records. It is a
 	// separate bucket from the AKIA access keys and is opened lazily on its own
 	// readiness flag so a missing session bucket never disables AKIA auth.
@@ -215,6 +233,12 @@ type NATSIAMProvider struct {
 	// independently of the AKIA buckets so either path can come up alone.
 	sessionsBucket nats.KeyValue
 	sessionsReady  bool
+
+	// Groups bucket has its own readiness flag for the same reason: a missing
+	// groups bucket must not disable direct-grant IAM auth for users who never
+	// use groups. Group resolution is an additive layer on the user path.
+	groupsBucket nats.KeyValue
+	groupsReady  bool
 
 	watcher   nats.KeyWatcher
 	done      chan struct{}
@@ -360,6 +384,28 @@ func (p *NATSIAMProvider) ensureSessionsBucket() error {
 	p.sessionsBucket = bucket
 	p.sessionsReady = true
 	slog.Info("STS session-credentials bucket now available — ASIA session auth is active")
+	return nil
+}
+
+// ensureGroupsBucket lazily opens the IAM groups KV bucket. Like the session
+// bucket it is decoupled from ensureBuckets: a missing groups bucket must not
+// disable direct-grant IAM auth. The caller must hold p.mu.
+func (p *NATSIAMProvider) ensureGroupsBucket() error {
+	if p.groupsReady {
+		return nil
+	}
+	if p.js == nil {
+		return fmt.Errorf("JetStream context not available")
+	}
+
+	bucket, err := p.js.KeyValue(kvBucketGroups)
+	if err != nil {
+		return fmt.Errorf("open groups bucket: %w", err)
+	}
+
+	p.groupsBucket = bucket
+	p.groupsReady = true
+	slog.Info("IAM groups bucket now available — group-inherited S3 permissions are active")
 	return nil
 }
 
@@ -643,7 +689,86 @@ func (p *NATSIAMProvider) resolveUserPolicies(accountID, userName string) ([]iam
 		return nil, fmt.Errorf("unmarshal user: %w", err)
 	}
 
-	return p.resolveManagedPolicies(accountID, user.AttachedPolicies)
+	docs, err := p.resolveManagedPolicies(accountID, user.AttachedPolicies)
+	if err != nil {
+		return nil, err
+	}
+
+	// Group-inherited policies (managed + inline). Appended to the same slice so
+	// evaluateS3Access combines direct, group-managed, and group-inline grants
+	// under deny-wins. The common no-group user pays no extra lock or KV round-trip.
+	if len(user.Groups) > 0 {
+		groupDocs, err := p.resolveGroupPolicies(accountID, userName, user.Groups)
+		if err != nil {
+			return nil, err
+		}
+		docs = append(docs, groupDocs...)
+	}
+
+	return docs, nil
+}
+
+// resolveGroupPolicies resolves the managed and inline policies inherited from a
+// user's groups. It mirrors spinifex's GetUserPolicies group loop: a missing
+// group is skipped (a deleted group is inert), an unresolvable/malformed group
+// policy fails closed, an absent groups bucket skips all group resolution, and a
+// groups-bucket infra fault fails closed.
+func (p *NATSIAMProvider) resolveGroupPolicies(accountID, userName string, groups []string) ([]iamPolicyDocument, error) {
+	// Lazily open the groups bucket. A not-yet-created bucket means groups-v1 is
+	// not deployed on the spinifex side, so no group records exist anywhere and
+	// there is nothing (no Allow and no Deny) to resolve — skip safely. Any other
+	// open error is an infra fault: fail closed rather than risk dropping a Deny.
+	p.mu.Lock()
+	if !p.groupsReady {
+		if err := p.ensureGroupsBucket(); err != nil {
+			p.mu.Unlock()
+			if errors.Is(err, nats.ErrBucketNotFound) || errors.Is(err, nats.ErrStreamNotFound) {
+				slog.Warn("Groups bucket not available — skipping group-inherited policies "+
+					"(group grants will not apply until spinifex creates the bucket)",
+					"accountID", accountID, "user", userName)
+				return nil, nil
+			}
+			return nil, fmt.Errorf("open groups bucket: %w", err)
+		}
+	}
+	bucket := p.groupsBucket
+	p.mu.Unlock()
+
+	var docs []iamPolicyDocument
+	for _, groupName := range groups {
+		gEntry, err := bucket.Get(accountID + "." + groupName)
+		if err != nil {
+			if errors.Is(err, nats.ErrKeyNotFound) {
+				// Membership to a deleted group is inert (spinifex refuses to
+				// delete a non-empty group), so this is a benign racing-delete
+				// remnant. Skip it; a deleted group carries no grant to drop.
+				slog.Warn("resolveUserPolicies: member references missing group; skipping",
+					"accountID", accountID, "user", userName, "group", groupName)
+				continue
+			}
+			return nil, fmt.Errorf("lookup group %s.%s: %w", accountID, groupName, err)
+		}
+
+		var group iamGroup
+		if err := json.Unmarshal(gEntry.Value(), &group); err != nil {
+			return nil, fmt.Errorf("unmarshal group %s: %w", groupName, err)
+		}
+
+		managed, err := p.resolveManagedPolicies(accountID, group.AttachedPolicies)
+		if err != nil {
+			return nil, err // fail closed (mirrors direct-policy handling)
+		}
+		docs = append(docs, managed...)
+
+		for name, raw := range group.InlinePolicies {
+			var doc iamPolicyDocument
+			if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+				return nil, fmt.Errorf("parse group inline policy %s/%s: %w", groupName, name, err)
+			}
+			docs = append(docs, doc)
+		}
+	}
+	return docs, nil
 }
 
 // resolveRolePolicies resolves an assumed-role session's permissions: load the

--- a/s3/auth_group_test.go
+++ b/s3/auth_group_test.go
@@ -5,8 +5,10 @@
 package s3
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
@@ -302,4 +304,153 @@ func TestResolveUserPolicies_NoGroupsUnchanged(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, docs, 1, "a no-groups user resolves direct policies only")
 	assert.True(t, evaluateS3Access("s3:ListBucket", "arn:aws:s3:::any", docs))
+}
+
+// TestResolveUserPolicies_MultipleGroups proves the per-group loop accumulates
+// grants across more than one group and that a missing group in a NON-last
+// position is skipped without aborting the groups that follow it. Single-group
+// fixtures only ever exercise the skip as the final iteration, so this guards the
+// skip path against a continue→break (or other early-exit) regression.
+func TestResolveUserPolicies_MultipleGroups(t *testing.T) {
+	users := map[string][]byte{
+		inlineTestAccount + ".alice": mustMarshal(t, iamUser{
+			UserName:  "alice",
+			AccountID: inlineTestAccount,
+			Groups:    []string{"Ghost", "Engineers", "Auditors"}, // Ghost has no KV record
+		}),
+	}
+	groups := map[string][]byte{
+		inlineTestAccount + ".Engineers": mustMarshal(t, iamGroup{
+			GroupName:        "Engineers",
+			AccountID:        inlineTestAccount,
+			AttachedPolicies: []string{groupManagedARN},
+		}),
+		inlineTestAccount + ".Auditors": mustMarshal(t, iamGroup{
+			GroupName:      "Auditors",
+			AccountID:      inlineTestAccount,
+			InlinePolicies: map[string]string{"AllowS3": allowAllS3Policy},
+		}),
+	}
+	policies := map[string][]byte{
+		inlineTestAccount + ".GroupAllowS3": mustMarshal(t, iamPolicy{
+			PolicyName: "GroupAllowS3", PolicyDocument: allowAllS3Policy,
+		}),
+	}
+	p := newGroupProvider(users, policies, groups)
+
+	docs, err := p.resolveUserPolicies(inlineTestAccount, "alice")
+	require.NoError(t, err, "a missing group mid-list must be skipped, not abort resolution")
+	require.Len(t, docs, 2,
+		"the managed grant from Engineers and the inline grant from Auditors must both resolve past the skipped Ghost")
+	assert.True(t, evaluateS3Access("s3:ListBucket", "arn:aws:s3:::any", docs))
+}
+
+// TestResolveUserPolicies_GroupKVError proves a non-NotFound fault on a per-group
+// Get (the groups bucket is already open) fails closed, rather than being swallowed
+// like a missing group — which would risk silently dropping a group Deny.
+func TestResolveUserPolicies_GroupKVError(t *testing.T) {
+	users := map[string][]byte{
+		inlineTestAccount + ".alice": mustMarshal(t, iamUser{
+			UserName: "alice", AccountID: inlineTestAccount, Groups: []string{"Engineers"},
+		}),
+	}
+	// Non-nil groups map → groupsReady true; override the bucket to fault on Get.
+	p := newGroupProvider(users, map[string][]byte{}, map[string][]byte{})
+	p.groupsBucket = &fakeKV{getErr: errors.New("nats: connection closed")}
+
+	_, err := p.resolveUserPolicies(inlineTestAccount, "alice")
+	require.Error(t, err, "a per-group KV fault must fail closed, not be skipped")
+	assert.False(t, errors.Is(err, nats.ErrKeyNotFound),
+		"an infra fault must not be mistaken for a missing group")
+}
+
+// TestLookupSession_UserGroupPoliciesResolve exercises the ASIA GetSessionToken
+// user path end-to-end through the public LookupCredentials entry point — the
+// second caller of resolveUserPolicies. A user whose ONLY S3 grant is inherited
+// from a group must be authorized on the session path, not just the AKIA path,
+// guarding against a future fork that resolves session users differently.
+func TestLookupSession_UserGroupPoliciesResolve(t *testing.T) {
+	k := loadTestKey(t)
+	const secret = "session-secret-value"
+	cred := sessionCredential{
+		AccessKeyID:     testSessionAKID,
+		SecretEncrypted: encryptSessionSecret(t, k.AEAD, secret),
+		AccountID:       testSessionAccount,
+		PrincipalType:   "user",
+		SessionName:     testSessionUser,
+		ExpiresAt:       time.Now().UTC().Add(time.Hour),
+	}
+	sessions := map[string][]byte{testSessionAKID: mustMarshal(t, cred)}
+	users := map[string][]byte{
+		testSessionAccount + "." + testSessionUser: mustMarshal(t, iamUser{
+			UserName:  testSessionUser,
+			AccountID: testSessionAccount,
+			Groups:    []string{"Engineers"}, // no direct policies: the only grant is via the group
+		}),
+	}
+	groups := map[string][]byte{
+		testSessionAccount + ".Engineers": mustMarshal(t, iamGroup{
+			GroupName:        "Engineers",
+			AccountID:        testSessionAccount,
+			AttachedPolicies: []string{groupManagedARN},
+		}),
+	}
+	policies := map[string][]byte{
+		testSessionAccount + ".GroupAllowS3": mustMarshal(t, iamPolicy{
+			PolicyName: "GroupAllowS3", PolicyDocument: allowAllS3Policy,
+		}),
+	}
+	p := newSessionProvider(k, sessions, users, nil, policies)
+	p.groupsBucket = &fakeKV{data: groups}
+	p.groupsReady = true
+
+	res, err := p.LookupCredentials(testSessionAKID)
+	require.NoError(t, err)
+	require.Len(t, res.PolicyDocuments, 1, "the group-inherited policy must resolve on the user-session path")
+	assert.True(t, evaluateS3Access("s3:ListBucket", "arn:aws:s3:::any", res.PolicyDocuments),
+		"a user-session whose only grant is via a group must be authorized")
+}
+
+// TestIamGroup_UnmarshalsSpinifexJSON pins predastore's iamGroup JSON tags against a
+// representative spinifex Group record. Extra fields (group_id, arn, path, tags) must
+// be ignored; a tag drift from spinifex's struct would silently break group resolution
+// in production while the marshal-roundtrip fixtures in this file stayed green.
+func TestIamGroup_UnmarshalsSpinifexJSON(t *testing.T) {
+	raw := `{
+		"group_name": "Engineers",
+		"group_id": "AGPAEXAMPLE",
+		"account_id": "000000000001",
+		"arn": "arn:aws:iam::000000000001:group/Engineers",
+		"path": "/",
+		"created_at": "2026-01-01T00:00:00Z",
+		"attached_policies": ["arn:aws:iam::000000000001:policy/GroupAllowS3"],
+		"inline_policies": {"AllowS3": "{\"Version\":\"2012-10-17\"}"},
+		"tags": []
+	}`
+	var group iamGroup
+	require.NoError(t, json.Unmarshal([]byte(raw), &group))
+	assert.Equal(t, "Engineers", group.GroupName)
+	assert.Equal(t, "000000000001", group.AccountID)
+	assert.Equal(t, []string{"arn:aws:iam::000000000001:policy/GroupAllowS3"}, group.AttachedPolicies)
+	assert.Equal(t, map[string]string{"AllowS3": `{"Version":"2012-10-17"}`}, group.InlinePolicies)
+}
+
+// TestIamUser_GroupsUnmarshalsSpinifexJSON pins the new iamUser.Groups tag against a
+// spinifex User record so a `groups` tag drift cannot silently sever group membership.
+func TestIamUser_GroupsUnmarshalsSpinifexJSON(t *testing.T) {
+	raw := `{
+		"user_name": "alice",
+		"user_id": "AIDAEXAMPLE",
+		"account_id": "000000000001",
+		"arn": "arn:aws:iam::000000000001:user/alice",
+		"path": "/",
+		"access_keys": ["AKIAEXAMPLE"],
+		"tags": [],
+		"attached_policies": ["arn:aws:iam::000000000001:policy/DirectAllowS3"],
+		"groups": ["Engineers", "Auditors"]
+	}`
+	var user iamUser
+	require.NoError(t, json.Unmarshal([]byte(raw), &user))
+	assert.Equal(t, []string{"Engineers", "Auditors"}, user.Groups)
+	assert.Equal(t, []string{"arn:aws:iam::000000000001:policy/DirectAllowS3"}, user.AttachedPolicies)
 }

--- a/s3/auth_group_test.go
+++ b/s3/auth_group_test.go
@@ -1,0 +1,305 @@
+// Copyright 2025 Mulga Defense Corporation (MDC). All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license
+// that can be found in the LICENSE file.
+
+package s3
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fake nats.JetStreamContext (embeds the interface; only KeyValue is exercised) ---
+
+// fakeJS lets resolveGroupPolicies drive the lazy groups-bucket open without a
+// live NATS connection: KeyValue returns the configured error.
+type fakeJS struct {
+	nats.JetStreamContext
+
+	kvErr error
+}
+
+func (j *fakeJS) KeyValue(bucket string) (nats.KeyValue, error) { return nil, j.kvErr }
+
+// --- group resolution helpers ---
+
+const (
+	groupManagedARN = "arn:aws:iam::" + inlineTestAccount + ":policy/GroupAllowS3"
+	directAllowARN  = "arn:aws:iam::" + inlineTestAccount + ":policy/DirectAllowS3"
+)
+
+// newGroupProvider wires a NATSIAMProvider to fake users/policies/groups buckets
+// for the AKIA group-resolution path. A nil groups map leaves the groups bucket
+// unwired (groupsReady false), mirroring a provider that has not yet opened it.
+func newGroupProvider(users, policies, groups map[string][]byte) *NATSIAMProvider {
+	p := &NATSIAMProvider{
+		cache:          make(map[string]*cachedCredential),
+		done:           make(chan struct{}),
+		usersBucket:    &fakeKV{data: users},
+		policiesBucket: &fakeKV{data: policies},
+		bucketsReady:   true,
+	}
+	if groups != nil {
+		p.groupsBucket = &fakeKV{data: groups}
+		p.groupsReady = true
+	}
+	return p
+}
+
+// TestResolveUserPolicies_GroupManagedAllow proves a managed policy attached to a
+// user's group resolves and authorizes on the S3 data path, with no direct grant.
+func TestResolveUserPolicies_GroupManagedAllow(t *testing.T) {
+	users := map[string][]byte{
+		inlineTestAccount + ".alice": mustMarshal(t, iamUser{
+			UserName:  "alice",
+			AccountID: inlineTestAccount,
+			Groups:    []string{"Engineers"},
+		}),
+	}
+	groups := map[string][]byte{
+		inlineTestAccount + ".Engineers": mustMarshal(t, iamGroup{
+			GroupName:        "Engineers",
+			AccountID:        inlineTestAccount,
+			AttachedPolicies: []string{groupManagedARN},
+		}),
+	}
+	policies := map[string][]byte{
+		inlineTestAccount + ".GroupAllowS3": mustMarshal(t, iamPolicy{
+			PolicyName: "GroupAllowS3", PolicyDocument: allowAllS3Policy,
+		}),
+	}
+	p := newGroupProvider(users, policies, groups)
+
+	docs, err := p.resolveUserPolicies(inlineTestAccount, "alice")
+	require.NoError(t, err)
+	require.Len(t, docs, 1, "group-managed Allow must resolve")
+	assert.True(t, evaluateS3Access("s3:ListBucket", "arn:aws:s3:::any", docs),
+		"group-managed Allow must be honoured")
+}
+
+// TestResolveUserPolicies_GroupInlineAllow proves an inline policy embedded in a
+// user's group resolves and authorizes — the inline-via-group linchpin.
+func TestResolveUserPolicies_GroupInlineAllow(t *testing.T) {
+	users := map[string][]byte{
+		inlineTestAccount + ".alice": mustMarshal(t, iamUser{
+			UserName: "alice", AccountID: inlineTestAccount, Groups: []string{"Engineers"},
+		}),
+	}
+	groups := map[string][]byte{
+		inlineTestAccount + ".Engineers": mustMarshal(t, iamGroup{
+			GroupName:      "Engineers",
+			AccountID:      inlineTestAccount,
+			InlinePolicies: map[string]string{"AllowS3": allowAllS3Policy},
+		}),
+	}
+	p := newGroupProvider(users, map[string][]byte{}, groups)
+
+	docs, err := p.resolveUserPolicies(inlineTestAccount, "alice")
+	require.NoError(t, err)
+	require.Len(t, docs, 1, "group-inline Allow must resolve")
+	assert.True(t, evaluateS3Access("s3:ListBucket", "arn:aws:s3:::any", docs),
+		"group-inline Allow must be honoured")
+}
+
+// TestResolveUserPolicies_GroupDenyOverridesDirectAllow proves direct and
+// group-inline documents are evaluated together: a group Deny overrides a direct
+// Allow, the standard IAM deny-wins outcome across direct + group.
+func TestResolveUserPolicies_GroupDenyOverridesDirectAllow(t *testing.T) {
+	users := map[string][]byte{
+		inlineTestAccount + ".alice": mustMarshal(t, iamUser{
+			UserName:         "alice",
+			AccountID:        inlineTestAccount,
+			AttachedPolicies: []string{directAllowARN},
+			Groups:           []string{"Restricted"},
+		}),
+	}
+	groups := map[string][]byte{
+		inlineTestAccount + ".Restricted": mustMarshal(t, iamGroup{
+			GroupName:      "Restricted",
+			AccountID:      inlineTestAccount,
+			InlinePolicies: map[string]string{"DenyS3": denyAllS3Policy},
+		}),
+	}
+	policies := map[string][]byte{
+		inlineTestAccount + ".DirectAllowS3": mustMarshal(t, iamPolicy{
+			PolicyName: "DirectAllowS3", PolicyDocument: allowAllS3Policy,
+		}),
+	}
+	p := newGroupProvider(users, policies, groups)
+
+	docs, err := p.resolveUserPolicies(inlineTestAccount, "alice")
+	require.NoError(t, err)
+	require.Len(t, docs, 2, "direct Allow and group Deny must both resolve")
+	assert.False(t, evaluateS3Access("s3:ListBucket", "arn:aws:s3:::any", docs),
+		"group Deny must override direct Allow (deny-wins)")
+}
+
+// TestResolveUserPolicies_CombineDirectAndGroup proves a direct managed policy and
+// a group managed policy both contribute to the resolved set.
+func TestResolveUserPolicies_CombineDirectAndGroup(t *testing.T) {
+	users := map[string][]byte{
+		inlineTestAccount + ".alice": mustMarshal(t, iamUser{
+			UserName:         "alice",
+			AccountID:        inlineTestAccount,
+			AttachedPolicies: []string{directAllowARN},
+			Groups:           []string{"Engineers"},
+		}),
+	}
+	groups := map[string][]byte{
+		inlineTestAccount + ".Engineers": mustMarshal(t, iamGroup{
+			GroupName:        "Engineers",
+			AccountID:        inlineTestAccount,
+			AttachedPolicies: []string{groupManagedARN},
+		}),
+	}
+	policies := map[string][]byte{
+		inlineTestAccount + ".DirectAllowS3": mustMarshal(t, iamPolicy{
+			PolicyName: "DirectAllowS3", PolicyDocument: allowAllS3Policy,
+		}),
+		inlineTestAccount + ".GroupAllowS3": mustMarshal(t, iamPolicy{
+			PolicyName: "GroupAllowS3", PolicyDocument: allowAllS3Policy,
+		}),
+	}
+	p := newGroupProvider(users, policies, groups)
+
+	docs, err := p.resolveUserPolicies(inlineTestAccount, "alice")
+	require.NoError(t, err)
+	assert.Len(t, docs, 2, "direct and group managed policies must both resolve")
+}
+
+// TestResolveUserPolicies_MissingGroupSkipped proves a membership to a group with
+// no KV record is inert: the user's direct policies still resolve with no error.
+func TestResolveUserPolicies_MissingGroupSkipped(t *testing.T) {
+	users := map[string][]byte{
+		inlineTestAccount + ".alice": mustMarshal(t, iamUser{
+			UserName:         "alice",
+			AccountID:        inlineTestAccount,
+			AttachedPolicies: []string{directAllowARN},
+			Groups:           []string{"Ghost"}, // no record under inlineTestAccount.Ghost
+		}),
+	}
+	policies := map[string][]byte{
+		inlineTestAccount + ".DirectAllowS3": mustMarshal(t, iamPolicy{
+			PolicyName: "DirectAllowS3", PolicyDocument: allowAllS3Policy,
+		}),
+	}
+	p := newGroupProvider(users, policies, map[string][]byte{})
+
+	docs, err := p.resolveUserPolicies(inlineTestAccount, "alice")
+	require.NoError(t, err, "a missing group must be skipped, not fail")
+	require.Len(t, docs, 1, "the user's direct policy must still resolve")
+	assert.True(t, evaluateS3Access("s3:ListBucket", "arn:aws:s3:::any", docs))
+}
+
+// TestResolveUserPolicies_GroupInlineMalformedFailsClosed proves a corrupt inline
+// document within a resolvable group fails closed rather than silently dropping it.
+func TestResolveUserPolicies_GroupInlineMalformedFailsClosed(t *testing.T) {
+	users := map[string][]byte{
+		inlineTestAccount + ".alice": mustMarshal(t, iamUser{
+			UserName: "alice", AccountID: inlineTestAccount, Groups: []string{"BadGroup"},
+		}),
+	}
+	groups := map[string][]byte{
+		inlineTestAccount + ".BadGroup": mustMarshal(t, iamGroup{
+			GroupName:      "BadGroup",
+			AccountID:      inlineTestAccount,
+			InlinePolicies: map[string]string{"Broken": "{not json"},
+		}),
+	}
+	p := newGroupProvider(users, map[string][]byte{}, groups)
+
+	_, err := p.resolveUserPolicies(inlineTestAccount, "alice")
+	assert.Error(t, err, "a malformed group inline document must fail closed")
+}
+
+// TestResolveUserPolicies_GroupManagedMissingFailsClosed proves a group managed
+// attachment pointing at a non-existent policy record fails closed.
+func TestResolveUserPolicies_GroupManagedMissingFailsClosed(t *testing.T) {
+	users := map[string][]byte{
+		inlineTestAccount + ".alice": mustMarshal(t, iamUser{
+			UserName: "alice", AccountID: inlineTestAccount, Groups: []string{"Engineers"},
+		}),
+	}
+	groups := map[string][]byte{
+		inlineTestAccount + ".Engineers": mustMarshal(t, iamGroup{
+			GroupName:        "Engineers",
+			AccountID:        inlineTestAccount,
+			AttachedPolicies: []string{groupManagedARN}, // no GroupAllowS3 policy record
+		}),
+	}
+	p := newGroupProvider(users, map[string][]byte{}, groups)
+
+	_, err := p.resolveUserPolicies(inlineTestAccount, "alice")
+	assert.Error(t, err, "an unresolvable group managed policy must fail closed")
+}
+
+// TestResolveUserPolicies_GroupsBucketAbsent proves that when the groups bucket
+// has not been created (groups-v1 not deployed), group resolution is skipped and
+// the user keeps their direct grants with no error.
+func TestResolveUserPolicies_GroupsBucketAbsent(t *testing.T) {
+	users := map[string][]byte{
+		inlineTestAccount + ".alice": mustMarshal(t, iamUser{
+			UserName:         "alice",
+			AccountID:        inlineTestAccount,
+			AttachedPolicies: []string{directAllowARN},
+			Groups:           []string{"Engineers"},
+		}),
+	}
+	policies := map[string][]byte{
+		inlineTestAccount + ".DirectAllowS3": mustMarshal(t, iamPolicy{
+			PolicyName: "DirectAllowS3", PolicyDocument: allowAllS3Policy,
+		}),
+	}
+	// groups map nil → groupsReady false; js returns ErrBucketNotFound on open.
+	p := newGroupProvider(users, policies, nil)
+	p.js = &fakeJS{kvErr: nats.ErrBucketNotFound}
+
+	docs, err := p.resolveUserPolicies(inlineTestAccount, "alice")
+	require.NoError(t, err, "an absent groups bucket must skip group resolution, not fail")
+	require.Len(t, docs, 1, "the user's direct policy must still resolve")
+	assert.True(t, evaluateS3Access("s3:ListBucket", "arn:aws:s3:::any", docs))
+	assert.False(t, p.groupsReady, "a failed open must not mark the groups bucket ready")
+}
+
+// TestResolveUserPolicies_GroupsBucketInfraFault proves a non-not-found error
+// opening the groups bucket fails closed rather than silently dropping a Deny.
+func TestResolveUserPolicies_GroupsBucketInfraFault(t *testing.T) {
+	users := map[string][]byte{
+		inlineTestAccount + ".alice": mustMarshal(t, iamUser{
+			UserName: "alice", AccountID: inlineTestAccount, Groups: []string{"Engineers"},
+		}),
+	}
+	p := newGroupProvider(users, map[string][]byte{}, nil)
+	p.js = &fakeJS{kvErr: errors.New("nats: connection closed")}
+
+	_, err := p.resolveUserPolicies(inlineTestAccount, "alice")
+	assert.Error(t, err, "a groups-bucket infra fault must fail closed")
+}
+
+// TestResolveUserPolicies_NoGroupsUnchanged proves a user with no groups never
+// dereferences the groups bucket: resolution succeeds with the groups bucket
+// unwired (nil) and groupsReady false.
+func TestResolveUserPolicies_NoGroupsUnchanged(t *testing.T) {
+	users := map[string][]byte{
+		inlineTestAccount + ".alice": mustMarshal(t, iamUser{
+			UserName:         "alice",
+			AccountID:        inlineTestAccount,
+			AttachedPolicies: []string{directAllowARN},
+		}),
+	}
+	policies := map[string][]byte{
+		inlineTestAccount + ".DirectAllowS3": mustMarshal(t, iamPolicy{
+			PolicyName: "DirectAllowS3", PolicyDocument: allowAllS3Policy,
+		}),
+	}
+	p := newGroupProvider(users, policies, nil) // groupsBucket nil, groupsReady false, js nil
+
+	docs, err := p.resolveUserPolicies(inlineTestAccount, "alice")
+	require.NoError(t, err)
+	require.Len(t, docs, 1, "a no-groups user resolves direct policies only")
+	assert.True(t, evaluateS3Access("s3:ListBucket", "arn:aws:s3:::any", docs))
+}


### PR DESCRIPTION
## Summary

Teaches predastore's NATS-IAM authorizer to honour **group-inherited** S3 permissions. Previously `resolveUserPolicies` resolved only a caller's directly-attached managed policies and never looked at group membership, so any S3 permission granted through a group — via the group's managed attachment or its inline document — was silently dropped on the S3 data path. A user whose only S3 grant was via a group was denied by predastore even though spinifex's gateway would allow them.

## Changes

- Replicate the group subset spinifex writes to KV: add `Groups []string` to `iamUser` and a new `iamGroup` type (`group_name`, `account_id`, `attached_policies`, `inline_policies`), mirroring the existing `iamRole` replication.
- Add the `spinifex-iam-groups` bucket with its own `groupsReady` readiness flag and a lazy `ensureGroupsBucket()`, mirroring the session-credentials bucket. A transiently-absent groups bucket skips group resolution rather than disabling direct-grant IAM auth.
- Extend `resolveUserPolicies` to resolve `user.Groups` via a new `resolveGroupPolicies` helper and append each group's managed and inline documents to the caller's effective set. Because `evaluateS3Access` is deny-wins across all collected documents, direct, group-managed, and group-inline grants combine correctly with no special-casing.

This reproduces spinifex's `GetUserPolicies` group-loop contract exactly:

- **Missing group** (`ErrKeyNotFound`) → skip with a warn (a deleted group is inert).
- **Group managed/inline policy unresolvable or malformed** → fail closed.
- **Groups bucket genuinely absent** (groups not deployed on spinifex) → skip all group resolution.
- **Groups bucket infra fault** → fail closed.

Both the AKIA user-key path and the ASIA `GetSessionToken` user-session path call `resolveUserPolicies`, so group inheritance applies to both. Assumed-role sessions go through `resolveRolePolicies` and are correctly unaffected.