### PR TITLE
feat: IAM user inline-policy S3 authorization parity

### DIFF
--- a/s3/auth.go
+++ b/s3/auth.go
@@ -658,6 +658,15 @@ func (p *NATSIAMProvider) resolveUserPolicies(accountID, userName string) ([]iam
 		return nil, err
 	}
 
+	// User-own inline policies. Shares the group/role parse helper so a malformed
+	// document fails closed identically; keeps the S3 decision in lockstep with
+	// spinifex's GetUserPolicies user-inline loop.
+	inline, err := resolveInlinePolicies(user.InlinePolicies, "user "+userName)
+	if err != nil {
+		return nil, err
+	}
+	docs = append(docs, inline...)
+
 	// Group-inherited policies (managed + inline). Appended to the same slice so
 	// iampolicy.Evaluate combines direct, group-managed, and group-inline grants
 	// under deny-wins. The common no-group user pays no extra lock or KV round-trip.

--- a/s3/auth.go
+++ b/s3/auth.go
@@ -68,10 +68,11 @@ type sessionCredential struct {
 
 // iamUser mirrors the spinifex IAM User stored in NATS KV.
 type iamUser struct {
-	UserName         string   `json:"user_name"`
-	AccountID        string   `json:"account_id"`
-	AttachedPolicies []string `json:"attached_policies"` // policy ARNs
-	Groups           []string `json:"groups"`            // group NAMES the user belongs to (≤10)
+	UserName         string            `json:"user_name"`
+	AccountID        string            `json:"account_id"`
+	AttachedPolicies []string          `json:"attached_policies"` // policy ARNs
+	Groups           []string          `json:"groups"`            // group NAMES the user belongs to (≤10)
+	InlinePolicies   map[string]string `json:"inline_policies"`   // policyName → document JSON
 }
 
 // iamRole mirrors the spinifex IAM Role stored in NATS KV (spinifex-iam-roles).

--- a/s3/auth_user_inline_test.go
+++ b/s3/auth_user_inline_test.go
@@ -1,0 +1,72 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveUserPolicies_UserInlineAllow proves a user's own inline policy
+// resolves and authorizes on the S3 data path — the user-inline linchpin that
+// keeps the S3 decision in lockstep with spinifex's GetUserPolicies.
+func TestResolveUserPolicies_UserInlineAllow(t *testing.T) {
+	users := map[string][]byte{
+		inlineTestAccount + ".alice": mustMarshal(t, iamUser{
+			UserName:       "alice",
+			AccountID:      inlineTestAccount,
+			InlinePolicies: map[string]string{"AllowS3": allowAllS3Policy},
+		}),
+	}
+	p := newGroupProvider(users, map[string][]byte{}, nil)
+
+	docs, err := p.resolveUserPolicies(inlineTestAccount, "alice")
+	require.NoError(t, err)
+	require.Len(t, docs, 1, "user-inline Allow must resolve")
+	assert.True(t, allowed("s3:ListBucket", "arn:aws:s3:::any", docs),
+		"user-inline Allow must be honoured")
+}
+
+// TestResolveUserPolicies_UserInlineDenyOverridesManagedAllow proves a user's
+// direct managed Allow and its own inline Deny are evaluated together, with the
+// inline Deny winning — the standard IAM deny-wins outcome. A user-inline Deny
+// dropped on the S3 path would be a split-brain over-permit.
+func TestResolveUserPolicies_UserInlineDenyOverridesManagedAllow(t *testing.T) {
+	users := map[string][]byte{
+		inlineTestAccount + ".alice": mustMarshal(t, iamUser{
+			UserName:         "alice",
+			AccountID:        inlineTestAccount,
+			AttachedPolicies: []string{directAllowARN},
+			InlinePolicies:   map[string]string{"DenyS3": denyAllS3Policy},
+		}),
+	}
+	policies := map[string][]byte{
+		inlineTestAccount + ".DirectAllowS3": mustMarshal(t, iamPolicy{
+			PolicyName: "DirectAllowS3", PolicyDocument: allowAllS3Policy,
+		}),
+	}
+	p := newGroupProvider(users, policies, nil)
+
+	docs, err := p.resolveUserPolicies(inlineTestAccount, "alice")
+	require.NoError(t, err)
+	require.Len(t, docs, 2, "direct Allow and user-inline Deny must both resolve")
+	assert.False(t, allowed("s3:ListBucket", "arn:aws:s3:::any", docs),
+		"user-inline Deny must override direct Allow (deny-wins)")
+}
+
+// TestResolveUserPolicies_UserInlineMalformedFailsClosed proves a corrupt inline
+// document on the user fails closed rather than silently dropping it, matching the
+// group/role inline handling via the shared resolveInlinePolicies helper.
+func TestResolveUserPolicies_UserInlineMalformedFailsClosed(t *testing.T) {
+	users := map[string][]byte{
+		inlineTestAccount + ".alice": mustMarshal(t, iamUser{
+			UserName:       "alice",
+			AccountID:      inlineTestAccount,
+			InlinePolicies: map[string]string{"Broken": "{not json"},
+		}),
+	}
+	p := newGroupProvider(users, map[string][]byte{}, nil)
+
+	_, err := p.resolveUserPolicies(inlineTestAccount, "alice")
+	assert.Error(t, err, "a malformed user inline document must fail closed")
+}


### PR DESCRIPTION
## Summary

Adds S3-side authorization parity for IAM user inline policies. Predastore enforces S3 access with its own replicated copy of the IAM model, so it must resolve a user's own inline policies the same way spinifex's gateway does — otherwise a user with an inline policy is evaluated one way on an EC2/IAM call and a different way on an S3 call, the split-brain the group-auth work was built to prevent. Companion to the spinifex `feat/iam-user-inline-policies` PR.

## Changes

- Add `InlinePolicies map[string]string` (`json:"inline_policies"`) to the replicated `iamUser` struct, matching the existing `iamGroup` / `iamRole` and the spinifex wire shape. Additive: pre-existing user records decode to a nil map, no migration or version bump.
- In `resolveUserPolicies`, after `resolveManagedPolicies` and alongside the group block, append the user's own inline documents via the shared `resolveInlinePolicies` helper that the group and role resolvers already call. It parses each document and fails closed on a malformed one, so user / group / role inline parsing cannot diverge.

The combined slice is evaluated under the shared `iampolicy.Evaluate` deny-wins evaluator, so direct, user-inline, group-managed, and group-inline grants all combine uniformly. No extra KV round-trip: the user record is already loaded, and this covers both principal paths (AKIA and session-user).