### PR TITLE
fix: single-encode S3 canonical URI so '='-key signatures verify

### DIFF
--- a/auth/sigv4.go
+++ b/auth/sigv4.go
@@ -89,6 +89,19 @@ func WithBodyHash(hex string) func(*Options) {
 	return func(o *Options) { o.bodyHash = hex }
 }
 
+// newSigner builds an SDK signer configured for the signing service. S3
+// uses single URI-path encoding (auth-scheme DisableDoubleEncoding=true):
+// the canonical URI is the already-percent-encoded wire path, not re-
+// escaped. Without this, object keys whose canonical URI contains '=',
+// ' ', etc. get double-encoded ('%3D' -> '%253D') on re-sign and fail
+// verification — breaking Hive-partitioned keys (pen_id=x/date=y/...).
+// Non-S3 services (EC2/IAM/...) keep the SDK default double-encoding.
+func newSigner(service string) *v4.Signer {
+	return v4.NewSigner(func(o *v4.SignerOptions) {
+		o.DisableURIPathEscaping = service == "s3"
+	})
+}
+
 func resolveOpts(optFns []func(*Options)) Options {
 	o := Options{Time: time.Now}
 	for _, fn := range optFns {
@@ -129,7 +142,7 @@ func SignReq(
 	// client middleware does); set it here for direct-signing callers.
 	r.Header.Set("X-Amz-Content-Sha256", payloadHash)
 
-	return v4.NewSigner().SignHTTP(
+	return newSigner(service).SignHTTP(
 		context.Background(),
 		aws.Credentials{AccessKeyID: accessKeyID, SecretAccessKey: secretAccessKey},
 		r, payloadHash, service, region, o.Time().UTC(),
@@ -252,7 +265,7 @@ func (req *Request) Verify(
 	}
 
 	req.Header.Del(authHeaderKey)
-	signErr := v4.NewSigner().SignHTTP(
+	signErr := newSigner(service).SignHTTP(
 		context.Background(),
 		aws.Credentials{AccessKeyID: req.AccessKeyID, SecretAccessKey: secretAccessKey},
 		req.Request, payloadHash, service, region, req.SignedTime.UTC(),

--- a/auth/sigv4_test.go
+++ b/auth/sigv4_test.go
@@ -297,6 +297,52 @@ func TestStreamingSentinels(t *testing.T) {
 	}
 }
 
+// TestVerify_S3EncodedObjectKeys pins that Verify accepts requests signed
+// by a real AWS S3 client for object keys whose canonical URI contains
+// characters that require percent-encoding ('=', ' ', ...). S3 uses
+// single URI-encoding (the SDK's DisableURIPathEscaping=true / auth-scheme
+// DisableDoubleEncoding=true), so the server must not re-escape the
+// already-encoded canonical URI ('%3D' -> '%253D'). Hive-partitioned keys
+// (pen_id=abc/date=2026-07-03/...) are the motivating case.
+func TestVerify_S3EncodedObjectKeys(t *testing.T) {
+	body := []byte("frame-bytes")
+	sum := sha256.Sum256(body)
+	bodyHashHex := hex.EncodeToString(sum[:])
+
+	// signAsS3Client reproduces what boto3/aws-sdk-go-v2 emit for S3:
+	// single URI-path encoding. NewSigner's default (matching EC2/IAM)
+	// double-encodes, which is exactly the divergence under test.
+	signAsS3Client := func(target string) *http.Request {
+		req := httptest.NewRequest(http.MethodPut, target, bytes.NewReader(body))
+		req.Host = "s3.amazonaws.com"
+		req.Header.Set("X-Amz-Content-Sha256", bodyHashHex)
+		s3Signer := v4.NewSigner(func(o *v4.SignerOptions) {
+			o.DisableURIPathEscaping = true
+		})
+		require.NoError(t, s3Signer.SignHTTP(
+			context.Background(),
+			aws.Credentials{AccessKeyID: exAccessKeyID, SecretAccessKey: exSecret},
+			req, bodyHashHex, exService, exRegion, exTime,
+		))
+		return req
+	}
+
+	keys := []string{
+		"/bucket/test/pen_id=abc/x.txt",
+		"/bucket/pen_id=abc/date=2026-07-03/frame.jpg",
+		"/bucket/plain/key.txt",
+		"/bucket/has%20space/key.txt",
+	}
+	for _, target := range keys {
+		t.Run(target, func(t *testing.T) {
+			sig, err := auth.ParseReq(signAsS3Client(target))
+			require.NoError(t, err)
+			require.NoError(t, sig.Verify(exSecret, exService, exRegion,
+				auth.WithTime(exTime), auth.WithBodyHash(bodyHashHex)))
+		})
+	}
+}
+
 // TestVerify_WithBodyHash pins WithBodyHash's three contracts:
 //  1. matching hex hash accepts;
 //  2. mismatching hex hash returns ErrBodyHashMismatch;


### PR DESCRIPTION
## Summary

Object keys containing `=` (and other characters that need percent-encoding, e.g. spaces) failed SigV4 verification with `AccessDenied: The request signature does not match`. This breaks Hive-partitioned key layouts (`pen_id=x/date=y/...`), which are standard for Athena/Glue interop. Reported as issue 1 of mulgadc/spinifex#471.

## Root cause

`Verify` re-signs the incoming request with `aws-sdk-go-v2`'s `v4.NewSigner()` and byte-compares the reproduced `Authorization` header against the wire value. `NewSigner()` defaults to `DisableURIPathEscaping=false`, which **double-encodes** the canonical URI — it runs `httpbinding.EscapePath` over the already-percent-encoded wire path, turning `%3D` into `%253D`.

Real S3 clients (boto3, aws-sdk-go) **single-encode** per the S3 auth scheme (`DisableDoubleEncoding=true`), so the reproduced signature never matched for any key whose canonical URI needs encoding. It went unnoticed because `SignReq` and `Verify` both used the same default signer, so the internal round-trip test was self-consistent while disagreeing with every real client. Affected both PUT and CreateMultipartUpload (same `Verify` path).

## Fix

Route `SignReq` and `Verify` through a service-aware `newSigner(service)` that sets `DisableURIPathEscaping = (service == "s3")`, mirroring AWS's per-service rule. Non-S3 services (EC2/IAM/...) keep the SDK default double-encoding.

## Testing

- New `TestVerify_S3EncodedObjectKeys` signs requests the way a real S3 client does (single-encoding) for `=` keys, nested Hive keys, plain keys, and space keys. Confirmed it **fails on the pre-fix code** (signature mismatch on the encoded cases) and **passes after the fix**.
- Existing property/tamper/streaming tests remain green.
- `make preflight` passes (lint, govulncheck, coverage, race, integration).

Fixes issue 1 of mulgadc/spinifex#471.