### PR TITLE
feat(metrics): enrich request metric with bytes + real S3 error code

### DIFF
--- a/otelsetup/http.go
+++ b/otelsetup/http.go
@@ -16,16 +16,26 @@ import (
 
 const httpTracerName = "github.com/mulgadc/predastore/otelsetup"
 
-// statusRecorder captures the response status for span attributes.
+// statusRecorder captures the response status and body size for span and
+// metric attributes.
 type statusRecorder struct {
 	http.ResponseWriter
 
-	status int
+	status  int
+	written int64
 }
 
 func (w *statusRecorder) WriteHeader(code int) {
 	w.status = code
 	w.ResponseWriter.WriteHeader(code)
+}
+
+// Write tracks bytes actually written to the client, not a forced read of
+// the response body.
+func (w *statusRecorder) Write(b []byte) (int, error) {
+	n, err := w.ResponseWriter.Write(b)
+	w.written += int64(n)
+	return n, err
 }
 
 // HTTPMiddleware opens a server span per request, honoring an inbound W3C
@@ -57,7 +67,20 @@ func HTTPMiddleware(serverName string) func(http.Handler) http.Handler {
 				span.SetStatus(codes.Error, fmt.Sprintf("HTTP %d", rec.status))
 				outcome = "error"
 			}
-			RecordRequest(ctx, action.name, outcome, time.Since(start))
+
+			// Content-Length is read from the header set before the body was
+			// consumed; -1 (unknown/chunked) is left unrecorded rather than
+			// forcing a body read to measure it.
+			reqBytes := max(r.ContentLength, 0)
+			RecordRequest(ctx, RequestMetric{
+				Action:     action.name,
+				Outcome:    outcome,
+				StatusCode: rec.status,
+				ErrorCode:  action.errorCode,
+				ReqBytes:   reqBytes,
+				RespBytes:  rec.written,
+				Elapsed:    time.Since(start),
+			})
 		})
 	}
 }

--- a/otelsetup/metrics.go
+++ b/otelsetup/metrics.go
@@ -8,21 +8,31 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 // actionAttrKey names the logical operation on request metrics. Values must
 // stay low-cardinality: resolved S3 action names only, never bucket/key IDs.
 const actionAttrKey = "s3.action"
 
+// errorCodeAttrKey carries the real S3 error code (e.g. "NoSuchBucket") when
+// the request failed. Bounded set: only predastore's own S3Error codes.
+const errorCodeAttrKey = "s3.error_code"
+
+// directionAttrKey distinguishes bytes read from the request body ("in")
+// from bytes written to the response body ("out") on the bytes counter.
+const directionAttrKey = "direction"
+
 var (
 	instrumentsOnce sync.Once
 	requestCounter  metric.Int64Counter
 	requestDuration metric.Float64Histogram
+	requestBytes    metric.Int64Counter
 )
 
 // requestInstruments lazily creates the shared request instruments. The
 // global meter delegates to the real provider once Init installs it.
-func requestInstruments() (metric.Int64Counter, metric.Float64Histogram) {
+func requestInstruments() (metric.Int64Counter, metric.Float64Histogram, metric.Int64Counter) {
 	instrumentsOnce.Do(func() {
 		m := otel.Meter(httpTracerName)
 		var err error
@@ -38,33 +48,77 @@ func requestInstruments() (metric.Int64Counter, metric.Float64Histogram) {
 		if err != nil {
 			otel.Handle(err)
 		}
+		requestBytes, err = m.Int64Counter("mulga.request.bytes",
+			metric.WithDescription("Bytes transferred handling service requests, by direction."),
+			metric.WithUnit("By"))
+		if err != nil {
+			otel.Handle(err)
+		}
 	})
-	return requestCounter, requestDuration
+	return requestCounter, requestDuration, requestBytes
 }
 
-// RecordRequest records one handled request on the shared counter and
-// duration histogram. outcome is "success"/"error", or empty when the
-// result is not observable at the instrumentation point.
-func RecordRequest(ctx context.Context, action, outcome string, elapsed time.Duration) {
-	counter, duration := requestInstruments()
-	attrs := []attribute.KeyValue{attribute.String(actionAttrKey, action)}
-	if outcome != "" {
-		attrs = append(attrs, attribute.String("outcome", outcome))
+// RequestMetric is the set of attributes recorded for one handled HTTP
+// request. Outcome is "success"/"error", or empty when not observable at the
+// instrumentation point. ErrorCode is the real S3 error code (e.g.
+// "NoSuchBucket") and is empty on success. ReqBytes/RespBytes are the
+// request/response body sizes; zero means not known and is not recorded.
+type RequestMetric struct {
+	Action     string
+	Outcome    string
+	StatusCode int
+	ErrorCode  string
+	ReqBytes   int64
+	RespBytes  int64
+	Elapsed    time.Duration
+}
+
+// RecordRequest records one handled request on the shared counter, duration
+// histogram, and bytes-transferred counter.
+func RecordRequest(ctx context.Context, m RequestMetric) {
+	counter, duration, bytesCounter := requestInstruments()
+
+	attrs := []attribute.KeyValue{attribute.String(actionAttrKey, m.Action)}
+	if m.Outcome != "" {
+		attrs = append(attrs, attribute.String("outcome", m.Outcome))
+	}
+	if m.StatusCode > 0 {
+		attrs = append(attrs, semconv.HTTPResponseStatusCode(m.StatusCode))
+	}
+	if m.ErrorCode != "" {
+		attrs = append(attrs, attribute.String(errorCodeAttrKey, m.ErrorCode))
 	}
 	opt := metric.WithAttributeSet(attribute.NewSet(attrs...))
+
 	if counter != nil {
 		counter.Add(ctx, 1, opt)
 	}
 	if duration != nil {
-		duration.Record(ctx, elapsed.Seconds(), opt)
+		duration.Record(ctx, m.Elapsed.Seconds(), opt)
+	}
+	if bytesCounter == nil {
+		return
+	}
+	actionAttr := attribute.String(actionAttrKey, m.Action)
+	if m.ReqBytes > 0 {
+		bytesCounter.Add(ctx, m.ReqBytes, metric.WithAttributeSet(
+			attribute.NewSet(actionAttr, attribute.String(directionAttrKey, "in"))))
+	}
+	if m.RespBytes > 0 {
+		bytesCounter.Add(ctx, m.RespBytes, metric.WithAttributeSet(
+			attribute.NewSet(actionAttr, attribute.String(directionAttrKey, "out"))))
 	}
 }
 
 // requestActionKey carries a mutable per-request holder so downstream
-// middleware can name the request after routing resolves the S3 action.
+// middleware can name the request, and record the S3 error code, after
+// routing resolves them.
 type requestActionKey struct{}
 
-type requestAction struct{ name string }
+type requestAction struct {
+	name      string
+	errorCode string
+}
 
 // SetRequestAction sets the logical action recorded on request metrics for
 // the in-flight request. No-op when the request did not pass through
@@ -72,5 +126,14 @@ type requestAction struct{ name string }
 func SetRequestAction(ctx context.Context, action string) {
 	if h, ok := ctx.Value(requestActionKey{}).(*requestAction); ok && action != "" {
 		h.name = action
+	}
+}
+
+// SetRequestErrorCode records the real S3 error code (e.g. "NoSuchBucket")
+// for the in-flight request's metrics. No-op when the request did not pass
+// through HTTPMiddleware.
+func SetRequestErrorCode(ctx context.Context, code string) {
+	if h, ok := ctx.Value(requestActionKey{}).(*requestAction); ok && code != "" {
+		h.errorCode = code
 	}
 }

--- a/otelsetup/metrics_test.go
+++ b/otelsetup/metrics_test.go
@@ -1,0 +1,210 @@
+package otelsetup
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// resetRequestInstruments clears the cached request instruments so a test
+// can rebind them to its own reader. The sync.Once in requestInstruments
+// only ever fires once per process, so tests that need to observe recorded
+// values must reset it after installing their own MeterProvider.
+func resetRequestInstruments() {
+	instrumentsOnce = sync.Once{}
+	requestCounter = nil
+	requestDuration = nil
+	requestBytes = nil
+}
+
+// setupTestMeterProvider installs an SDK MeterProvider backed by a
+// ManualReader for the duration of the test, and resets the request
+// instrument cache so RecordRequest binds to it.
+func setupTestMeterProvider(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	resetRequestInstruments()
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prev)
+		resetRequestInstruments()
+	})
+	return reader
+}
+
+// collectMetric returns the collected data for the named instrument, or nil
+// if it was not recorded.
+func collectMetric(t *testing.T, reader *sdkmetric.ManualReader, name string) *metricdata.Metrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for i := range sm.Metrics {
+			if sm.Metrics[i].Name == name {
+				return &sm.Metrics[i]
+			}
+		}
+	}
+	return nil
+}
+
+// attrsOf returns the string/int-stringified attribute map for the sole
+// data point of an int64 Sum metric.
+func attrsOf(t *testing.T, m *metricdata.Metrics) map[string]string {
+	t.Helper()
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	if !ok || len(sum.DataPoints) == 0 {
+		t.Fatalf("metric %s has no int64 sum data points", m.Name)
+	}
+	got := map[string]string{}
+	for _, kv := range sum.DataPoints[0].Attributes.ToSlice() {
+		got[string(kv.Key)] = kv.Value.Emit()
+	}
+	return got
+}
+
+func TestRecordRequestSuccess2xx(t *testing.T) {
+	reader := setupTestMeterProvider(t)
+
+	RecordRequest(context.Background(), RequestMetric{
+		Action:     "GetObject",
+		Outcome:    "success",
+		StatusCode: http.StatusOK,
+		ReqBytes:   0,
+		RespBytes:  4096,
+		Elapsed:    10 * time.Millisecond,
+	})
+
+	reqs := collectMetric(t, reader, "mulga.requests")
+	if reqs == nil {
+		t.Fatal("mulga.requests not recorded")
+	}
+	attrs := attrsOf(t, reqs)
+	if attrs["s3.action"] != "GetObject" {
+		t.Errorf("s3.action = %q, want GetObject", attrs["s3.action"])
+	}
+	if attrs["outcome"] != "success" {
+		t.Errorf("outcome = %q, want success", attrs["outcome"])
+	}
+	if attrs["http.response.status_code"] != "200" {
+		t.Errorf("http.response.status_code = %q, want 200", attrs["http.response.status_code"])
+	}
+	if _, ok := attrs["s3.error_code"]; ok {
+		t.Errorf("s3.error_code should be absent on success, got %q", attrs["s3.error_code"])
+	}
+
+	bytes := collectMetric(t, reader, "mulga.request.bytes")
+	if bytes == nil {
+		t.Fatal("mulga.request.bytes not recorded")
+	}
+	sum, ok := bytes.Data.(metricdata.Sum[int64])
+	if !ok || len(sum.DataPoints) != 1 {
+		t.Fatalf("mulga.request.bytes data points = %+v, want 1 (out only)", bytes.Data)
+	}
+	dp := sum.DataPoints[0]
+	if dp.Value != 4096 {
+		t.Errorf("bytes value = %d, want 4096", dp.Value)
+	}
+	direction, _ := dp.Attributes.Value(attribute.Key(directionAttrKey))
+	if direction.AsString() != "out" {
+		t.Errorf("direction = %q, want out", direction.AsString())
+	}
+}
+
+func TestRecordRequestClientError4xx(t *testing.T) {
+	reader := setupTestMeterProvider(t)
+
+	RecordRequest(context.Background(), RequestMetric{
+		Action:     "GetObject",
+		Outcome:    "error",
+		StatusCode: http.StatusNotFound,
+		ErrorCode:  "NoSuchKey",
+		Elapsed:    time.Millisecond,
+	})
+
+	reqs := collectMetric(t, reader, "mulga.requests")
+	if reqs == nil {
+		t.Fatal("mulga.requests not recorded")
+	}
+	attrs := attrsOf(t, reqs)
+	if attrs["http.response.status_code"] != "404" {
+		t.Errorf("http.response.status_code = %q, want 404", attrs["http.response.status_code"])
+	}
+	if attrs["s3.error_code"] != "NoSuchKey" {
+		t.Errorf("s3.error_code = %q, want NoSuchKey", attrs["s3.error_code"])
+	}
+	// outcome stays whatever the middleware bucketed (4xx isn't forced to
+	// "error" here since HTTPMiddleware only flips outcome on >=500).
+	if attrs["outcome"] != "error" {
+		t.Errorf("outcome = %q, want error", attrs["outcome"])
+	}
+}
+
+func TestRecordRequestServerError5xx(t *testing.T) {
+	reader := setupTestMeterProvider(t)
+
+	RecordRequest(context.Background(), RequestMetric{
+		Action:     "PutObject",
+		Outcome:    "error",
+		StatusCode: http.StatusInternalServerError,
+		ErrorCode:  "InternalError",
+		ReqBytes:   1024,
+		Elapsed:    5 * time.Millisecond,
+	})
+
+	reqs := collectMetric(t, reader, "mulga.requests")
+	if reqs == nil {
+		t.Fatal("mulga.requests not recorded")
+	}
+	attrs := attrsOf(t, reqs)
+	if attrs["http.response.status_code"] != "500" {
+		t.Errorf("http.response.status_code = %q, want 500", attrs["http.response.status_code"])
+	}
+	if attrs["s3.error_code"] != "InternalError" {
+		t.Errorf("s3.error_code = %q, want InternalError", attrs["s3.error_code"])
+	}
+
+	bytes := collectMetric(t, reader, "mulga.request.bytes")
+	if bytes == nil {
+		t.Fatal("mulga.request.bytes not recorded")
+	}
+	sum, ok := bytes.Data.(metricdata.Sum[int64])
+	if !ok || len(sum.DataPoints) != 1 {
+		t.Fatalf("mulga.request.bytes data points = %+v, want 1 (in only)", bytes.Data)
+	}
+	dp := sum.DataPoints[0]
+	if dp.Value != 1024 {
+		t.Errorf("bytes value = %d, want 1024", dp.Value)
+	}
+	direction, _ := dp.Attributes.Value(attribute.Key(directionAttrKey))
+	if direction.AsString() != "in" {
+		t.Errorf("direction = %q, want in", direction.AsString())
+	}
+}
+
+func TestRecordRequestZeroBytesNotRecorded(t *testing.T) {
+	reader := setupTestMeterProvider(t)
+
+	RecordRequest(context.Background(), RequestMetric{
+		Action:     "HeadObject",
+		Outcome:    "success",
+		StatusCode: http.StatusOK,
+		Elapsed:    time.Millisecond,
+	})
+
+	if m := collectMetric(t, reader, "mulga.request.bytes"); m != nil {
+		if sum, ok := m.Data.(metricdata.Sum[int64]); ok && len(sum.DataPoints) != 0 {
+			t.Errorf("expected no bytes data points when ReqBytes/RespBytes are 0, got %+v", sum.DataPoints)
+		}
+	}
+}

--- a/s3/httpserver.go
+++ b/s3/httpserver.go
@@ -285,6 +285,7 @@ func (s *HTTP2Server) writeS3Error(w http.ResponseWriter, r *http.Request, statu
 		RequestId: uuid.NewString(),
 		HostId:    r.Host,
 	}
+	otelsetup.SetRequestErrorCode(r.Context(), code)
 
 	w.Header().Set("Content-Type", "application/xml")
 	w.WriteHeader(statusCode)
@@ -331,6 +332,7 @@ func (s *HTTP2Server) handleError(w http.ResponseWriter, r *http.Request, err er
 
 	s3error.RequestId = uuid.NewString()
 	s3error.HostId = r.Host
+	otelsetup.SetRequestErrorCode(r.Context(), s3error.Code)
 
 	w.Header().Set("Content-Type", "application/xml")
 	w.WriteHeader(statusCode)


### PR DESCRIPTION
## Summary

Phase 2 of the observability plan (predastore enrichment): `mulga.requests` /
`mulga.request.duration` only distinguished success/error on HTTP >= 500 and
never recorded bytes transferred, limiting throughput and real error-rate
analysis in the predastore S3-profiling dashboard.

- `RecordRequest` (`otelsetup/metrics.go`) now takes a `RequestMetric` struct
  carrying `StatusCode`, `ErrorCode`, `ReqBytes`, and `RespBytes` alongside
  the existing action/outcome/elapsed fields.
- `mulga.requests` and `mulga.request.duration` gain an
  `http.response.status_code` attribute (always) and an `s3.error_code`
  attribute (only set on error, e.g. `NoSuchBucket`, `AccessDenied`,
  `InternalError`) — so 4xx is now distinguishable from 5xx, and real error
  codes are visible. The existing `outcome` attribute is unchanged, so the
  live "Throughput by outcome" panel keeps working unmodified.
- New `mulga.request.bytes` `Int64Counter` (unit `By`), attributed by
  `s3.action` + `direction` (`in`/`out`). Request bytes come from
  `Content-Length` (skipped when unknown/chunked, no forced body read);
  response bytes come from actual bytes written through a `Write` override
  on the existing `statusRecorder` — no extra allocation or I/O.
- `s3/httpserver.go`: `writeS3Error` and `handleError` (the two response
  choke points) now call `otelsetup.SetRequestErrorCode` so the real S3
  error code reaches the metric via the existing per-request context holder
  (same pattern as `SetRequestAction`).

## Test plan

- [x] `otelsetup/metrics_test.go` (new): unit tests for `RecordRequest`
      across 2xx/4xx/5xx, asserting `http.response.status_code`,
      `s3.error_code` presence/absence, and `mulga.request.bytes`
      direction/value, using an in-memory SDK `ManualReader`.
- [x] `make preflight` passes (lint, govulncheck, test-cover, diff-coverage,
      test-race, test-integration).