### PR TITLE
fix(otel): gate slog->OTLP bridge at configured level

### DIFF
--- a/otelsetup/slog.go
+++ b/otelsetup/slog.go
@@ -16,7 +16,10 @@ import (
 // stdout (journald) at the given level, with trace_id/span_id stamping. If a
 // real OTLP LoggerProvider is already installed (via Init), the default also
 // fans out to it, so repeated calls (once per HTTP server setup) re-establish
-// stdout-at-level without ever clobbering the OTLP bridge.
+// stdout-at-level without ever clobbering the OTLP bridge. Both sinks are
+// gated at the same level: the OTLP bridge has no severity filter of its
+// own, so without gating it every record (including Debug) would ship to
+// OTLP regardless of the configured level.
 func SetDefaultJSONLogger(level slog.Level) {
 	stdout := NewSlogHandler(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: level,
@@ -28,7 +31,7 @@ func SetDefaultJSONLogger(level slog.Level) {
 		return
 	}
 	bridge := otelslog.NewHandler("predastore", otelslog.WithLoggerProvider(lp))
-	slog.SetDefault(slog.New(newFanoutHandler(stdout, bridge)))
+	slog.SetDefault(slog.New(newFanoutHandler(stdout, newLevelHandler(level, bridge))))
 }
 
 var _ slog.Handler = (*traceHandler)(nil)
@@ -66,6 +69,38 @@ func (h *traceHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 
 func (h *traceHandler) WithGroup(name string) slog.Handler {
 	return &traceHandler{inner: h.inner.WithGroup(name)}
+}
+
+var _ slog.Handler = (*levelHandler)(nil)
+
+// levelHandler gates inner at a minimum level. The otelslog bridge reports
+// Enabled==true for every level (its BatchProcessor has no severity filter),
+// so without this wrapper every Debug record would be exported to OTLP
+// regardless of the configured level — and slog would never short-circuit
+// Debug calls at the call site.
+type levelHandler struct {
+	level slog.Level
+	inner slog.Handler
+}
+
+// newLevelHandler returns a handler that only forwards records at or above
+// level to inner, regardless of what inner.Enabled reports.
+func newLevelHandler(level slog.Level, inner slog.Handler) slog.Handler {
+	return &levelHandler{level: level, inner: inner}
+}
+
+func (h *levelHandler) Enabled(_ context.Context, l slog.Level) bool { return l >= h.level }
+
+func (h *levelHandler) Handle(ctx context.Context, r slog.Record) error {
+	return h.inner.Handle(ctx, r)
+}
+
+func (h *levelHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &levelHandler{level: h.level, inner: h.inner.WithAttrs(attrs)}
+}
+
+func (h *levelHandler) WithGroup(name string) slog.Handler {
+	return &levelHandler{level: h.level, inner: h.inner.WithGroup(name)}
 }
 
 var _ slog.Handler = (*fanoutHandler)(nil)

--- a/s3/httpserver.go
+++ b/s3/httpserver.go
@@ -71,7 +71,10 @@ func (s *HTTP2Server) setupRoutes() {
 	// Middleware
 	r.Use(otelsetup.HTTPMiddleware("predastore"))
 	r.Use(s3SpanMiddleware)
-	if !s.config.DisableLogging {
+	// chi's access log duplicates the APM transaction from HTTPMiddleware and
+	// is a synchronous per-request write on the hot path; only enable it for
+	// explicit debug sessions.
+	if s.config.Debug {
 		r.Use(middleware.Logger)
 	}
 	r.Use(middleware.Recoverer)


### PR DESCRIPTION
## Summary

predastore is by far the noisiest service in the ES/OTLP sink — the `apm.app.predastore` dataset holds ~110M docs (vs ~14.5M for `spinifex_daemon`). Root cause: the slog→OTLP bridge has **no level gate**.

`SetDefaultJSONLogger(level)` wraps only the stdout handler at `Level: level`; the `otelslog` bridge is added raw to the fanout. `fanoutHandler.Handle` gates each handler by its own `Enabled()`, but the bridge's `Enabled()` delegates to the OTel SDK `BatchProcessor`, which returns `true` for every level. Net effects:

1. Every `slog.Debug` on the S3 hot path (~20-30 lines per PutObject via RS shard/stream fan-out) ships to ES regardless of the configured INFO threshold.
2. Because `fanoutHandler.Enabled` returns true if *any* handler is enabled, `slog.Logger` never short-circuits Debug calls at the call site — per-request CPU/alloc cost on the hot path (record build + clone + bridge conversion).

## Changes

- **`otelsetup/slog.go`** — new `levelHandler` wrapper; wrap the bridge in `newLevelHandler(level, bridge)` before fanout. Both sinks now genuinely share the level. With Debug gated off, `slog.Logger` short-circuits Debug calls (no record build, no write, no export) → fixes both ES volume and the handler-side hot-path cost.
- **`s3/httpserver.go`** — move chi's `middleware.Logger` behind `s.config.Debug`. It emits one synchronous stdlib-log line per S3 request (a hot-path serialization point) and duplicates the APM transaction already produced by `HTTPMiddleware` + `s3SpanMiddleware`.

## Test

- `GOWORK=off go build ./...` + `go vet ./otelsetup/... ./s3/...` pass
- `gofmt -l` clean on both files
- `go test ./otelsetup/...` and `./s3/...` pass

## Context

Found investigating why the storage layer produces ~100x the orchestrator's log volume. A companion mulga-side change de-dupes the parallel journald→OTLP replay (`apm.app.spinifex_*` datasets); this PR fixes the dominant direct-bridge flood.