### PR TITLE
fix(obs): sanitize OTLP log records to valid UTF-8 before export

### DIFF
--- a/otelsetup/logsanitize.go
+++ b/otelsetup/logsanitize.go
@@ -1,0 +1,130 @@
+package otelsetup
+
+import (
+	"context"
+	"strings"
+	"unicode/utf8"
+
+	"go.opentelemetry.io/otel/log"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+)
+
+// replacementRune substitutes each maximal run of invalid UTF-8 bytes.
+const replacementRune = "�"
+
+var _ sdklog.Processor = (*utf8Processor)(nil)
+
+// utf8Processor coerces every string field of a log record (body, attribute
+// keys, attribute values, recursively through slices and maps) to valid UTF-8
+// before delegating to next. OTLP marshals these as protobuf `string` fields,
+// which reject invalid UTF-8 and fail the whole export batch — dropping every
+// co-batched record. Peer-supplied QUIC CONNECTION_CLOSE/RESET_STREAM reason
+// phrases (not UTF-8 mandated) reach here via `err.Error()` on shard-put logs;
+// sanitising at the processor defends the pipeline regardless of call site.
+type utf8Processor struct {
+	next sdklog.Processor
+}
+
+// newUTF8Processor wraps next so records are UTF-8-sanitised before it runs.
+func newUTF8Processor(next sdklog.Processor) sdklog.Processor {
+	return &utf8Processor{next: next}
+}
+
+func (p *utf8Processor) OnEmit(ctx context.Context, record *sdklog.Record) error {
+	if v, changed := sanitizeValue(record.Body()); changed {
+		record.SetBody(v)
+	}
+
+	var dirty bool
+	record.WalkAttributes(func(kv log.KeyValue) bool {
+		if !utf8.ValidString(kv.Key) {
+			dirty = true
+			return false
+		}
+		if _, changed := sanitizeValue(kv.Value); changed {
+			dirty = true
+			return false
+		}
+		return true
+	})
+	if dirty {
+		attrs := make([]log.KeyValue, 0, record.AttributesLen())
+		record.WalkAttributes(func(kv log.KeyValue) bool {
+			v, _ := sanitizeValue(kv.Value)
+			attrs = append(attrs, log.KeyValue{Key: sanitizeString(kv.Key), Value: v})
+			return true
+		})
+		record.SetAttributes(attrs...)
+	}
+
+	return p.next.OnEmit(ctx, record)
+}
+
+func (p *utf8Processor) Enabled(ctx context.Context, param sdklog.EnabledParameters) bool {
+	return p.next.Enabled(ctx, param)
+}
+
+func (p *utf8Processor) Shutdown(ctx context.Context) error {
+	return p.next.Shutdown(ctx)
+}
+
+func (p *utf8Processor) ForceFlush(ctx context.Context) error {
+	return p.next.ForceFlush(ctx)
+}
+
+// sanitizeString returns s with each run of invalid UTF-8 replaced. Valid
+// strings are returned unchanged with no allocation (the common hot path).
+func sanitizeString(s string) string {
+	if utf8.ValidString(s) {
+		return s
+	}
+	return strings.ToValidUTF8(s, replacementRune)
+}
+
+// sanitizeValue recurses through string, slice, and map values, returning the
+// sanitised value and whether anything changed. Non-string scalars (bool, int,
+// float, bytes) pass through untouched — bytes marshal as a protobuf `bytes`
+// field, which permits arbitrary octets.
+func sanitizeValue(v log.Value) (log.Value, bool) {
+	switch v.Kind() {
+	case log.KindString:
+		s := v.AsString()
+		if utf8.ValidString(s) {
+			return v, false
+		}
+		return log.StringValue(strings.ToValidUTF8(s, replacementRune)), true
+	case log.KindSlice:
+		elems := v.AsSlice()
+		var changed bool
+		out := make([]log.Value, len(elems))
+		for i, e := range elems {
+			sv, c := sanitizeValue(e)
+			out[i] = sv
+			changed = changed || c
+		}
+		if !changed {
+			return v, false
+		}
+		return log.SliceValue(out...), true
+	case log.KindMap:
+		kvs := v.AsMap()
+		var changed bool
+		out := make([]log.KeyValue, len(kvs))
+		for i, kv := range kvs {
+			sv, c := sanitizeValue(kv.Value)
+			key := kv.Key
+			if !utf8.ValidString(key) {
+				key = strings.ToValidUTF8(key, replacementRune)
+				c = true
+			}
+			out[i] = log.KeyValue{Key: key, Value: sv}
+			changed = changed || c
+		}
+		if !changed {
+			return v, false
+		}
+		return log.MapValue(out...), true
+	default:
+		return v, false
+	}
+}

--- a/otelsetup/logsanitize_test.go
+++ b/otelsetup/logsanitize_test.go
@@ -1,0 +1,158 @@
+package otelsetup
+
+import (
+	"context"
+	"testing"
+	"unicode/utf8"
+
+	"go.opentelemetry.io/otel/log"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+)
+
+// rawReason mimics a peer-supplied QUIC CONNECTION_CLOSE reason phrase carrying
+// bytes that are not valid UTF-8, as surfaced through err.Error() on the
+// shard-put path.
+const rawReason = "reset by peer: \xff\xfe\x80 shard"
+
+// assertAllStringsValid walks a record's body and attributes and fails if any
+// string field would be rejected by protobuf UTF-8 marshaling.
+func assertAllStringsValid(t *testing.T, rec sdklog.Record) {
+	t.Helper()
+	assertValueValid(t, rec.Body())
+	rec.WalkAttributes(func(kv log.KeyValue) bool {
+		if !utf8.ValidString(kv.Key) {
+			t.Errorf("attribute key not valid UTF-8: %q", kv.Key)
+		}
+		assertValueValid(t, kv.Value)
+		return true
+	})
+}
+
+func assertValueValid(t *testing.T, v log.Value) {
+	t.Helper()
+	switch v.Kind() {
+	case log.KindString:
+		if !utf8.ValidString(v.AsString()) {
+			t.Errorf("string value not valid UTF-8: %q", v.AsString())
+		}
+	case log.KindSlice:
+		for _, e := range v.AsSlice() {
+			assertValueValid(t, e)
+		}
+	case log.KindMap:
+		for _, kv := range v.AsMap() {
+			if !utf8.ValidString(kv.Key) {
+				t.Errorf("map key not valid UTF-8: %q", kv.Key)
+			}
+			assertValueValid(t, kv.Value)
+		}
+	}
+}
+
+// TestUTF8ProcessorSanitizesPoisonedBatch is the regression guard for
+// mulga-lo5a6: a record carrying a non-UTF-8 attribute must be exported with
+// the bytes replaced, AND a valid record co-emitted through the same processor
+// must survive intact — proving one poisoned record no longer fails the batch
+// and drops its neighbours.
+func TestUTF8ProcessorSanitizesPoisonedBatch(t *testing.T) {
+	exp := &recordingLogExporter{}
+	lp := sdklog.NewLoggerProvider(
+		sdklog.WithProcessor(newUTF8Processor(sdklog.NewSimpleProcessor(exp))),
+	)
+	defer func() { _ = lp.Shutdown(context.Background()) }()
+
+	logger := lp.Logger("test")
+
+	var poisoned log.Record
+	poisoned.SetBody(log.StringValue("handlePUTShard: append failed"))
+	poisoned.AddAttributes(log.String("error", rawReason))
+	logger.Emit(context.Background(), poisoned)
+
+	var valid log.Record
+	valid.SetBody(log.StringValue("healthy record"))
+	valid.AddAttributes(log.String("bucket", "images"))
+	logger.Emit(context.Background(), valid)
+
+	records := exp.snapshot()
+	if len(records) != 2 {
+		t.Fatalf("got %d exported records, want 2 (valid record must survive a poisoned co-batch)", len(records))
+	}
+
+	for _, rec := range records {
+		assertAllStringsValid(t, rec)
+	}
+
+	// The poisoned attribute keeps its non-invalid prefix/suffix; only the bad
+	// bytes become the replacement rune.
+	gotErr := attrString(records[0], "error")
+	if utf8.ValidString(gotErr) == false || gotErr == rawReason {
+		t.Errorf("poisoned error attr not sanitised: %q", gotErr)
+	}
+	if !containsReplacement(gotErr) {
+		t.Errorf("expected replacement rune in sanitised error, got %q", gotErr)
+	}
+
+	// The valid record must be byte-for-byte unchanged.
+	if got := attrString(records[1], "bucket"); got != "images" {
+		t.Errorf("valid record mutated: bucket = %q, want images", got)
+	}
+}
+
+// TestSanitizeValueLeavesValidUnchanged proves the hot path returns the same
+// value (no allocation, identity preserved) when everything is already valid,
+// including nested slices and maps.
+func TestSanitizeValueLeavesValidUnchanged(t *testing.T) {
+	cases := []log.Value{
+		log.StringValue("plain ascii"),
+		log.StringValue("valid utf-8: café €"),
+		log.Int64Value(42),
+		log.BoolValue(true),
+		log.BytesValue([]byte{0xff, 0xfe}), // raw bytes marshal as protobuf bytes, untouched
+		log.SliceValue(log.StringValue("a"), log.Int64Value(1)),
+		log.MapValue(log.String("k", "v"), log.Int64("n", 2)),
+	}
+	for _, v := range cases {
+		got, changed := sanitizeValue(v)
+		if changed {
+			t.Errorf("sanitizeValue(%v) reported changed, want unchanged", v)
+		}
+		if !got.Equal(v) {
+			t.Errorf("sanitizeValue(%v) = %v, want identical", v, got)
+		}
+	}
+}
+
+// TestSanitizeValueRecursesNested proves invalid bytes nested inside slices and
+// maps are fixed, not just top-level string attributes.
+func TestSanitizeValueRecursesNested(t *testing.T) {
+	nested := log.MapValue(
+		log.String("reason", rawReason),
+		log.Slice("frames", log.StringValue("ok"), log.StringValue("bad\xffbyte")),
+	)
+	got, changed := sanitizeValue(nested)
+	if !changed {
+		t.Fatal("sanitizeValue reported unchanged for nested invalid UTF-8")
+	}
+	assertValueValid(t, got)
+}
+
+func attrString(rec sdklog.Record, key string) string {
+	var out string
+	rec.WalkAttributes(func(kv log.KeyValue) bool {
+		if kv.Key == key {
+			out = kv.Value.AsString()
+			return false
+		}
+		return true
+	})
+	return out
+}
+
+func containsReplacement(s string) bool {
+	for _, r := range s {
+		if r == '�' {
+			return true
+		}
+	}
+	return false
+}

--- a/otelsetup/otelsetup.go
+++ b/otelsetup/otelsetup.go
@@ -85,7 +85,7 @@ func Init(ctx context.Context, serviceName string) (func(context.Context) error,
 	}
 	lp := sdklog.NewLoggerProvider(
 		sdklog.WithResource(res),
-		sdklog.WithProcessor(sdklog.NewBatchProcessor(logExp)),
+		sdklog.WithProcessor(newUTF8Processor(sdklog.NewBatchProcessor(logExp))),
 	)
 	loggerglobal.SetLoggerProvider(lp)
 


### PR DESCRIPTION
## Problem

predastore's OTLP log export batch fails protobuf marshal with `string field contains invalid UTF-8`, dropping the whole batch (`grpc: error while marshaling`). Recurring ~1/sec across 30+ CI runs and live `wattle`.

**Root cause:** QUIC shard-put path logs `slog.Error(..., "error", err)` where `err` wraps a quic-go transport error carrying the peer's CONNECTION_CLOSE/RESET_STREAM reason phrase verbatim. QUIC reason phrases are not UTF-8-mandated. mulga-7bu04's slog→OTLP bridge turns that into an OTLP LogRecord string attribute → protobuf marshal rejects it → **entire batch dropped**, silently losing every co-batched record.

**Proven silent loss (ES, mulga-obs, 14d):** OTLP predastore dataset had **0** ERROR-severity records vs **6787** in the journald copy; `shard distribution failed` / `put failed` absent from OTLP entirely.

## Fix

Add `utf8Processor` in `otelsetup`, wrapping the batch processor. `OnEmit` coerces every log-record string field (body, attribute keys/values, recursing through slices and maps) to valid UTF-8 via `strings.ToValidUTF8` before export, then delegates. Valid strings pass through with **no allocation** (`utf8.ValidString` fast path). Non-string scalars incl. `bytes` untouched (protobuf `bytes` permits arbitrary octets).

Processor-layer defence over per-call-site scrubbing: protects the whole pipeline regardless of emitter, and restores batch integrity — a poisoned record is repaired, never dropped. No new deps.

## Testing

- Poisoned-batch regression: non-UTF-8 `error` attr exported sanitised; co-emitted valid record survives byte-for-byte (no batch drop).
- Hot-path identity: valid strings/ints/bools/bytes/nested slices+maps pass through unchanged.
- Nested recursion: invalid bytes inside slice/map values repaired.
- `go test -race ./otelsetup/`, `go vet`, `golangci-lint` clean.

Bead: mulga-lo5a6