### PR TITLE
fix: accept us-east-1 credential scope for S3 ListBuckets

### DIFF
--- a/pkg/sigv4/verify.go
+++ b/pkg/sigv4/verify.go
@@ -10,8 +10,9 @@ import (
 )
 
 // Verify checks the request signature under secretAccessKey and confirms the credential
-// scope's region and service match the endpoint's expected values, returning a
-// VerifiedRequest when the request is authentic.
+// scope's region and service match region and service, returning a VerifiedRequest when
+// the request is authentic. region is the region the caller requires the client to have
+// signed with, which is not necessarily the endpoint's own.
 func (req *SignedRequest) Verify(secretAccessKey, region, service string) (*VerifiedRequest, error) {
 	// Ensure client region and service match the caller's expected values.
 	if req.Credential.Region != region {

--- a/s3/httpserver.go
+++ b/s3/httpserver.go
@@ -26,6 +26,10 @@ import (
 	"github.com/mulgadc/predastore/ratelimit"
 )
 
+// globalSigningRegion is the region clients sign S3's global operations against,
+// independent of the region they are configured for or the endpoint they target.
+const globalSigningRegion = "us-east-1"
+
 // HTTP2Server is an HTTP/2 compatible S3 server using net/http
 type HTTP2Server struct {
 	config    *Config
@@ -158,7 +162,17 @@ func (s *HTTP2Server) sigV4AuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		if _, err := sig.Verify(credResult.SecretAccessKey, s.config.Region, "s3"); err != nil {
+		// Regional operations must carry the endpoint's own region, as AWS enforces.
+		expectedRegion := s.config.Region
+
+		// ListBuckets is the only global operation served here, and clients sign it against
+		// us-east-1 whatever region they are configured for. Some SDKs sign it with the
+		// configured region instead, so accept either rather than pinning to us-east-1.
+		if bucket, _ := parseS3Path(path); bucket == "" && sig.Credential.Region == globalSigningRegion {
+			expectedRegion = globalSigningRegion
+		}
+
+		if _, err := sig.Verify(credResult.SecretAccessKey, expectedRegion, "s3"); err != nil {
 			s.respondSigV4Error(w, r, accessKey, err, nil)
 			return
 		}


### PR DESCRIPTION
Clients sign S3's global operations against us-east-1 whatever region they are configured for, so ListBuckets against an endpoint serving another region failed the SigV4 credential-scope check and surfaced to the client as SignatureDoesNotMatch.

Select the expected region at the S3 verify call rather than relaxing the check in sigv4: regional operations stay pinned to the endpoint's region as AWS enforces, while ListBuckets accepts either us-east-1 or the endpoint's own region, since some SDKs sign it with the configured region.