### PR TITLE
refactor: drop per-op DEBUG traces from the read/write hot path

### DIFF
--- a/backend/distributed/distributed.go
+++ b/backend/distributed/distributed.go
@@ -3,9 +3,7 @@ package distributed
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/gob"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -300,8 +298,6 @@ func (b *Backend) GlobalState() GlobalState {
 
 // putObjectViaQUIC splits a file into RS shards and sends each to the appropriate node via QUIC.
 func (b *Backend) putObjectViaQUIC(ctx context.Context, bucket string, objectPath string, objectHash [32]byte) (size int64, err error) {
-	slog.Debug("putObjectViaQUIC: starting", "bucket", bucket, "objectPath", objectPath)
-
 	enc, err := reedsolomon.NewStream(b.rsDataShard, b.rsParityShard)
 	if err != nil {
 		return 0, err
@@ -319,7 +315,6 @@ func (b *Backend) putObjectViaQUIC(ctx context.Context, bucket string, objectPat
 	}
 
 	size = instat.Size()
-	slog.Debug("putObjectViaQUIC: file size", "size", size)
 
 	// Use objectHash for hash ring placement for consistency with storage and retrieval
 	hashRingShards, err := b.hashRing.GetClosestN(objectHash[:], b.rsDataShard+b.rsParityShard)
@@ -405,8 +400,6 @@ func (b *Backend) putObjectViaQUIC(ctx context.Context, bucket string, objectPat
 	// Step 3: Encode parity shards using the buffered data shards
 	dataReaders := make([]io.Reader, b.rsDataShard)
 	for i := 0; i < b.rsDataShard; i++ {
-		shardHash := sha256.Sum256(dataShardBuffers[i])
-		slog.Debug("parity encoding: data shard", "shard", i, "len", len(dataShardBuffers[i]), "sha256", hex.EncodeToString(shardHash[:4]))
 		dataReaders[i] = bytes.NewReader(dataShardBuffers[i])
 	}
 
@@ -488,7 +481,6 @@ func (b *Backend) putObjectViaQUIC(ctx context.Context, bucket string, objectPat
 		return 0, firstErr
 	}
 
-	slog.Debug("putObjectViaQUIC: completed successfully", "size", size)
 	return size, nil
 }
 

--- a/backend/distributed/get.go
+++ b/backend/distributed/get.go
@@ -78,18 +78,6 @@ func (b *Backend) handleRangeRequest(ctx context.Context, req *backend.GetObject
 		endShardIdx = b.rsDataShard - 1
 	}
 
-	slog.Debug("Range request",
-		"bucket", req.Bucket,
-		"key", req.Key,
-		"start", start,
-		"end", end,
-		"totalSize", totalSize,
-		"shardSize", shardSize,
-		"startShard", startShardIdx,
-		"endShard", endShardIdx,
-		"rsDataShard", b.rsDataShard,
-	)
-
 	// Optimization: if range is within a single shard, fetch just that shard portion
 	if startShardIdx == endShardIdx {
 		data, err := b.readRangeFromSingleShard(ctx, req.Bucket, req.Key, shards, startShardIdx, start, end, shardSize, totalSize)
@@ -140,13 +128,6 @@ func (b *Backend) readRangeFromSingleShard(ctx context.Context, bucket, key stri
 	if endInShard >= actualShardSize {
 		endInShard = actualShardSize - 1
 	}
-
-	slog.Debug("Reading from single shard",
-		"shardIdx", shardIdx,
-		"offsetInShard", offsetInShard,
-		"endInShard", endInShard,
-		"actualShardSize", actualShardSize,
-	)
 
 	// Request the specific range from the shard via QUIC
 	nodeNum := int(shards.DataShardNodes[shardIdx])

--- a/backend/distributed/put.go
+++ b/backend/distributed/put.go
@@ -19,8 +19,6 @@ const arnObjectPrefixPut = "arn:aws:s3:::"
 
 // PutObject stores an object using Reed-Solomon encoding across multiple nodes
 func (b *Backend) PutObject(ctx context.Context, req *backend.PutObjectRequest) (*backend.PutObjectResponse, error) {
-	slog.Debug("distributed.PutObject: starting", "bucket", req.Bucket, "key", req.Key)
-
 	if req.Bucket == "" {
 		return nil, backend.ErrNoSuchBucketError.WithResource(req.Bucket)
 	}
@@ -54,7 +52,6 @@ func (b *Backend) PutObject(ctx context.Context, req *backend.PutObjectRequest) 
 		if req.IsChunked && req.ContentEncoding == "aws-chunked" {
 			reader = chunked.NewDecoder(req.Body, req.DecodedLength)
 		}
-		slog.Debug("distributed.PutObject: copying body to temp file")
 		_, err = io.Copy(tmpFile, reader)
 		if err != nil {
 			slog.Error("distributed.PutObject: copy to temp file failed", "error", err)
@@ -64,7 +61,6 @@ func (b *Backend) PutObject(ctx context.Context, req *backend.PutObjectRequest) 
 	if closeErr := tmpFile.Close(); closeErr != nil {
 		slog.Debug("Failed to close temp file", "path", tmpFile.Name(), "error", closeErr)
 	}
-	slog.Debug("distributed.PutObject: temp file created", "path", tmpFile.Name())
 
 	var size int64
 	size, err = b.putObjectViaQUIC(ctx, req.Bucket, tmpFile.Name(), objectHash)
@@ -72,7 +68,6 @@ func (b *Backend) PutObject(ctx context.Context, req *backend.PutObjectRequest) 
 		slog.Error("distributed.PutObject: shard distribution failed", "error", err)
 		return nil, backend.NewS3Error(backend.ErrInternalError, err.Error(), 500)
 	}
-	slog.Debug("distributed.PutObject: shards distributed", "size", size)
 
 	objectToShardNodes.Size = size
 

--- a/quic/quicclient/pool.go
+++ b/quic/quicclient/pool.go
@@ -90,9 +90,7 @@ func (p *Pool) Get(ctx context.Context, addr string) (*Client, error) {
 			// Connection exists and is still open
 			pc.lastUsed = time.Now()
 			pc.useCount++
-			useCount := pc.useCount
 			pc.mu.Unlock()
-			slog.Debug("Pool.Get: reusing connection", "addr", addr, "useCount", useCount)
 			return pc.client, nil
 		}
 		pc.mu.Unlock()

--- a/quic/quicclient/quicclient.go
+++ b/quic/quicclient/quicclient.go
@@ -71,12 +71,6 @@ func (c *Client) nextID() uint64 {
 
 // Put sends a shard to the QUIC server and returns the WriteResult
 func (c *Client) Put(ctx context.Context, putReq quicserver.PutRequest, shardData io.Reader) (*quicserver.PutResponse, error) {
-	slog.Debug("QUIC Put starting",
-		"bucket", putReq.Bucket,
-		"shardIndex", putReq.ShardIndex,
-		"shardSize", putReq.ShardSize,
-	)
-
 	putReqBytes, err := json.Marshal(putReq)
 	if err != nil {
 		return nil, fmt.Errorf("marshal put request: %w", err)
@@ -92,12 +86,6 @@ func (c *Client) Put(ctx context.Context, putReq quicserver.PutRequest, shardDat
 		return nil, fmt.Errorf("put request failed: %w", err)
 	}
 
-	slog.Debug("QUIC Put doPut completed",
-		"bucket", putReq.Bucket,
-		"shardIndex", putReq.ShardIndex,
-		"status", rh.Status,
-	)
-
 	if rh.Status != quicproto.StatusOK {
 		return nil, fmt.Errorf("put: status %d", rh.Status)
 	}
@@ -111,18 +99,11 @@ func (c *Client) Put(ctx context.Context, putReq quicserver.PutRequest, shardDat
 		return nil, fmt.Errorf("put error: %s", response.Error)
 	}
 
-	slog.Debug("QUIC Put completed successfully",
-		"bucket", putReq.Bucket,
-		"shardIndex", putReq.ShardIndex,
-		"shardSize", response.ShardSize,
-	)
-
 	return &response, nil
 }
 
 // doPut performs a PUT RPC with body streaming
 func (c *Client) doPut(ctx context.Context, requestBytes []byte, body io.Reader, bodyLen int64) (quicproto.Header, []byte, error) {
-	slog.Debug("doPut: opening stream")
 	s, err := c.conn.OpenStreamSync(ctx)
 	if err != nil {
 		slog.Error("doPut: failed to open stream", "error", err)
@@ -130,7 +111,6 @@ func (c *Client) doPut(ctx context.Context, requestBytes []byte, body io.Reader,
 	}
 	c.incActive()
 	defer c.decActive()
-	slog.Debug("doPut: stream opened", "streamID", s.StreamID())
 
 	br := bufio.NewReaderSize(s, 128*1024)
 	bw := bufio.NewWriterSize(s, 128*1024)
@@ -165,14 +145,12 @@ func (c *Client) doPut(ctx context.Context, requestBytes []byte, body io.Reader,
 	}
 
 	// Stream the body data
-	slog.Debug("doPut: streaming body", "bodyLen", bodyLen)
 	written, err := io.CopyN(bw, body, bodyLen)
 	if err != nil {
 		slog.Error("doPut: body write failed", "written", written, "bodyLen", bodyLen, "error", err)
 		_ = s.Close()
 		return quicproto.Header{}, nil, fmt.Errorf("write body: %w (wrote %d of %d)", err, written, bodyLen)
 	}
-	slog.Debug("doPut: body written", "written", written)
 
 	// Flush the body
 	if err := bw.Flush(); err != nil {
@@ -180,7 +158,6 @@ func (c *Client) doPut(ctx context.Context, requestBytes []byte, body io.Reader,
 		_ = s.Close()
 		return quicproto.Header{}, nil, fmt.Errorf("flush body: %w", err)
 	}
-	slog.Debug("doPut: body flushed, waiting for response")
 
 	// Read response header
 	respHdr, err := quicproto.ReadHeader(br)
@@ -189,7 +166,6 @@ func (c *Client) doPut(ctx context.Context, requestBytes []byte, body io.Reader,
 		_ = s.Close()
 		return quicproto.Header{}, nil, fmt.Errorf("read response header: %w", err)
 	}
-	slog.Debug("doPut: response header received", "status", respHdr.Status, "metaLen", respHdr.MetaLen)
 
 	// Read response metadata
 	var respMeta []byte
@@ -207,7 +183,6 @@ func (c *Client) doPut(ctx context.Context, requestBytes []byte, body io.Reader,
 	// Both are needed for the stream to be fully released in QUIC.
 	s.CancelRead(0)
 	_ = s.Close()
-	slog.Debug("doPut: stream closed", "streamID", s.StreamID())
 	return respHdr, respMeta, nil
 }
 

--- a/quic/quicserver/get.go
+++ b/quic/quicserver/get.go
@@ -71,23 +71,8 @@ func (qs *QuicServer) handleGET(bw *bufio.Writer, req quicproto.Header, objectRe
 		src = io.NewSectionReader(reader, 0, totalSize)
 	}
 
-	bytesWritten, err := io.Copy(bw, src)
-	if err != nil {
+	if _, err := io.Copy(bw, src); err != nil {
 		slog.Error("handleGET: streaming failed", "error", err)
 		return
-	}
-
-	if isRangeRequest {
-		slog.Debug("handleGET: range request completed",
-			"bucket", objectRequest.Bucket,
-			"object", objectRequest.Object,
-			"rangeStart", rangeStart,
-			"rangeEnd", rangeEnd,
-			"bytesWritten", bytesWritten)
-	} else {
-		slog.Debug("handleGET: completed",
-			"bucket", objectRequest.Bucket,
-			"object", objectRequest.Object,
-			"bytes", bytesWritten)
 	}
 }

--- a/quic/quicserver/put.go
+++ b/quic/quicserver/put.go
@@ -14,13 +14,6 @@ import (
 // Append reserves slots under a short lock, then the caller streams directly
 // from the QUIC stream lock-free — no pre-buffer needed.
 func (qs *QuicServer) handlePUTShard(br *bufio.Reader, bw *bufio.Writer, req quicproto.Header, putReq PutRequest) {
-	slog.Debug("handlePUTShard: starting",
-		"bucket", putReq.Bucket,
-		"shardIndex", putReq.ShardIndex,
-		"shardSize", putReq.ShardSize,
-		"bodyLen", req.BodyLen,
-	)
-
 	// Determine how many bytes to read
 	var bodyLen int64
 	if req.BodyLen > 0 {
@@ -51,13 +44,6 @@ func (qs *QuicServer) handlePUTShard(br *bufio.Reader, bw *bufio.Writer, req qui
 		return
 	}
 
-	slog.Debug("handlePUTShard: stored shard",
-		"bucket", putReq.Bucket,
-		"object", putReq.Object,
-		"shardIndex", putReq.ShardIndex,
-		"size", bodyLen,
-	)
-
 	response := PutResponse{ShardSize: bodyLen}
 	respBytes, err := json.Marshal(response)
 	if err != nil {
@@ -86,9 +72,4 @@ func (qs *QuicServer) handlePUTShard(br *bufio.Reader, bw *bufio.Writer, req qui
 		slog.Error("handlePUTShard: flush failed", "error", err)
 		return
 	}
-
-	slog.Debug("handlePUTShard: response sent",
-		"bucket", putReq.Bucket,
-		"shardIndex", putReq.ShardIndex,
-	)
 }

--- a/quic/quicserver/server.go
+++ b/quic/quicserver/server.go
@@ -314,9 +314,8 @@ func (qs *QuicServer) serveConn(conn *quic.Conn) {
 }
 
 func (qs *QuicServer) handleStream(s *quic.Stream) {
-	activeCount := qs.activeStreams.Add(1)
+	qs.activeStreams.Add(1)
 	streamID := s.StreamID()
-	slog.Debug("handleStream: started", "streamID", streamID, "activeStreams", activeCount)
 
 	defer func() {
 		// Close both sides of the stream to fully release it.
@@ -328,13 +327,8 @@ func (qs *QuicServer) handleStream(s *quic.Stream) {
 		if err := s.Close(); err != nil {
 			slog.Debug("handleStream: close error", "streamID", streamID, "error", err)
 		}
-		finalCount := qs.activeStreams.Add(-1)
-		slog.Debug("handleStream: closed", "streamID", streamID, "activeStreams", finalCount)
+		qs.activeStreams.Add(-1)
 	}()
-
-	if activeCount%100 == 0 || activeCount > 50 {
-		slog.Debug("handleStream: active streams high", "count", activeCount, "streamID", streamID)
-	}
 
 	br := bufio.NewReaderSize(s, 128*1024)
 	bw := bufio.NewWriterSize(s, 128*1024)


### PR DESCRIPTION
The per-op slog.Debug traces on the QUIC read/write path cost work on every request regardless of configured log level. slog.Debug builds its variadic ...any slice, boxing ints, at the call site before slog checks whether Debug is enabled, so running at INFO does not make these free.

The parity encoder was the worst case: it computed a full SHA-256 over every data shard purely to feed a Debug log line, on every PutObject. crypto/sha256 and encoding/hex were imported for that log and nothing else.

Remove the happy-path per-op traces from Pool.Get, handleStream, handlePUTShard, handleGET, doPut, Put, PutObject, putObjectViaQUIC and the range-read path. Failure-path Debug logging is left intact: it only allocates when something has already gone wrong, and it is what makes these paths diagnosable. Connection-lifecycle traces in the pool are kept for the same reason — they fire per connection, not per request.