### PR TITLE
fix: tombstone extents superseded by an overwrite

### DIFF
--- a/store/compaction.go
+++ b/store/compaction.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -202,6 +203,11 @@ func (store *Store) compactSegment(num uint64) (segmentStats, error) {
 // reserved slot in the active append segment, then compare-and-swaps the index
 // onto the new slot. Verbatim is load-bearing: fragNum rides along inside the
 // copied bytes, so the GCM nonce is preserved and never reused.
+//
+// The copy runs without store.mutex so it never stalls the write path, which
+// leaves room for a concurrent overwrite or delete of the same key to land
+// first and win the slot. The swap resolves that race and accounts for the
+// copy either way.
 func (store *Store) relocateExtent(key []byte, old extent) error {
 	fragCount := uint64(old.PSize / totalFragSize) //nolint:gosec // PSize is a non-negative multiple of totalFragSize.
 
@@ -243,10 +249,45 @@ func (store *Store) relocateExtent(key []byte, old extent) error {
 		return fmt.Errorf("sync destination idx: %w", err)
 	}
 
-	if _, err := store.casExtent(key, old, newExt); err != nil {
-		return fmt.Errorf("commit relocation: %w", err)
+	// Swap the index onto the new slot, but only if the key still points at the
+	// one we copied from — an overwrite or delete may have landed while we copied
+	// without the mutex. Losing that race strands the copy: only this swap could
+	// ever have referenced it, and slots are never reissued, so it is dead the
+	// moment the swap fails. Tombstone it in the same transaction, or those bytes
+	// pad their segment's live count and mask it from a later compaction.
+	for {
+		err := store.index.Badger.Update(func(txn *badger.Txn) error {
+			stale := false
+			item, err := txn.Get(key)
+			switch {
+			case errors.Is(err, badger.ErrKeyNotFound):
+				stale = true
+			case err != nil:
+				return err
+			default:
+				cur, err := item.ValueCopy(nil)
+				if err != nil {
+					return err
+				}
+				stale = !bytes.Equal(cur, old.encode())
+			}
+
+			if stale {
+				return txn.Set(tombstoneKey(newExt.SegNum, newExt.Off), tombstoneValue(newExt.PSize))
+			}
+			return txn.Set(key, newExt.encode())
+		})
+
+		// Reading the key before writing it puts this txn under badger's conflict
+		// detection, which a concurrent commit on the same key trips.
+		if errors.Is(err, badger.ErrConflict) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("commit relocation: %w", err)
+		}
+		return nil
 	}
-	return nil
 }
 
 // copyExtent streams size bytes from src@srcOff to dst@dstOff via disjoint

--- a/store/compaction.go
+++ b/store/compaction.go
@@ -154,10 +154,8 @@ type segmentStats struct {
 	bytes   int64
 }
 
-// compactSegment relocates every live extent the segment holds into the active
-// append segment, then drops the drained segment and clears its tombstones. An
-// extent enumerated from .idx is live only if the index still points at this
-// exact slot; anything deleted or superseded is skipped.
+// compactSegment relocates a segment's live extents into the active append
+// segment, then drops it and clears its tombstones.
 func (store *Store) compactSegment(num uint64) (segmentStats, error) {
 	var stats segmentStats
 
@@ -179,6 +177,8 @@ func (store *Store) compactSegment(num uint64) (segmentStats, error) {
 		if err != nil {
 			return stats, fmt.Errorf("decode extent: %w", err)
 		}
+		// A .idx row is only live if the index still points at this exact slot;
+		// anything deleted or superseded is already dead.
 		if cur.SegNum != num || cur.Off != e.Off {
 			continue
 		}
@@ -199,15 +199,9 @@ func (store *Store) compactSegment(num uint64) (segmentStats, error) {
 	return stats, store.deleteTombstones(num)
 }
 
-// relocateExtent copies an extent's raw fragment bytes verbatim into a freshly
-// reserved slot in the active append segment, then compare-and-swaps the index
-// onto the new slot. Verbatim is load-bearing: fragNum rides along inside the
-// copied bytes, so the GCM nonce is preserved and never reused.
-//
-// The copy runs without store.mutex so it never stalls the write path, which
-// leaves room for a concurrent overwrite or delete of the same key to land
-// first and win the slot. The swap resolves that race and accounts for the
-// copy either way.
+// relocateExtent moves an extent into the active append segment and repoints
+// the index at it, unless a concurrent overwrite or delete of the same key gets
+// there first.
 func (store *Store) relocateExtent(key []byte, old extent) error {
 	fragCount := uint64(old.PSize / totalFragSize) //nolint:gosec // PSize is a non-negative multiple of totalFragSize.
 
@@ -234,11 +228,15 @@ func (store *Store) relocateExtent(key []byte, old extent) error {
 		store.mutex.Unlock()
 		return fmt.Errorf("append destination idx: %w", err)
 	}
+	// Copy without the mutex so compaction never stalls the write path. This is
+	// the window a racing overwrite or delete lands in.
 	store.mutex.Unlock()
 
 	defer srcSeg.releaseRef()
 	defer dstSeg.releaseRef()
 
+	// Verbatim is load-bearing: fragNum rides inside the copied bytes, so the
+	// nonce moves with them and is never reissued.
 	if err := copyExtent(srcSeg, old.Off, dstSeg, dstOff, old.PSize); err != nil {
 		return fmt.Errorf("copy extent bytes: %w", err)
 	}
@@ -249,12 +247,7 @@ func (store *Store) relocateExtent(key []byte, old extent) error {
 		return fmt.Errorf("sync destination idx: %w", err)
 	}
 
-	// Swap the index onto the new slot, but only if the key still points at the
-	// one we copied from — an overwrite or delete may have landed while we copied
-	// without the mutex. Losing that race strands the copy: only this swap could
-	// ever have referenced it, and slots are never reissued, so it is dead the
-	// moment the swap fails. Tombstone it in the same transaction, or those bytes
-	// pad their segment's live count and mask it from a later compaction.
+	// Swap onto the new slot only if the key still holds the one we copied from.
 	for {
 		err := store.index.Badger.Update(func(txn *badger.Txn) error {
 			stale := false
@@ -272,14 +265,17 @@ func (store *Store) relocateExtent(key []byte, old extent) error {
 				stale = !bytes.Equal(cur, old.encode())
 			}
 
+			// Losing the race strands the copy for good — only this swap could have
+			// referenced it, and slots are never reissued — so tombstone it here
+			// rather than let it pad its segment's live count.
 			if stale {
 				return txn.Set(tombstoneKey(newExt.SegNum, newExt.Off), tombstoneValue(newExt.PSize))
 			}
 			return txn.Set(key, newExt.encode())
 		})
 
-		// Reading the key before writing it puts this txn under badger's conflict
-		// detection, which a concurrent commit on the same key trips.
+		// The read above puts this txn under badger's conflict detection, which a
+		// concurrent commit on the same key trips.
 		if errors.Is(err, badger.ErrConflict) {
 			continue
 		}

--- a/store/compaction_internal_test.go
+++ b/store/compaction_internal_test.go
@@ -211,6 +211,144 @@ func TestCandidateSelectionNeverSelectsActiveSegment(t *testing.T) {
 	}
 }
 
+// tombstones reads the whole slot-keyed tombstone namespace, mapping each
+// dead slot to the byte count it records.
+func tombstones(t *testing.T, st *Store) map[slot]int64 {
+	t.Helper()
+	found := map[slot]int64{}
+	err := st.index.Scan([]byte{tombstonePrefix}, func(k, v []byte) error {
+		s := slot{segNum: tombstoneSegNum(k), off: int64(binary.BigEndian.Uint64(k[9:17]))}
+		found[s] = int64(binary.BigEndian.Uint64(v))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan tombstones: %v", err)
+	}
+	return found
+}
+
+type slot struct {
+	segNum uint64
+	off    int64
+}
+
+func slotOf(ext extent) slot { return slot{segNum: ext.SegNum, off: ext.Off} }
+
+// An overwrite supersedes the key's previous extent, so those bytes are dead
+// the moment the new one commits and must carry a tombstone. The live slot
+// must not.
+func TestOverwriteTombstonesSupersededExtent(t *testing.T) {
+	st, _ := openTestStore(t, WithMaxSegSize(1*MiB))
+	oh := [32]byte{0x11}
+
+	putShard(t, st, oh, 0, bytes.Repeat([]byte{0xaa}, 12*KiB))
+	old := extentOf(t, st, oh, 0)
+
+	putShard(t, st, oh, 0, bytes.Repeat([]byte{0xbb}, 12*KiB))
+	cur := extentOf(t, st, oh, 0)
+
+	if slotOf(cur) == slotOf(old) {
+		t.Fatalf("overwrite reused slot %v; test cannot distinguish live from dead", slotOf(old))
+	}
+
+	found := tombstones(t, st)
+	if got, ok := found[slotOf(old)]; !ok {
+		t.Fatalf("superseded slot %v has no tombstone; it is invisible to compaction", slotOf(old))
+	} else if got != old.PSize {
+		t.Fatalf("tombstone for %v records %d bytes, want PSize %d", slotOf(old), got, old.PSize)
+	}
+	if _, ok := found[slotOf(cur)]; ok {
+		t.Fatalf("live slot %v was tombstoned", slotOf(cur))
+	}
+}
+
+// A first write supersedes nothing, so it must leave the tombstone namespace
+// untouched — a spurious tombstone would understate a segment's live bytes.
+func TestFirstWriteLeavesNoTombstone(t *testing.T) {
+	st, _ := openTestStore(t, WithMaxSegSize(1*MiB))
+	oh := [32]byte{0x22}
+
+	putShard(t, st, oh, 0, bytes.Repeat([]byte{0xcc}, 12*KiB))
+
+	if found := tombstones(t, st); len(found) != 0 {
+		t.Fatalf("first write produced %d tombstone(s): %v", len(found), found)
+	}
+}
+
+// Append only reserves space; the old extent stays live and readable until the
+// writer commits. The tombstone must land at commit and not one moment sooner,
+// or an abandoned write would permanently mark still-live bytes dead.
+func TestTombstoneLandsAtCommitNotAppend(t *testing.T) {
+	st, _ := openTestStore(t, WithMaxSegSize(1*MiB))
+	oh := [32]byte{0x33}
+	body := bytes.Repeat([]byte{0xdd}, 12*KiB)
+
+	putShard(t, st, oh, 0, body)
+	old := extentOf(t, st, oh, 0)
+
+	// Reserve and fill an overwrite, but hold it short of Close.
+	w, err := st.Append(oh, 0, int64(len(body)))
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if _, err := w.Write(bytes.Repeat([]byte{0xee}, 12*KiB)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if found := tombstones(t, st); len(found) != 0 {
+		t.Fatalf("uncommitted append produced %d tombstone(s): %v", len(found), found)
+	}
+	if got := extentOf(t, st, oh, 0); slotOf(got) != slotOf(old) {
+		t.Fatalf("uncommitted append moved the index off %v to %v", slotOf(old), slotOf(got))
+	}
+	if got := readShard(t, st, oh, 0); !bytes.Equal(got, body) {
+		t.Fatalf("uncommitted append changed the readable body")
+	}
+
+	// Committing is what supersedes the old extent — and it also releases the
+	// segment ref Append took, which store.Close waits on.
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	if _, ok := tombstones(t, st)[slotOf(old)]; !ok {
+		t.Fatalf("commit did not tombstone superseded slot %v", slotOf(old))
+	}
+}
+
+// The reclaim path this bug is about: a segment emptied purely by overwrite
+// churn (no Delete) must become a candidate and drain. Before the fix its dead
+// bytes carried no tombstone, so it read as fully live and was never selected.
+func TestOverwriteChurnDrainsSegment(t *testing.T) {
+	st, dir, oh := segment0LayoutStore(t)
+	body := bytes.Repeat([]byte{0x99}, 12*KiB)
+
+	// Shards 0 and 1 fill segment 0; rewriting both relocates them and leaves
+	// segment 0 entirely dead.
+	putShard(t, st, oh, 0, body)
+	putShard(t, st, oh, 1, body)
+
+	cands, err := st.candidateSegments()
+	if err != nil {
+		t.Fatalf("candidates: %v", err)
+	}
+	if len(cands) != 1 || cands[0] != 0 {
+		t.Fatalf("expected overwrite-dead segment 0 as sole candidate, got %v", cands)
+	}
+
+	if err := st.compactOnce(); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, fmt.Sprintf(segFilename, uint64(0)))); !os.IsNotExist(err) {
+		t.Fatalf("drained segment 0 still on disk: %v", err)
+	}
+	for _, idx := range []uint32{0, 1} {
+		if got := readShard(t, st, oh, idx); !bytes.Equal(got, body) {
+			t.Fatalf("shard %d body wrong after overwrite churn + compaction", idx)
+		}
+	}
+}
+
 // Every index-committed extent must already be enumerable from its segment's
 // .idx, or a drop could lose a live extent. Assert the back-check slot for each
 // live shard appears in scanIdx of its segment.

--- a/store/fragment.go
+++ b/store/fragment.go
@@ -27,10 +27,8 @@ const (
 	fragTagSize    = 16
 	totalFragSize  = fragHeaderSize + fragBodySize + fragTagSize
 
-	// bufLen is the per-shard fragment window: shardWriter buffers this many
-	// fragments before issuing one WriteAt, and shardReader fills the same
-	// window per seg.ReadAt. Trades RAM (≈ bufLen * 8 KiB per reader/writer)
-	// for syscall amortization. Cap at shard's fragment count when smaller.
+	// bufLen is the per-shard fragment window each reader and writer batches
+	// into one syscall, trading ≈ bufLen * 8 KiB of RAM apiece for fewer of them.
 	bufLen = 32
 )
 
@@ -53,14 +51,10 @@ const (
 // or the master key / storeID do not match what was bound at seal time.
 var ErrIntegrity = errors.New("fragment integrity check failed")
 
-// fragment is a fixed-size view over the on-disk fragment layout. Callers
-// instantiate it by casting a slice of a window buffer:
+// fragment is a fixed-size view over the on-disk layout, instantiated by casting
+// a slice of a window buffer:
 //
 //	frag := (*fragment)(buf[pos : pos+totalFragSize])
-//
-// Header reads/writes, body fill, seal/open, and AAD/nonce construction all
-// live here so reader.go and writer.go can stay focused on streaming and
-// batching.
 type fragment [totalFragSize]byte
 
 func (f *fragment) fragNum() uint64       { return binary.BigEndian.Uint64(f[0:8]) }
@@ -88,11 +82,10 @@ func (f *fragment) ciphertext() []byte {
 	return f[fragHeaderSize:totalFragSize]
 }
 
-// seal writes size + flags into the header, zero-pads the body past size
-// (the ciphertext is fixed-length under GCM), then encrypts the body in
-// place under aead. shardNum and fragNum are read from the just-stamped
-// header.
+// seal stamps size and flags, then encrypts the body in place. shardNum and
+// fragNum come from the already-stamped header.
 func (f *fragment) seal(aead cipher.AEAD, objectHash [32]byte, shardIndex, storeID uint32, size uint32, flags fragFlags) {
+	// Zero the tail: the ciphertext is fixed-length under GCM regardless of size.
 	if size < fragBodySize {
 		clear(f[fragHeaderSize+size : fragHeaderSize+fragBodySize])
 	}
@@ -104,9 +97,9 @@ func (f *fragment) seal(aead cipher.AEAD, objectHash [32]byte, shardIndex, store
 	aead.Seal(f.body()[:0], nonce[:], f.body(), aad[:])
 }
 
-// open decrypts the body in place, verifies the GCM tag, validates the
-// header size field, and returns the plaintext slice (length == size).
-// shardNum/fragNum come from the on-disk header.
+// open decrypts and authenticates the body in place, returning the plaintext.
+// shardNum and fragNum come from the on-disk header, so tampering with them
+// fails the tag.
 func (f *fragment) open(aead cipher.AEAD, objectHash [32]byte, shardIndex, storeID uint32) ([]byte, error) {
 	aad := makeAAD(objectHash, shardIndex, f.shardNum(), f.fragNum())
 	nonce := makeNonce(f.fragNum(), storeID)
@@ -123,10 +116,9 @@ func (f *fragment) open(aead cipher.AEAD, objectHash [32]byte, shardIndex, store
 	return plaintext[:sz], nil
 }
 
-// makeNonce builds the 12-byte GCM nonce: BE(fragNum) || BE(storeID).
-// fragNum is monotonic per data dir (crash-safe via state.json high-water);
-// storeID is 4 random bytes generated on first Store.Open. Together they are
-// unique for the lifetime of the master key.
+// makeNonce builds the 12-byte GCM nonce as BE(fragNum) ‖ BE(storeID). fragNum
+// is monotonic per data dir and storeID is random per data dir, so the pair is
+// unique for the master key's lifetime — which GCM requires absolutely.
 func makeNonce(fragNum uint64, storeID uint32) [12]byte {
 	var nonce [12]byte
 	binary.BigEndian.PutUint64(nonce[0:8], fragNum)
@@ -134,10 +126,9 @@ func makeNonce(fragNum uint64, storeID uint32) [12]byte {
 	return nonce
 }
 
-// makeAAD binds each fragment to its logical position. A tampered fragment
-// header or a fragment spliced into a different shard / object / position
-// produces a different AAD at read time, and GCM Open fails. Returned by
-// value so it stays on the stack on the per-fragment hot path.
+// makeAAD binds a fragment to its logical position, so one spliced into a
+// different shard, object or offset fails to open. Returned by value to stay on
+// the stack on the per-fragment hot path.
 func makeAAD(objectHash [32]byte, shardIndex uint32, shardNum, fragNum uint64) [aadSize]byte {
 	var aad [aadSize]byte
 	copy(aad[0:32], objectHash[:])

--- a/store/reader.go
+++ b/store/reader.go
@@ -9,20 +9,20 @@ import (
 
 var ErrClosedReader = errors.New("closed reader")
 
-// reader provides random and sequential access to a single shard's data.
-// It reads fragments from disk in batches of up to bufLen, opens each under
-// AES-256-GCM, and copies the plaintext into the caller's buffer. readPos
-// tracks the logical position for sequential Read() calls; ReadAt is stateless.
+// reader gives random and sequential access to one shard, decrypting fragments
+// as it goes.
 type reader struct {
 	objectHash [32]byte
 	shardIndex uint32
 	storeID    uint32
-	aead       cipher.AEAD // shared cipher.AEAD built once at Store.Open; safe for concurrent use.
+	aead       cipher.AEAD
 
 	seg *segment
 	ext extent
 
-	buf     []byte
+	buf []byte
+
+	// Sequential position for Read; ReadAt is stateless.
 	readPos int64
 
 	closed bool
@@ -43,19 +43,9 @@ func (r *reader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-// ReadAt reads len(p) bytes from the shard starting at logical byte offset.
-// Translates logical offsets to on-disk fragment positions:
-//
-//	fragIndex = logicalPos / fragBodySize
-//	diskOff   = ext.Off + fragIndex * totalFragSize
-//
-// Fragments are read in batches of up to bufLen at a time — one seg.ReadAt
-// fills the buffer, then each fragment is opened in place. This mirrors the
-// writer's one-WriteAt-per-window pattern so bufLen acts as a tunable
-// syscall-batch knob symmetric on both sides.
-//
-// A failed Open wraps ErrIntegrity — disk corruption, tamper, and wrong
-// master key share one path.
+// ReadAt reads len(p) bytes from the shard's logical offset, translating it to
+// on-disk fragment positions. A failed decrypt wraps ErrIntegrity, so
+// corruption, tamper and a wrong master key all surface the same way.
 func (r *reader) ReadAt(p []byte, off int64) (int, error) {
 	if r.closed {
 		return 0, ErrClosedReader
@@ -70,13 +60,15 @@ func (r *reader) ReadAt(p []byte, off int64) (int, error) {
 	}
 
 	totalCopied := 0
-	// Only the very first fragment we touch can start mid-body; all
-	// subsequent fragments (within or across batches) begin at body offset 0
-	// because each non-final copy consumes exactly fragBodySize logical bytes.
+
+	// Only the first fragment can start mid-body; every later one begins at 0,
+	// since each non-final copy consumes exactly fragBodySize logical bytes.
 	bodyOffset := int(off % fragBodySize)
 
 	batchCap := len(r.buf) / totalFragSize
 
+	// One seg.ReadAt fills the window, then each fragment is opened in place —
+	// mirroring the writer, so bufLen tunes syscall batching on both sides.
 	for totalCopied < len(p) {
 		logicalPos := off + int64(totalCopied)
 		startFragIdx := logicalPos / fragBodySize

--- a/store/segment.go
+++ b/store/segment.go
@@ -17,10 +17,9 @@ const (
 	idxSegFilename = "%016d.idx"
 )
 
-// idxEntry is one row of a segment's reverse sidecar (.idx): the in-segment
-// offset of an allocated extent, the shard key it holds, and its physical size.
-// Append-only; one row written per allocation so compaction can enumerate a
-// segment's extents without a full index scan.
+// idxEntry is one row of a segment's append-only reverse sidecar (.idx), written
+// per allocation so compaction can enumerate a segment's extents without
+// scanning the whole index.
 const idxEntrySize = 52 // Off(8) ‖ Key(36) ‖ PSize(8)
 
 type idxEntry struct {
@@ -47,9 +46,9 @@ func decodeIdxEntry(b []byte) (e idxEntry, err error) {
 	return e, nil
 }
 
-// scanIdx sequentially reads a segment's whole .idx sidecar into memory. Used
-// by compaction to enumerate every extent ever allocated in the segment; the
-// returned rows are selection hints back-checked against the index authority.
+// scanIdx reads a segment's whole .idx into memory, listing every extent ever
+// allocated there. The rows are hints: callers must back-check each against the
+// index, which is the authority on what is live.
 func scanIdx(dir string, segNum uint64) ([]idxEntry, error) {
 	f, err := openFile(filepath.Join(dir, fmt.Sprintf(idxSegFilename, segNum)))
 	if err != nil {
@@ -66,9 +65,8 @@ func scanIdx(dir string, segNum uint64) ([]idxEntry, error) {
 		return nil, err
 	}
 
-	// A torn trailing record is a crash mid-append: since .idx is fsynced before
-	// the index commit, that extent never went live, so dropping the partial row
-	// is safe. Enumerate only whole records.
+	// Whole records only. A torn trailing row is a crash mid-append, and since
+	// .idx is fsynced before the index commit, that extent never went live.
 	count := info.Size() / idxEntrySize
 	entries := make([]idxEntry, 0, count)
 	buf := make([]byte, idxEntrySize)
@@ -139,13 +137,7 @@ var openFile = func(path string) (file, error) {
 	return os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
 }
 
-// segment is an open segment file handle with a reference count. refs tracks
-// active readers and writers; Store.Close calls refs.Wait to drain them
-// before closing the file descriptor. The WaitGroup is safe because addRef is
-// only called from Lookup/Append (which hold store.mutex), and Close flips
-// store.closed under the same mutex before waiting — so no new addRef can
-// race with Wait. full caches the on-disk full flag so the hot Append path
-// avoids a ReadAt per call.
+// segment is an open segment file handle with a reference count.
 type segment struct {
 	file // .seg
 
@@ -153,7 +145,13 @@ type segment struct {
 	idxSize int64  // .idx append cursor, guarded by store.mutex
 	num     uint64 // for unlink paths on drop
 
+	// Active readers and writers, drained before the fd closes. Safe as a
+	// WaitGroup because addRef only runs from Lookup/Append under store.mutex,
+	// and Close flips store.closed under that same mutex before waiting — so no
+	// addRef can race a Wait.
 	refs sync.WaitGroup
+
+	// Caches the on-disk full flag, sparing the hot Append path a ReadAt.
 	full atomic.Bool
 }
 
@@ -173,9 +171,9 @@ func (seg *segment) appendIdx(e idxEntry) error {
 
 func (seg *segment) syncIdx() error { return seg.idx.Sync() }
 
-// dropSegment removes a fully-drained segment: evict from segCache, drain refs,
-// close both fds, and unlink .seg + .idx. Caller holds store.mutex. Safe only
-// after every live extent the segment held has been CAS-committed elsewhere.
+// dropSegment unlinks a drained segment and its sidecar. Caller holds
+// store.mutex. Safe only once every live extent it held has been committed
+// elsewhere.
 func (store *Store) dropSegment(num uint64) error {
 	seg, ok := store.segCache[num]
 	if !ok {

--- a/store/state.go
+++ b/store/state.go
@@ -20,12 +20,10 @@ type state struct {
 	StoreID          uint32 `json:"storeID"`
 }
 
-// loadState reads state.json from the Store directory and restores monotonic
-// counters. If state.json does not exist, a fresh storeID is generated and
-// the in-memory counters are zeroed; callers MUST follow up with a durable
-// saveState before any fragment is written under this storeID — otherwise a
-// crash + restart could regenerate a different storeID and orphan any data
-// written under the old one.
+// loadState restores the monotonic counters, generating a fresh storeID when
+// the data dir has no state.json. Callers must follow with a durable saveState
+// before any fragment is sealed: a crash first would regenerate a different
+// storeID and orphan everything written under the old one.
 func (store *Store) loadState() error {
 	data, err := os.ReadFile(filepath.Join(store.dir, stateFilename))
 	if err != nil {
@@ -50,16 +48,14 @@ func (store *Store) loadState() error {
 	store.shardNum = sta.ShardNum
 	store.storeID = sta.StoreID
 	store.fragNumHighWater = sta.FragNumHighWater
-	// fragNum resumes from the persisted high-water mark: the unflushed
-	// reservation window from before the crash is sacrificed to guarantee
-	// nonce uniqueness (see Stage 1 plan, "fragNum high-water reservation").
+	// Resume from the high-water, not the last fragNum: the unflushed window from
+	// before a crash is sacrificed to keep nonces unique.
 	store.fragNum = sta.FragNumHighWater
 	return nil
 }
 
-// saveState atomically and durably persists the Store's counters to disk:
-// write to state.json.tmp, fsync the file, rename to state.json, fsync the
-// parent directory. Returns when all writes are guaranteed durable.
+// saveState persists the counters atomically, returning only once they are
+// durable.
 func (store *Store) saveState() (retErr error) {
 	sta := state{
 		SegNum:           store.segNum,
@@ -105,6 +101,7 @@ func (store *Store) saveState() (retErr error) {
 		return err
 	}
 
+	// The rename itself is only durable once the parent directory is fsynced.
 	dir, err := os.Open(store.dir)
 	if err != nil {
 		return err

--- a/store/store.go
+++ b/store/store.go
@@ -22,41 +22,39 @@ import (
 
 const indexFilename = "db"
 
-// fragNumReservation is the size of each batched fragNum allocation written
-// durably to state.json. Append hands out fragNums freely below the persisted
-// high-water; only an allocation that crosses the high-water triggers an
-// fsync. Sized so a typical 100-fragment shard fsyncs roughly every 10k
-// Append calls. Tunable; not on-disk-format-critical.
+// fragNumReservation is how many fragNums one durable state.json reservation
+// covers; only an allocation that crosses the high-water costs an fsync. Sized
+// so a typical shard fsyncs about every 10k Appends. Tunable, and not
+// on-disk-format-critical.
 const fragNumReservation = 1 << 20 // 1 048 576
 
-// Store manages segment files and an index mapping shard keys to on-disk extents.
-// All public methods are safe for concurrent use. Segment files are pre-allocated
-// via Truncate and written lock-free with WriteAt; the mutex protects only metadata
-// (counters, segment cache, index commits).
-//
-// segCache is unbounded — entries accumulate as the store touches old
-// segments. Fine for the current single-data-dir scale; a long-lived store
-// reading from thousands of distinct segments will need an LRU.
+// Store manages segment files and an index mapping shard keys to on-disk
+// extents. All public methods are safe for concurrent use.
 type Store struct {
-	dir      string
-	index    *s3db.S3DB
-	segCache map[uint64]*segment
-	mutex    sync.Mutex
+	dir   string
+	index *s3db.S3DB
 
-	// At-rest encryption: aead is supplied by the caller via WithAEAD and
-	// shared (concurrency-safe per stdlib contract) across every shardWriter
-	// and shardReader. The store never sees raw key bytes — cipher construction
-	// lives at the layer that loads the key file. storeID is intrinsic per
-	// data dir, generated on first Open and bound into every nonce.
-	aead    cipher.AEAD
+	// Unbounded: entries accumulate as the store touches old segments. Fine at
+	// single-data-dir scale; thousands of distinct segments would want an LRU.
+	segCache map[uint64]*segment
+
+	// Guards metadata only — counters, segCache, index commits. Segment bytes
+	// are pre-allocated via Truncate and written lock-free through WriteAt.
+	mutex sync.Mutex
+
+	// Shared by every reader and writer; GCM permits concurrent Seal/Open.
+	aead cipher.AEAD
+
+	// Intrinsic to the data dir, generated on first Open and bound into every
+	// nonce.
 	storeID uint32
 
 	// Monotonic counters persisted to state.json across restarts.
-	// fragNumHighWater is the durably-reserved upper bound on fragNum; Append
-	// extends it (and fsyncs) only when an allocation would cross it.
-	segNum           uint64
-	shardNum         uint64
-	fragNum          uint64
+	segNum   uint64
+	shardNum uint64
+	fragNum  uint64
+
+	// The durably-reserved ceiling on fragNum; Append fsyncs only to raise it.
 	fragNumHighWater uint64
 
 	maxSegSize uint64
@@ -113,13 +111,9 @@ func WithCompaction(interval time.Duration) Option {
 	}
 }
 
-// WithAEAD configures the cipher.AEAD used to seal/open every fragment. The
-// AEAD is shared across all writers and readers; the stdlib's GCM guarantees
-// concurrent Seal/Open are safe. The store builds 12-byte nonces as
-// BE(fragNum) || BE(storeID), so the AEAD must report NonceSize() == 12.
-//
-// Cipher construction (and the raw key it consumes) live at the operator
-// layer — the store deliberately never sees key bytes.
+// WithAEAD sets the cipher sealing every fragment, and is mandatory. The nonce
+// layout fixes NonceSize at 12. Callers build the cipher themselves, so the
+// store never sees raw key bytes.
 func WithAEAD(aead cipher.AEAD) Option {
 	return func(s *Store) error {
 		if aead == nil {
@@ -133,13 +127,8 @@ func WithAEAD(aead cipher.AEAD) Option {
 	}
 }
 
-// Open recovers or creates a Store in dir. On startup it restores monotonic
-// counters from state.json (or generates a fresh storeID for a new data dir),
-// advances and durably persists the fragNum high-water reservation, opens the
-// index, then advances segNum past any full segments left over from a prior
-// crash so the first Append sees a writable segment.
-//
-// WithAEAD is mandatory — Open errors if no cipher was supplied.
+// Open recovers or creates a Store in dir, leaving it ready for the first
+// Append. WithAEAD is mandatory.
 func Open(dir string, opts ...Option) (store *Store, err error) {
 	store = &Store{
 		dir:                dir,
@@ -162,10 +151,9 @@ func Open(dir string, opts ...Option) (store *Store, err error) {
 		return nil, fmt.Errorf("load state: %w", err)
 	}
 
-	// Reserve a fresh high-water window. For fresh stores this also locks in
-	// the just-generated storeID before any fragment can be sealed under it.
-	// The save MUST be durable before Open returns — see plan §"first save of
-	// state.json".
+	// Reserve a fresh window durably before Open returns. On a new data dir this
+	// is also what locks in the generated storeID, before any fragment can be
+	// sealed under it.
 	store.fragNumHighWater = store.fragNum + fragNumReservation
 	if err := store.saveState(); err != nil {
 		return nil, fmt.Errorf("save state: %w", err)
@@ -237,11 +225,8 @@ func (store *Store) Lookup(objectHash [32]byte, shardIndex uint32) (Reader, erro
 }
 
 // Append reserves space for a shard of the given logical size and returns a
-// writer. The segment file is pre-allocated (Truncated) to fit all fragments,
-// so subsequent WriteAt calls from the writer never extend the file. If the
-// current segment can't fit the shard, it is marked full and the store rolls
-// to the next segment. The index entry is committed only when the writer is
-// closed.
+// writer. The shard reaches the index only when that writer is closed, so an
+// overwrite keeps serving its previous data until then.
 func (store *Store) Append(objectHash [32]byte, shardIndex uint32, size int64) (Writer, error) {
 	if size < 0 {
 		return nil, fmt.Errorf("negative size %d", size)
@@ -254,15 +239,12 @@ func (store *Store) Append(objectHash [32]byte, shardIndex uint32, size int64) (
 		return nil, ErrClosedStore
 	}
 
-	// Ceiling division: number of fragments needed to hold size logical bytes.
-	// size == 0 yields fragCount == 0; the writer's ReadFrom loop never runs
-	// and Close commits an empty-extent index entry.
+	// Ceiling division; size == 0 yields an empty extent the writer never fills.
 	fragCount := (uint64(size) + fragBodySize - 1) / fragBodySize
 
-	// Reserve fragNums durably before handing them out. We must fsync before
-	// any fragment can be sealed under (storeID, fragNum) — otherwise a crash
-	// after the writer returns could rewind fragNum on restart and cause
-	// catastrophic GCM nonce reuse.
+	// fragNums must be durable before they are handed out. A crash that rewound
+	// fragNum would reissue a nonce under the same key, which breaks GCM
+	// catastrophically, so this fsync is not optional.
 	if store.fragNum+fragCount > store.fragNumHighWater {
 		for store.fragNumHighWater < store.fragNum+fragCount {
 			store.fragNumHighWater += fragNumReservation
@@ -329,9 +311,7 @@ func (store *Store) reserveExtent(fragCount uint64) (*segment, int64, error) {
 	newSegSize := uint64(segSize) + fragCount*totalFragSize //nolint:gosec // segSize from os.File.Stat().Size() is always non-negative.
 
 	if newSegSize >= store.maxSegSize {
-		// Mark full once we've decided this is the last shard for this segment.
-		// markFull failure is non-fatal: next Append re-reads the on-disk flag
-		// (cache stays as-is here too), so we'll retry the mark naturally.
+		// Non-fatal: the next Append re-reads the on-disk flag and retries the mark.
 		if err := seg.markFull(); err != nil {
 			slog.Warn("failed to mark segment full",
 				"segNum", store.segNum,
@@ -340,9 +320,8 @@ func (store *Store) reserveExtent(fragCount uint64) (*segment, int64, error) {
 		}
 	}
 
-	// Roll if this shard would overflow the segment, unless the segment is
-	// fresh (header-only) — then we let one oversized shard through so a
-	// pathological size still makes forward progress.
+	// Roll if the shard would overflow, unless the segment is fresh: one
+	// oversized shard is let through so a pathological size still makes progress.
 	if newSegSize > store.maxSegSize && segSize != segHeaderSize {
 		seg, err = store.rollSegment()
 		if err != nil {
@@ -363,16 +342,9 @@ func (store *Store) reserveExtent(fragCount uint64) (*segment, int64, error) {
 	return seg, off, nil
 }
 
-// commitExtent persists a shard's extent to the index. Called by writers from
-// Close once the data is durable. Concurrency-safe via badger; no Store-level
-// lock needed.
-//
-// An overwrite supersedes whatever extent the key already held, so the old slot
-// becomes dead space. Its tombstone is written in the same transaction that
-// repoints the key — the commit is the instant the supersession happens, so the
-// dead-space hint can neither precede nor outlive it. Without this the orphaned
-// bytes stay invisible to compaction's selector and mask their segment from
-// candidacy forever.
+// commitExtent points a shard's key at ext, tombstoning any extent it
+// supersedes. Called from writer.Close once the data is durable; takes no
+// store.mutex.
 func (store *Store) commitExtent(objectHash [32]byte, shardIndex uint32, ext extent) error {
 	key := MakeShardKey(objectHash, shardIndex)
 
@@ -380,11 +352,13 @@ func (store *Store) commitExtent(objectHash [32]byte, shardIndex uint32, ext ext
 		err := store.index.Badger.Update(func(txn *badger.Txn) error {
 			old, err := readExtent(txn, key)
 			switch {
-			// A first write has nothing to supersede.
+			// A first write supersedes nothing.
 			case errors.Is(err, badger.ErrKeyNotFound):
 			case err != nil:
 				return err
 			default:
+				// The old extent dies at this commit and nowhere else, so its hint
+				// rides the same txn and can neither precede nor outlive it.
 				if err := txn.Set(tombstoneKey(old.SegNum, old.Off), tombstoneValue(old.PSize)); err != nil {
 					return fmt.Errorf("put tombstone: %w", err)
 				}
@@ -393,8 +367,8 @@ func (store *Store) commitExtent(objectHash [32]byte, shardIndex uint32, ext ext
 			return txn.Set(key, ext.encode())
 		})
 
-		// Reading the key before writing it puts this txn under badger's conflict
-		// detection: a compactor relocating the same key races us here.
+		// The read above puts this txn under badger's conflict detection, which a
+		// compactor relocating the same key trips.
 		if errors.Is(err, badger.ErrConflict) {
 			continue
 		}
@@ -423,14 +397,10 @@ func readExtent(txn *badger.Txn, key []byte) (extent, error) {
 	return ext, nil
 }
 
-// Delete removes the index entry for a shard in a single index transaction:
-// read the current extent, write a slot-keyed tombstone for compaction's
-// selector, then delete the live key. Tombstone and deletion commit together,
-// so the dead-space hint can never outlive or precede the deletion it records.
-// The on-disk extent becomes dead space reclaimable by the compactor.
-// Delete tombstones the extent for the given shard and removes its index entry.
-// The bool reports whether an extent existed and was removed; a missing shard is
-// not an error and returns (false, nil), keeping deletes idempotent.
+// Delete removes a shard's index entry and tombstones its extent, in one
+// transaction so the dead-space hint cannot outlive or precede the deletion.
+// Reports whether an extent existed; a missing shard is not an error, which
+// keeps deletes idempotent.
 func (store *Store) Delete(objectHash [32]byte, shardIndex uint32) (bool, error) {
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
@@ -477,9 +447,8 @@ func (store *Store) Close() error {
 	c := store.compactor
 	store.mutex.Unlock()
 
-	// Stop the compactor without holding the mutex: an in-flight cycle takes
-	// store.mutex, so joining under the lock would deadlock. closed is already
-	// set, so no new public mutation slips in behind the join.
+	// Join without the mutex: an in-flight cycle takes it, so joining under the
+	// lock would deadlock. closed is already set, so nothing new slips in behind.
 	if c != nil {
 		c.stop()
 	}
@@ -508,11 +477,11 @@ func (store *Store) Close() error {
 	return errors.Join(errs...)
 }
 
-// Slot-keyed tombstones live in the index under the tombstonePrefix namespace:
-// Delete writes d ‖ BE(segNum) ‖ BE(off) → BE(PSize) for the extent it removes.
-// They are a candidate-selection accelerator for compaction only — never
-// consulted for correctness. Keyed by physical slot so the same object key
-// dying more than once stays unique.
+// Tombstones record a dead extent as d ‖ BE(segNum) ‖ BE(off) → BE(PSize). They
+// only accelerate compaction's candidate selection and are never consulted for
+// correctness. Keying by physical slot rather than object key is what lets one
+// key die repeatedly: on delete, on overwrite, and on a relocation that lost
+// its race.
 const tombstonePrefix = 'd'
 
 const tombstoneKeySize = 17 // prefix(1) ‖ segNum(8) ‖ off(8)

--- a/store/store.go
+++ b/store/store.go
@@ -6,7 +6,6 @@
 package store
 
 import (
-	"bytes"
 	"crypto/cipher"
 	"encoding/binary"
 	"errors"
@@ -422,43 +421,6 @@ func readExtent(txn *badger.Txn, key []byte) (extent, error) {
 		return extent{}, fmt.Errorf("decode extent: %w", err)
 	}
 	return ext, nil
-}
-
-// errStaleSlot signals that a compare-and-swap found the key no longer pointing
-// at the expected extent — a concurrent overwrite or delete won the race.
-var errStaleSlot = errors.New("extent slot moved")
-
-// casExtent commits new only if key still encodes old, in a single index
-// transaction; it retries on badger write conflicts. committed is false (with a
-// nil error) when the slot moved out from under us or the key was deleted — the
-// caller treats the just-copied bytes as harmless dead space.
-func (store *Store) casExtent(key []byte, old, next extent) (committed bool, err error) {
-	for {
-		err = store.index.Badger.Update(func(txn *badger.Txn) error {
-			item, err := txn.Get(key)
-			if err != nil {
-				return err
-			}
-			cur, err := item.ValueCopy(nil)
-			if err != nil {
-				return err
-			}
-			if !bytes.Equal(cur, old.encode()) {
-				return errStaleSlot
-			}
-			return txn.Set(key, next.encode())
-		})
-
-		switch {
-		case errors.Is(err, badger.ErrConflict):
-			continue
-		case errors.Is(err, errStaleSlot), errors.Is(err, badger.ErrKeyNotFound):
-			return false, nil
-		case err != nil:
-			return false, err
-		}
-		return true, nil
-	}
 }
 
 // Delete removes the index entry for a shard in a single index transaction:

--- a/store/store.go
+++ b/store/store.go
@@ -367,12 +367,61 @@ func (store *Store) reserveExtent(fragCount uint64) (*segment, int64, error) {
 // commitExtent persists a shard's extent to the index. Called by writers from
 // Close once the data is durable. Concurrency-safe via badger; no Store-level
 // lock needed.
+//
+// An overwrite supersedes whatever extent the key already held, so the old slot
+// becomes dead space. Its tombstone is written in the same transaction that
+// repoints the key — the commit is the instant the supersession happens, so the
+// dead-space hint can neither precede nor outlive it. Without this the orphaned
+// bytes stay invisible to compaction's selector and mask their segment from
+// candidacy forever.
 func (store *Store) commitExtent(objectHash [32]byte, shardIndex uint32, ext extent) error {
 	key := MakeShardKey(objectHash, shardIndex)
-	if err := store.index.Set(key, ext.encode()); err != nil {
-		return fmt.Errorf("commit: %w", err)
+
+	for {
+		err := store.index.Badger.Update(func(txn *badger.Txn) error {
+			old, err := readExtent(txn, key)
+			switch {
+			// A first write has nothing to supersede.
+			case errors.Is(err, badger.ErrKeyNotFound):
+			case err != nil:
+				return err
+			default:
+				if err := txn.Set(tombstoneKey(old.SegNum, old.Off), tombstoneValue(old.PSize)); err != nil {
+					return fmt.Errorf("put tombstone: %w", err)
+				}
+			}
+
+			return txn.Set(key, ext.encode())
+		})
+
+		// Reading the key before writing it puts this txn under badger's conflict
+		// detection: a compactor relocating the same key races us here.
+		if errors.Is(err, badger.ErrConflict) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("commit: %w", err)
+		}
+		return nil
 	}
-	return nil
+}
+
+// readExtent decodes the extent a key currently points at, propagating
+// badger.ErrKeyNotFound unwrapped so callers can branch on a missing key.
+func readExtent(txn *badger.Txn, key []byte) (extent, error) {
+	item, err := txn.Get(key)
+	if err != nil {
+		return extent{}, err
+	}
+	raw, err := item.ValueCopy(nil)
+	if err != nil {
+		return extent{}, fmt.Errorf("copy extent: %w", err)
+	}
+	ext, err := decodeExtent(raw)
+	if err != nil {
+		return extent{}, fmt.Errorf("decode extent: %w", err)
+	}
+	return ext, nil
 }
 
 // errStaleSlot signals that a compare-and-swap found the key no longer pointing
@@ -431,21 +480,12 @@ func (store *Store) Delete(objectHash [32]byte, shardIndex uint32) (bool, error)
 	key := MakeShardKey(objectHash, shardIndex)
 	deleted := false
 	err := store.index.Badger.Update(func(txn *badger.Txn) error {
-		item, err := txn.Get(key)
+		ext, err := readExtent(txn, key)
 		if errors.Is(err, badger.ErrKeyNotFound) {
 			return nil
 		}
 		if err != nil {
 			return fmt.Errorf("delete: read extent: %w", err)
-		}
-
-		raw, err := item.ValueCopy(nil)
-		if err != nil {
-			return fmt.Errorf("delete: copy extent: %w", err)
-		}
-		ext, err := decodeExtent(raw)
-		if err != nil {
-			return fmt.Errorf("delete: decode extent: %w", err)
 		}
 
 		if err := txn.Set(tombstoneKey(ext.SegNum, ext.Off), tombstoneValue(ext.PSize)); err != nil {

--- a/store/writer.go
+++ b/store/writer.go
@@ -9,11 +9,8 @@ import (
 
 var ErrClosedWriter = errors.New("closed writer")
 
-// writer buffers a single shard's fragments and seals each body in place
-// before flushing. The internal buffer mirrors the on-disk layout (headers,
-// body slots, and tag slots interleaved) so flush can issue one WriteAt for
-// the whole window. cursor advances past each fragment's tag slot when the
-// body fills, so the next iteration starts cleanly on a fragment boundary.
+// writer buffers one shard's fragments and seals each body in place before
+// flushing.
 type writer struct {
 	store      *Store
 	objectHash [32]byte
@@ -26,15 +23,18 @@ type writer struct {
 	shardNum uint64
 	fragNum  uint64
 
-	// buf holds the unflushed fragment window. cursor is the offset into the
-	// shard's extent where the next byte will go; flushedTo is the same kind
-	// of offset, fixed to the last successful WriteAt. cursor - flushedTo is
-	// the live buffer-fill in bytes. dataLen tracks logical bytes written so
-	// we don't recompute it from cursor on every iteration.
-	buf       []byte
+	// The unflushed fragment window, mirroring the on-disk layout so flush can
+	// issue one WriteAt for the whole thing.
+	buf []byte
+
+	// Offsets into the shard's extent: cursor is where the next byte goes,
+	// flushedTo is fixed to the last successful WriteAt, and their difference is
+	// the live buffer fill.
 	cursor    int64
 	flushedTo int64
-	dataLen   int64
+
+	// Logical bytes written, tracked so it isn't recomputed from cursor per loop.
+	dataLen int64
 
 	closed bool
 }
@@ -57,14 +57,10 @@ func (w *writer) Write(p []byte) (int, error) {
 }
 
 // ReadFrom streams from r into the shard, one fragment per iteration.
-// io.ReadFull fills the body, capped at the remaining shard bytes so the
-// final partial fragment doesn't try to over-read. Flush triggers when the
-// buffer window fills or the shard is done.
 //
-// If r is exhausted before the shard is filled (underfill), returns the
-// bytes consumed and io.EOF — the writer's Close will still flush whatever
-// partial bytes were buffered, but the index entry's LSize will exceed the
-// actual data; ReadAt of the unfilled tail will surface ErrIntegrity.
+// If r runs dry before the shard is full, returns the bytes consumed and
+// io.EOF. Close still flushes what was buffered, but the extent's LSize will
+// overstate the data, and reading the unfilled tail surfaces ErrIntegrity.
 func (w *writer) ReadFrom(r io.Reader) (total int64, err error) {
 	if w.closed {
 		return 0, ErrClosedWriter
@@ -77,6 +73,8 @@ func (w *writer) ReadFrom(r io.Reader) (total int64, err error) {
 		w.fragNum++
 		w.cursor += fragHeaderSize
 
+		// Cap the fill at the shard's remaining bytes so the final partial
+		// fragment doesn't over-read.
 		dataLeft := w.ext.LSize - w.dataLen
 		want := int(min(int64(fragBodySize), dataLeft))
 		n, readErr := io.ReadFull(r, frag.body()[:want])
@@ -87,9 +85,8 @@ func (w *writer) ReadFrom(r io.Reader) (total int64, err error) {
 		w.dataLen += int64(n)
 		total += int64(n)
 
-		// Skip the tag slot when the body filled, so the next iteration
-		// starts at a fragment boundary. The tag bytes themselves are
-		// written in place by flush()'s Seal.
+		// Skip the tag slot so the next iteration lands on a fragment boundary;
+		// flush's Seal writes the tag bytes themselves.
 		if n == fragBodySize {
 			w.cursor += fragTagSize
 		}
@@ -108,10 +105,10 @@ func (w *writer) ReadFrom(r io.Reader) (total int64, err error) {
 	return total, nil
 }
 
-// Close flushes any remaining buffered data, syncs the segment file, then
-// commits the extent to the index. Must be called exactly once. The segment
-// ref is always decremented on exit; the index commit only runs when the
-// data is fully durable, preserving rollback on flush/Sync failure.
+// Close flushes, makes the data durable, then commits the extent to the index —
+// so a failure before that last step leaves the shard's previous data intact.
+// Must be called exactly once; it is what releases the segment reference Append
+// took.
 func (w *writer) Close() (err error) {
 	if w.closed {
 		return ErrClosedWriter


### PR DESCRIPTION
Successful writes no prefix superseded extents with the deleted tombstone. Enabling compaction to clean up.