### PR TITLE
feat: pool free-space watermark + nearfull backpressure for capacity safety

### DIFF
--- a/backend/distributed/distributed.go
+++ b/backend/distributed/distributed.go
@@ -114,9 +114,10 @@ func (m myMember) String() string {
 
 // shardWriteOutcome captures the result of writing a shard via QUIC.
 type shardWriteOutcome struct {
-	shardIndex int
-	shardSize  int64
-	err        error
+	shardIndex   int
+	shardSize    int64
+	poolNearFull bool // mirrors PutResponse.PoolNearFull for this shard's node.
+	err          error
 }
 
 // bytesBufferWriter wraps a byte slice pointer for use as io.Writer.
@@ -296,22 +297,25 @@ func (b *Backend) GlobalState() GlobalState {
 	return b.globalState
 }
 
-// putObjectViaQUIC splits a file into RS shards and sends each to the appropriate node via QUIC.
-func (b *Backend) putObjectViaQUIC(ctx context.Context, bucket string, objectPath string, objectHash [32]byte) (size int64, err error) {
+// putObjectViaQUIC splits a file into RS shards and sends each to the
+// appropriate node via QUIC. poolNearFull reports whether ANY shard's target
+// node responded with PoolNearFull set — one node under pressure is enough
+// to warn the caller, even though the object as a whole still wrote fine.
+func (b *Backend) putObjectViaQUIC(ctx context.Context, bucket string, objectPath string, objectHash [32]byte) (size int64, poolNearFull bool, err error) {
 	enc, err := reedsolomon.NewStream(b.rsDataShard, b.rsParityShard)
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
 
 	f, err := os.Open(objectPath)
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
 	defer f.Close()
 
 	instat, err := f.Stat()
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
 
 	size = instat.Size()
@@ -319,7 +323,7 @@ func (b *Backend) putObjectViaQUIC(ctx context.Context, bucket string, objectPat
 	// Use objectHash for hash ring placement for consistency with storage and retrieval
 	hashRingShards, err := b.hashRing.GetClosestN(objectHash[:], b.rsDataShard+b.rsParityShard)
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
 
 	// Calculate shard size
@@ -337,7 +341,7 @@ func (b *Backend) putObjectViaQUIC(ctx context.Context, bucket string, objectPat
 	}
 
 	if splitErr := enc.Split(f, dataWriters, fileSize); splitErr != nil {
-		return 0, splitErr
+		return 0, false, splitErr
 	}
 
 	// Step 2: Send data shards to nodes via QUIC
@@ -378,7 +382,7 @@ func (b *Backend) putObjectViaQUIC(ctx context.Context, bucket string, objectPat
 				return
 			}
 
-			dataCh <- shardWriteOutcome{shardIndex: idx, shardSize: resp.ShardSize}
+			dataCh <- shardWriteOutcome{shardIndex: idx, shardSize: resp.ShardSize, poolNearFull: resp.PoolNearFull}
 		}(i, dataShardBuffers[i])
 	}
 
@@ -392,9 +396,12 @@ func (b *Backend) putObjectViaQUIC(ctx context.Context, bucket string, objectPat
 		if outcome.err != nil && firstErr == nil {
 			firstErr = outcome.err
 		}
+		if outcome.poolNearFull {
+			poolNearFull = true
+		}
 	}
 	if firstErr != nil {
-		return 0, firstErr
+		return 0, false, firstErr
 	}
 
 	// Step 3: Encode parity shards using the buffered data shards
@@ -449,7 +456,7 @@ func (b *Backend) putObjectViaQUIC(ctx context.Context, bucket string, objectPat
 				return
 			}
 
-			parityCh <- shardWriteOutcome{shardIndex: localParityIdx, shardSize: resp.ShardSize}
+			parityCh <- shardWriteOutcome{shardIndex: localParityIdx, shardSize: resp.ShardSize, poolNearFull: resp.PoolNearFull}
 		}(i, parityIdx, pr)
 	}
 
@@ -473,15 +480,18 @@ func (b *Backend) putObjectViaQUIC(ctx context.Context, bucket string, objectPat
 		if outcome.err != nil && firstErr == nil {
 			firstErr = outcome.err
 		}
+		if outcome.poolNearFull {
+			poolNearFull = true
+		}
 	}
 	if encodeErr != nil && firstErr == nil {
 		firstErr = encodeErr
 	}
 	if firstErr != nil {
-		return 0, firstErr
+		return 0, false, firstErr
 	}
 
-	return size, nil
+	return size, poolNearFull, nil
 }
 
 // openInput retrieves shard location metadata for an object.

--- a/backend/distributed/distributed.go
+++ b/backend/distributed/distributed.go
@@ -298,9 +298,8 @@ func (b *Backend) GlobalState() GlobalState {
 }
 
 // putObjectViaQUIC splits a file into RS shards and sends each to the
-// appropriate node via QUIC. poolNearFull reports whether ANY shard's target
-// node responded with PoolNearFull set — one node under pressure is enough
-// to warn the caller, even though the object as a whole still wrote fine.
+// appropriate node via QUIC. poolNearFull is set if any shard's target node
+// reported pressure.
 func (b *Backend) putObjectViaQUIC(ctx context.Context, bucket string, objectPath string, objectHash [32]byte) (size int64, poolNearFull bool, err error) {
 	enc, err := reedsolomon.NewStream(b.rsDataShard, b.rsParityShard)
 	if err != nil {

--- a/backend/distributed/multipart.go
+++ b/backend/distributed/multipart.go
@@ -179,9 +179,9 @@ func (b *Backend) UploadPart(ctx context.Context, req *backend.UploadPartRequest
 		slog.Debug("Failed to close temp file", "path", tmpPath, "error", closeErr)
 	}
 
-	if _, err = b.putObjectViaQUIC(ctx, req.Bucket, tmpPath, objectHash); err != nil {
+	if _, _, err = b.putObjectViaQUIC(ctx, req.Bucket, tmpPath, objectHash); err != nil {
 		slog.Error("Failed to store part", "uploadID", req.UploadID, "part", req.PartNumber, "error", err)
-		return nil, backend.NewS3Error(backend.ErrInternalError, "Failed to store part", 500)
+		return nil, mapPutErr(err)
 	}
 
 	// Create part metadata
@@ -383,9 +383,9 @@ func (b *Backend) CompleteMultipartUpload(ctx context.Context, req *backend.Comp
 	// Store the final object using PutObject mechanism
 	objectHash := s3db.GenObjectHash(req.Bucket, req.Key)
 
-	if _, err = b.putObjectViaQUIC(ctx, req.Bucket, tmpFile.Name(), objectHash); err != nil {
+	if _, _, err = b.putObjectViaQUIC(ctx, req.Bucket, tmpFile.Name(), objectHash); err != nil {
 		slog.Error("Failed to store final object", "uploadID", req.UploadID, "error", err)
-		return nil, backend.NewS3Error(backend.ErrInternalError, "Failed to store final object", 500)
+		return nil, mapPutErr(err)
 	}
 
 	// Get final object size

--- a/backend/distributed/put.go
+++ b/backend/distributed/put.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
 
 	"github.com/mulgadc/predastore/backend"
+	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/s3/chunked"
 	s3db "github.com/mulgadc/predastore/s3db"
 )
@@ -16,6 +18,19 @@ import (
 // arnObjectPrefix is the ARN prefix for object keys
 // Format: arn:aws:s3:::<bucket>/<key>.
 const arnObjectPrefixPut = "arn:aws:s3:::"
+
+// mapPutErr translates an error from putObjectViaQUIC into the S3 error a
+// client should see. A shard write that failed because a remote node's store
+// crossed its full free-space watermark carries quicclient.ErrInsufficientStorage
+// through the RS shard fan-out unwrapped (see putObjectViaQUIC's firstErr);
+// that specific case must reach the client as 507, not collapse into the
+// generic 500 every other shard-write failure gets.
+func mapPutErr(err error) *backend.S3Error {
+	if errors.Is(err, quicclient.ErrInsufficientStorage) {
+		return backend.ErrInsufficientStorageError
+	}
+	return backend.NewS3Error(backend.ErrInternalError, err.Error(), 500)
+}
 
 // PutObject stores an object using Reed-Solomon encoding across multiple nodes.
 func (b *Backend) PutObject(ctx context.Context, req *backend.PutObjectRequest) (*backend.PutObjectResponse, error) {
@@ -63,10 +78,11 @@ func (b *Backend) PutObject(ctx context.Context, req *backend.PutObjectRequest) 
 	}
 
 	var size int64
-	size, err = b.putObjectViaQUIC(ctx, req.Bucket, tmpFile.Name(), objectHash)
+	var poolNearFull bool
+	size, poolNearFull, err = b.putObjectViaQUIC(ctx, req.Bucket, tmpFile.Name(), objectHash)
 	if err != nil {
 		slog.Error("distributed.PutObject: shard distribution failed", "error", err)
-		return nil, backend.NewS3Error(backend.ErrInternalError, err.Error(), 500)
+		return nil, mapPutErr(err)
 	}
 
 	objectToShardNodes.Size = size
@@ -113,7 +129,8 @@ func (b *Backend) PutObject(ctx context.Context, req *backend.PutObjectRequest) 
 	}
 
 	return &backend.PutObjectResponse{
-		ETag: generateDistributedETag(req.Bucket, req.Key),
+		ETag:         generateDistributedETag(req.Bucket, req.Key),
+		PoolNearFull: poolNearFull,
 	}, nil
 }
 
@@ -144,7 +161,7 @@ func (b *Backend) PutObjectFromPath(ctx context.Context, bucket, objectPath stri
 	}
 
 	var size int64
-	size, err = b.putObjectViaQUIC(ctx, bucket, objectPath, objectHash)
+	size, _, err = b.putObjectViaQUIC(ctx, bucket, objectPath, objectHash)
 	if err != nil {
 		return err
 	}

--- a/backend/distributed/put.go
+++ b/backend/distributed/put.go
@@ -19,12 +19,9 @@ import (
 // Format: arn:aws:s3:::<bucket>/<key>.
 const arnObjectPrefixPut = "arn:aws:s3:::"
 
-// mapPutErr translates an error from putObjectViaQUIC into the S3 error a
-// client should see. A shard write that failed because a remote node's store
-// crossed its full free-space watermark carries quicclient.ErrInsufficientStorage
-// through the RS shard fan-out unwrapped (see putObjectViaQUIC's firstErr);
-// that specific case must reach the client as 507, not collapse into the
-// generic 500 every other shard-write failure gets.
+// mapPutErr translates a putObjectViaQUIC error into the S3 error returned
+// to the client. A pool-full shard write must surface as 507, not the
+// generic 500 other failures get.
 func mapPutErr(err error) *backend.S3Error {
 	if errors.Is(err, quicclient.ErrInsufficientStorage) {
 		return backend.ErrInsufficientStorageError

--- a/backend/distributed/put_test.go
+++ b/backend/distributed/put_test.go
@@ -1,0 +1,124 @@
+package distributed
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	s3backend "github.com/mulgadc/predastore/backend"
+	"github.com/mulgadc/predastore/internal/storetest"
+	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/quic/quicclient"
+	"github.com/mulgadc/predastore/quic/quicserver"
+	"github.com/stretchr/testify/require"
+)
+
+// mapPutErr is the seam between a QUIC shard-write failure and the S3
+// response a client sees. It must preserve the pool-full signal instead of
+// collapsing every putObjectViaQUIC failure into the same generic 500.
+func TestMapPutErrInsufficientStorage(t *testing.T) {
+	err := fmt.Errorf("put failed: %w", quicclient.ErrInsufficientStorage)
+
+	s3err := mapPutErr(err)
+
+	if s3err.StatusCode != http.StatusInsufficientStorage {
+		t.Fatalf("StatusCode = %d, want 507", s3err.StatusCode)
+	}
+	if s3err.Code != s3backend.ErrInsufficientStorage {
+		t.Fatalf("Code = %s, want %s", s3err.Code, s3backend.ErrInsufficientStorage)
+	}
+}
+
+func TestMapPutErrOtherErrorStaysInternalError(t *testing.T) {
+	s3err := mapPutErr(errors.New("dial failed: connection refused"))
+
+	if s3err.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("StatusCode = %d, want 500", s3err.StatusCode)
+	}
+	if s3err.Code != s3backend.ErrInternalError {
+		t.Fatalf("Code = %s, want %s", s3err.Code, s3backend.ErrInternalError)
+	}
+}
+
+// TestPutObjectFullPoolReturns507EndToEnd drives the real seam: five live
+// QuicServer nodes, each opened with an unsatisfiable free-space watermark
+// (0.9999 free-space fraction, above any real disk), so every shard PUT hits
+// store.ErrStoreFull. That crosses handlePUTShard (quicproto.StatusInsufficientStorage),
+// quicclient.Put (ErrInsufficientStorage), and mapPutErr (backend.S3Error),
+// landing on Backend.PutObject as a real 507 — the same status handleError
+// forwards verbatim to the HTTP client.
+func TestPutObjectFullPoolReturns507EndToEnd(t *testing.T) {
+	const bucket = "test-bucket-full"
+
+	tmpDir := t.TempDir()
+	testBasePort := 29981
+
+	cfg := &Config{
+		BadgerDir:      tmpDir,
+		PartitionCount: 5,
+		QuicBasePort:   testBasePort,
+		Buckets: []BucketConfig{
+			{Name: bucket, Region: "us-east-1"},
+		},
+	}
+	b, err := New(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	defer b.Close()
+
+	backend, ok := b.(*Backend)
+	require.True(t, ok)
+
+	dataDir := filepath.Join(tmpDir, "nodes")
+	backend.SetDataDir(dataDir)
+
+	certPath, keyPath, pool := testcerts.Generate(t)
+	quicclient.SetDefaultRootCAs(pool)
+	t.Cleanup(func() { quicclient.SetDefaultRootCAs(nil) })
+
+	// Every node's store is opened full: whichever nodes the hash ring picks
+	// for this object's data/parity shards, the write is rejected.
+	quicServers := make([]*quicserver.QuicServer, 5)
+	for i := range 5 {
+		nodeDir := filepath.Join(dataDir, fmt.Sprintf("node-%d", i))
+		require.NoError(t, os.MkdirAll(nodeDir, 0750))
+
+		qs, err := quicserver.NewWithRetry(nodeDir, fmt.Sprintf("127.0.0.1:%d", testBasePort+i), 5,
+			quicserver.WithMasterKey(storetest.TestKey()),
+			quicserver.WithTLSCertFiles(certPath, keyPath),
+			quicserver.WithFreeSpaceWatermark(0.9999, 0.9999),
+		)
+		require.NoError(t, err, "failed to start QUIC server for node %d", i)
+		quicServers[i] = qs
+	}
+	defer func() {
+		for _, qs := range quicServers {
+			if qs != nil {
+				_ = qs.Close()
+			}
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	ctx := context.Background()
+	putReq := &s3backend.PutObjectRequest{
+		Bucket: bucket,
+		Key:    "full-pool-object",
+		Body:   bytes.NewReader(bytes.Repeat([]byte{0x1}, 4096)),
+	}
+
+	_, err = backend.PutObject(ctx, putReq)
+	require.Error(t, err, "PutObject against a full pool must fail")
+
+	s3err, ok := s3backend.IsS3Error(err)
+	require.True(t, ok, "error is not a *backend.S3Error: %v", err)
+	require.Equal(t, 507, s3err.StatusCode, "PutObject against a full pool must surface 507")
+	require.Equal(t, s3backend.ErrInsufficientStorage, s3err.Code)
+}

--- a/backend/distributed/put_test.go
+++ b/backend/distributed/put_test.go
@@ -19,9 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// mapPutErr is the seam between a QUIC shard-write failure and the S3
-// response a client sees. It must preserve the pool-full signal instead of
-// collapsing every putObjectViaQUIC failure into the same generic 500.
 func TestMapPutErrInsufficientStorage(t *testing.T) {
 	err := fmt.Errorf("put failed: %w", quicclient.ErrInsufficientStorage)
 
@@ -46,13 +43,9 @@ func TestMapPutErrOtherErrorStaysInternalError(t *testing.T) {
 	}
 }
 
-// TestPutObjectFullPoolReturns507EndToEnd drives the real seam: five live
-// QuicServer nodes, each opened with an unsatisfiable free-space watermark
-// (0.9999 free-space fraction, above any real disk), so every shard PUT hits
-// store.ErrStoreFull. That crosses handlePUTShard (quicproto.StatusInsufficientStorage),
-// quicclient.Put (ErrInsufficientStorage), and mapPutErr (backend.S3Error),
-// landing on Backend.PutObject as a real 507 — the same status handleError
-// forwards verbatim to the HTTP client.
+// TestPutObjectFullPoolReturns507EndToEnd drives PutObject against five QUIC
+// nodes opened with an unsatisfiable free-space watermark, so every shard
+// write is rejected and the failure must surface as a 507 end-to-end.
 func TestPutObjectFullPoolReturns507EndToEnd(t *testing.T) {
 	const bucket = "test-bucket-full"
 
@@ -82,8 +75,7 @@ func TestPutObjectFullPoolReturns507EndToEnd(t *testing.T) {
 	quicclient.SetDefaultRootCAs(pool)
 	t.Cleanup(func() { quicclient.SetDefaultRootCAs(nil) })
 
-	// Every node's store is opened full: whichever nodes the hash ring picks
-	// for this object's data/parity shards, the write is rejected.
+	// Every node is opened full, so whichever ones the hash ring picks reject the write.
 	quicServers := make([]*quicserver.QuicServer, 5)
 	for i := range 5 {
 		nodeDir := filepath.Join(dataDir, fmt.Sprintf("node-%d", i))

--- a/backend/errors.go
+++ b/backend/errors.go
@@ -129,11 +129,9 @@ var (
 		StatusCode: 409,
 	}
 
-	// ErrInsufficientStorageError is returned when the store's backing
-	// filesystem has crossed the full free-space watermark and rejected a
-	// write. StatusCode 507 (Insufficient Storage) lets the client
-	// distinguish "the pool is full, stop and back off" from a transient
-	// 500.
+	// ErrInsufficientStorageError is returned when the store's free-space
+	// watermark rejects a write; 507 lets clients distinguish this from a
+	// transient 500.
 	ErrInsufficientStorageError = &S3Error{
 		Code:       ErrInsufficientStorage,
 		Message:    "The storage pool is at capacity and cannot accept new writes",

--- a/backend/errors.go
+++ b/backend/errors.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"errors"
 	"fmt"
+	"net/http"
 )
 
 // S3ErrorCode represents standardized S3 error codes.
@@ -26,6 +27,7 @@ const (
 	ErrInvalidBucketName       S3ErrorCode = "InvalidBucketName"
 	ErrMissingParameter        S3ErrorCode = "MissingParameter"
 	ErrChecksumMismatch        S3ErrorCode = "XAmzContentChecksumMismatch"
+	ErrInsufficientStorage     S3ErrorCode = "InsufficientStorage"
 )
 
 // S3Error represents a typed S3 error with code and message.
@@ -125,6 +127,17 @@ var (
 		Code:       ErrBucketNotEmpty,
 		Message:    "The bucket you tried to delete is not empty.",
 		StatusCode: 409,
+	}
+
+	// ErrInsufficientStorageError is returned when the store's backing
+	// filesystem has crossed the full free-space watermark and rejected a
+	// write. StatusCode 507 (Insufficient Storage) lets the client
+	// distinguish "the pool is full, stop and back off" from a transient
+	// 500.
+	ErrInsufficientStorageError = &S3Error{
+		Code:       ErrInsufficientStorage,
+		Message:    "The storage pool is at capacity and cannot accept new writes",
+		StatusCode: http.StatusInsufficientStorage,
 	}
 )
 

--- a/backend/types.go
+++ b/backend/types.go
@@ -57,10 +57,8 @@ type PutObjectRequest struct {
 // PutObjectResponse contains the result of PutObject operation.
 type PutObjectResponse struct {
 	ETag string
-	// PoolNearFull reports whether any node holding a shard of this object
-	// was in the nearfull free-space band. The S3 handler surfaces this as
-	// the X-Predastore-Pool-Pressure response header so clients can start
-	// backing off before the pool actually goes full.
+	// PoolNearFull reports whether any shard's node was in the nearfull
+	// free-space band; surfaced to clients via the X-Predastore-Pool-Pressure header.
 	PoolNearFull bool
 }
 

--- a/backend/types.go
+++ b/backend/types.go
@@ -57,6 +57,11 @@ type PutObjectRequest struct {
 // PutObjectResponse contains the result of PutObject operation.
 type PutObjectResponse struct {
 	ETag string
+	// PoolNearFull reports whether any node holding a shard of this object
+	// was in the nearfull free-space band. The S3 handler surfaces this as
+	// the X-Predastore-Pool-Pressure response header so clients can start
+	// backing off before the pool actually goes full.
+	PoolNearFull bool
 }
 
 // DeleteObjectRequest contains parameters for DeleteObject operation.

--- a/quic/quicclient/quicclient.go
+++ b/quic/quicclient/quicclient.go
@@ -21,17 +21,13 @@ const (
 	alpn = "mulga-repl-v1"
 )
 
-// ErrInsufficientStorage is returned by Put when the remote node's store
-// rejected the write because its backing filesystem crossed the full
-// free-space watermark (quicproto.StatusInsufficientStorage). Callers that
-// need to distinguish "backend is full" from an ordinary transport/server
-// failure should errors.Is against this rather than parsing status text.
+// ErrInsufficientStorage is returned by Put when the remote store rejected
+// the write for crossing its free-space watermark. Callers should
+// errors.Is against this rather than parsing status text.
 var ErrInsufficientStorage = errors.New("insufficient storage")
 
 // classifyPutStatus turns a non-OK PUT response status into the error Put
-// returns, preserving StatusInsufficientStorage as a distinguishable
-// sentinel instead of collapsing every non-OK status into the same generic
-// "put: status N" error.
+// returns, wrapping ErrInsufficientStorage for StatusInsufficientStorage.
 func classifyPutStatus(status uint16) error {
 	if status == quicproto.StatusInsufficientStorage {
 		return fmt.Errorf("put: status %d: %w", status, ErrInsufficientStorage)

--- a/quic/quicclient/quicclient.go
+++ b/quic/quicclient/quicclient.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -19,6 +20,24 @@ import (
 const (
 	alpn = "mulga-repl-v1"
 )
+
+// ErrInsufficientStorage is returned by Put when the remote node's store
+// rejected the write because its backing filesystem crossed the full
+// free-space watermark (quicproto.StatusInsufficientStorage). Callers that
+// need to distinguish "backend is full" from an ordinary transport/server
+// failure should errors.Is against this rather than parsing status text.
+var ErrInsufficientStorage = errors.New("insufficient storage")
+
+// classifyPutStatus turns a non-OK PUT response status into the error Put
+// returns, preserving StatusInsufficientStorage as a distinguishable
+// sentinel instead of collapsing every non-OK status into the same generic
+// "put: status N" error.
+func classifyPutStatus(status uint16) error {
+	if status == quicproto.StatusInsufficientStorage {
+		return fmt.Errorf("put: status %d: %w", status, ErrInsufficientStorage)
+	}
+	return fmt.Errorf("put: status %d", status)
+}
 
 type Client struct {
 	conn          *quic.Conn
@@ -87,7 +106,7 @@ func (c *Client) Put(ctx context.Context, putReq quicserver.PutRequest, shardDat
 	}
 
 	if rh.Status != quicproto.StatusOK {
-		return nil, fmt.Errorf("put: status %d", rh.Status)
+		return nil, classifyPutStatus(rh.Status)
 	}
 
 	var response quicserver.PutResponse

--- a/quic/quicclient/quicclient_test.go
+++ b/quic/quicclient/quicclient_test.go
@@ -1,10 +1,34 @@
 package quicclient
 
 import (
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/mulgadc/predastore/quic/quicproto"
 )
+
+// classifyPutStatus is the seam Put uses to turn a non-OK response status
+// into an error. A status of StatusInsufficientStorage must be
+// distinguishable via errors.Is(err, ErrInsufficientStorage) so callers
+// (the distributed backend) can translate it into a 507 S3 response instead
+// of collapsing it into a generic failure.
+func TestClassifyPutStatusInsufficientStorageIsDistinguishable(t *testing.T) {
+	err := classifyPutStatus(quicproto.StatusInsufficientStorage)
+	if !errors.Is(err, ErrInsufficientStorage) {
+		t.Fatalf("classifyPutStatus(%d) = %v, want an error wrapping ErrInsufficientStorage", quicproto.StatusInsufficientStorage, err)
+	}
+}
+
+func TestClassifyPutStatusOtherStatusIsNotInsufficientStorage(t *testing.T) {
+	for _, status := range []uint16{quicproto.StatusBadRequest, quicproto.StatusServerError, quicproto.StatusUnavailable, quicproto.StatusNotFound} {
+		err := classifyPutStatus(status)
+		if errors.Is(err, ErrInsufficientStorage) {
+			t.Fatalf("classifyPutStatus(%d) unexpectedly wraps ErrInsufficientStorage", status)
+		}
+	}
+}
 
 func TestClientActiveStreams(t *testing.T) {
 	c := &Client{}

--- a/quic/quicclient/quicclient_test.go
+++ b/quic/quicclient/quicclient_test.go
@@ -9,11 +9,6 @@ import (
 	"github.com/mulgadc/predastore/quic/quicproto"
 )
 
-// classifyPutStatus is the seam Put uses to turn a non-OK response status
-// into an error. A status of StatusInsufficientStorage must be
-// distinguishable via errors.Is(err, ErrInsufficientStorage) so callers
-// (the distributed backend) can translate it into a 507 S3 response instead
-// of collapsing it into a generic failure.
 func TestClassifyPutStatusInsufficientStorageIsDistinguishable(t *testing.T) {
 	err := classifyPutStatus(quicproto.StatusInsufficientStorage)
 	if !errors.Is(err, ErrInsufficientStorage) {

--- a/quic/quicproto/quicproto.go
+++ b/quic/quicproto/quicproto.go
@@ -23,6 +23,11 @@ const (
 	StatusServerError  uint16 = 500
 	StatusUnavailable  uint16 = 503
 	StatusUnauthorized uint16 = 401
+
+	// StatusInsufficientStorage signals that the store's backing filesystem
+	// crossed the full free-space watermark and rejected the write. Mirrors
+	// HTTP 507 so it survives translation straight through to the S3 client.
+	StatusInsufficientStorage uint16 = 507
 )
 
 var (

--- a/quic/quicserver/put.go
+++ b/quic/quicserver/put.go
@@ -29,18 +29,11 @@ func (qs *QuicServer) handlePUTShard(br *bufio.Reader, bw *bufio.Writer, req qui
 
 	writer, err := qs.store.Append(putReq.ObjectHash, putReq.ShardIndex, bodyLen)
 	if err != nil {
-		// Append rejected before consuming the request body. The client is
-		// still streaming it, so drain (and discard) the body before replying:
-		// returning without reading resets the un-drained QUIC stream mid-upload,
-		// and the client sees a stream cancellation instead of our status code —
-		// which loses the out-of-space signal entirely. Draining lets the client
-		// finish its write and read the real status.
+		// An un-drained QUIC stream gets reset instead of carrying our status
+		// code, so drain the client's in-flight body before replying.
 		if _, derr := io.Copy(io.Discard, io.LimitReader(br, bodyLen)); derr != nil {
 			slog.Warn("handlePUTShard: draining body after append error failed", "error", derr)
 		}
-		// The pool free-space watermark tripped: surface a distinguishable
-		// status so the client sees a real out-of-space error instead of a
-		// generic server failure. Every other Append error stays 500.
 		if errors.Is(err, store.ErrStoreFull) {
 			slog.Warn("handlePUTShard: store full, rejecting write", "error", err)
 			writeErr(bw, req, quicproto.StatusInsufficientStorage, fmt.Sprintf("append: %v", err))
@@ -63,9 +56,8 @@ func (qs *QuicServer) handlePUTShard(br *bufio.Reader, bw *bufio.Writer, req qui
 		return
 	}
 
-	// Surface pool pressure on the success path so a client backing off early
-	// (e.g. viperblock refusing new guest writes) learns about the nearfull
-	// band before this node ever rejects a write outright.
+	// Surface nearfull pressure on success too, so callers can back off
+	// before a write is ever outright rejected.
 	response := PutResponse{ShardSize: bodyLen, PoolNearFull: qs.store.NearFull()}
 	respBytes, err := json.Marshal(response)
 	if err != nil {

--- a/quic/quicserver/put.go
+++ b/quic/quicserver/put.go
@@ -3,11 +3,13 @@ package quicserver
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 
 	"github.com/mulgadc/predastore/quic/quicproto"
+	"github.com/mulgadc/predastore/store"
 )
 
 // handlePUTShard receives shard data via QUIC and writes it to the local store.
@@ -27,6 +29,23 @@ func (qs *QuicServer) handlePUTShard(br *bufio.Reader, bw *bufio.Writer, req qui
 
 	writer, err := qs.store.Append(putReq.ObjectHash, putReq.ShardIndex, bodyLen)
 	if err != nil {
+		// Append rejected before consuming the request body. The client is
+		// still streaming it, so drain (and discard) the body before replying:
+		// returning without reading resets the un-drained QUIC stream mid-upload,
+		// and the client sees a stream cancellation instead of our status code —
+		// which loses the out-of-space signal entirely. Draining lets the client
+		// finish its write and read the real status.
+		if _, derr := io.Copy(io.Discard, io.LimitReader(br, bodyLen)); derr != nil {
+			slog.Warn("handlePUTShard: draining body after append error failed", "error", derr)
+		}
+		// The pool free-space watermark tripped: surface a distinguishable
+		// status so the client sees a real out-of-space error instead of a
+		// generic server failure. Every other Append error stays 500.
+		if errors.Is(err, store.ErrStoreFull) {
+			slog.Warn("handlePUTShard: store full, rejecting write", "error", err)
+			writeErr(bw, req, quicproto.StatusInsufficientStorage, fmt.Sprintf("append: %v", err))
+			return
+		}
 		slog.Error("handlePUTShard: append failed", "error", err)
 		writeErr(bw, req, quicproto.StatusServerError, fmt.Sprintf("append: %v", err))
 		return
@@ -44,7 +63,10 @@ func (qs *QuicServer) handlePUTShard(br *bufio.Reader, bw *bufio.Writer, req qui
 		return
 	}
 
-	response := PutResponse{ShardSize: bodyLen}
+	// Surface pool pressure on the success path so a client backing off early
+	// (e.g. viperblock refusing new guest writes) learns about the nearfull
+	// band before this node ever rejects a write outright.
+	response := PutResponse{ShardSize: bodyLen, PoolNearFull: qs.store.NearFull()}
 	respBytes, err := json.Marshal(response)
 	if err != nil {
 		writeErr(bw, req, quicproto.StatusServerError, "marshal response failed")

--- a/quic/quicserver/put_e2e_test.go
+++ b/quic/quicserver/put_e2e_test.go
@@ -36,19 +36,11 @@ func newFullTestQuicServer(t *testing.T) (*quicserver.QuicServer, string) {
 	return qs, addr
 }
 
-// TestHandlePUTShardDrainsBodyBeforeRejectingOverQUIC is a regression test
-// for a bug where handlePUTShard replied with an error status without first
-// draining the client's in-flight body. Returning early left the QUIC stream
-// un-drained; when handleStream's deferred cleanup then called
-// s.CancelRead(0), a client still blocked writing the body saw the stream
-// reset instead of the response — the 507 out-of-space status never arrived.
-//
-// The body here (4 MiB) exceeds quicconf.InitialStreamReceiveWindow (2 MiB)
-// and the server never reads application-level bytes from a rejected PUT, so
-// the client's write blocks on flow control until the server actually drains
-// it. That only happens post-fix, which is what makes this reproduce the bug
-// without the drain: without it, client.Put fails with a transport-level
-// stream error instead of wrapping quicclient.ErrInsufficientStorage.
+// TestHandlePUTShardDrainsBodyBeforeRejectingOverQUIC pins down that a
+// rejected PUT drains the client's in-flight body before replying, so the
+// client observes the real status instead of a stream reset. The body size
+// exceeds the QUIC receive window, so the client blocks on flow control
+// until the server drains it.
 func TestHandlePUTShardDrainsBodyBeforeRejectingOverQUIC(t *testing.T) {
 	qs, addr := newFullTestQuicServer(t)
 	defer qs.Close()

--- a/quic/quicserver/put_e2e_test.go
+++ b/quic/quicserver/put_e2e_test.go
@@ -1,0 +1,77 @@
+package quicserver_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore/internal/storetest"
+	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/quic/quicclient"
+	"github.com/mulgadc/predastore/quic/quicserver"
+	"github.com/stretchr/testify/require"
+)
+
+// newFullTestQuicServer is newTestQuicServer (wedge_test.go) with the free-
+// space watermark forced unsatisfiable, so every Append on this node's store
+// fails with store.ErrStoreFull.
+func newFullTestQuicServer(t *testing.T) (*quicserver.QuicServer, string) {
+	t.Helper()
+	dir := t.TempDir()
+	port := 46000 + int(quicServerTestPortCounter.Add(1))
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	certPath, keyPath, pool := testcerts.Generate(t)
+	quicclient.SetDefaultRootCAs(pool)
+	t.Cleanup(func() { quicclient.SetDefaultRootCAs(nil) })
+	qs, err := quicserver.NewWithRetry(filepath.Join(dir, "wal"), addr, 5,
+		quicserver.WithMasterKey(storetest.TestKey()),
+		quicserver.WithTLSCertFiles(certPath, keyPath),
+		quicserver.WithFreeSpaceWatermark(0.9999, 0.9999),
+	)
+	require.NoError(t, err)
+	return qs, addr
+}
+
+// TestHandlePUTShardDrainsBodyBeforeRejectingOverQUIC is a regression test
+// for a bug where handlePUTShard replied with an error status without first
+// draining the client's in-flight body. Returning early left the QUIC stream
+// un-drained; when handleStream's deferred cleanup then called
+// s.CancelRead(0), a client still blocked writing the body saw the stream
+// reset instead of the response — the 507 out-of-space status never arrived.
+//
+// The body here (4 MiB) exceeds quicconf.InitialStreamReceiveWindow (2 MiB)
+// and the server never reads application-level bytes from a rejected PUT, so
+// the client's write blocks on flow control until the server actually drains
+// it. That only happens post-fix, which is what makes this reproduce the bug
+// without the drain: without it, client.Put fails with a transport-level
+// stream error instead of wrapping quicclient.ErrInsufficientStorage.
+func TestHandlePUTShardDrainsBodyBeforeRejectingOverQUIC(t *testing.T) {
+	qs, addr := newFullTestQuicServer(t)
+	defer qs.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	client, err := quicclient.Dial(ctx, addr)
+	require.NoError(t, err)
+	defer client.Close()
+
+	const bodySize = 4 * 1024 * 1024
+	body := bytes.Repeat([]byte{0x7}, bodySize)
+	hash := sha256.Sum256([]byte("full-store-drain-regression"))
+
+	_, err = client.Put(ctx, quicserver.PutRequest{
+		Bucket:     "full",
+		Object:     "obj",
+		ObjectHash: hash,
+		ShardSize:  bodySize,
+		ShardIndex: 0,
+	}, bytes.NewReader(body))
+
+	require.Error(t, err, "PUT against a full store must fail")
+	require.ErrorIs(t, err, quicclient.ErrInsufficientStorage,
+		"client must observe StatusInsufficientStorage (507), not a stream reset/cancellation")
+}

--- a/quic/quicserver/put_test.go
+++ b/quic/quicserver/put_test.go
@@ -21,10 +21,7 @@ func readPutResponse(t *testing.T, out *bytes.Buffer) quicproto.Header {
 	return hdr
 }
 
-// A store whose full watermark is set to reject everything (0.9999 free-space
-// fraction, guaranteed above any real disk's free fraction) exercises the
-// exact seam handlePUTShard uses to translate store.ErrStoreFull into a wire
-// status, without mocking statfs.
+// fullStore sets a full watermark that rejects everything, without mocking statfs.
 func fullStore(t *testing.T) *store.Store {
 	t.Helper()
 	st, err := store.Open(t.TempDir(),
@@ -56,10 +53,8 @@ func TestHandlePUTShardStoreFullReturnsInsufficientStorage(t *testing.T) {
 	}
 }
 
-// A store that is not full must still surface an ordinary 500 for an
-// unrelated Append failure — the 507 path must not swallow other errors.
-// Closing the store makes Append fail with store.ErrClosedStore, which is
-// deliberately NOT store.ErrStoreFull.
+// Closing the store makes Append fail with store.ErrClosedStore, not
+// store.ErrStoreFull, so the 507 path must not swallow it.
 func TestHandlePUTShardOtherAppendErrorStaysServerError(t *testing.T) {
 	st, err := store.Open(t.TempDir(), store.WithAEAD(storetest.TestAEAD()))
 	if err != nil {

--- a/quic/quicserver/put_test.go
+++ b/quic/quicserver/put_test.go
@@ -1,0 +1,87 @@
+package quicserver
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/mulgadc/predastore/internal/storetest"
+	"github.com/mulgadc/predastore/quic/quicproto"
+	"github.com/mulgadc/predastore/store"
+)
+
+// handlePUTShard writes its response header + meta straight onto bw; decode
+// it back to inspect the status the client would have seen.
+func readPutResponse(t *testing.T, out *bytes.Buffer) quicproto.Header {
+	t.Helper()
+	hdr, err := quicproto.ReadHeader(bufio.NewReader(out))
+	if err != nil {
+		t.Fatalf("read response header: %v", err)
+	}
+	return hdr
+}
+
+// A store whose full watermark is set to reject everything (0.9999 free-space
+// fraction, guaranteed above any real disk's free fraction) exercises the
+// exact seam handlePUTShard uses to translate store.ErrStoreFull into a wire
+// status, without mocking statfs.
+func fullStore(t *testing.T) *store.Store {
+	t.Helper()
+	st, err := store.Open(t.TempDir(),
+		store.WithAEAD(storetest.TestAEAD()),
+		store.WithFreeSpaceWatermark(0.9999, 0.9999),
+	)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func TestHandlePUTShardStoreFullReturnsInsufficientStorage(t *testing.T) {
+	qs := &QuicServer{store: fullStore(t)}
+
+	var out bytes.Buffer
+	bw := bufio.NewWriter(&out)
+	br := bufio.NewReader(bytes.NewReader(nil))
+
+	req := quicproto.Header{Version: quicproto.Version1, Method: quicproto.MethodPUT, ReqID: 1, BodyLen: 4}
+	putReq := PutRequest{ObjectHash: [32]byte{0x1}, ShardIndex: 0, ShardSize: 4}
+
+	qs.handlePUTShard(br, bw, req, putReq)
+
+	hdr := readPutResponse(t, &out)
+	if hdr.Status != quicproto.StatusInsufficientStorage {
+		t.Fatalf("response status = %d, want %d (StatusInsufficientStorage)", hdr.Status, quicproto.StatusInsufficientStorage)
+	}
+}
+
+// A store that is not full must still surface an ordinary 500 for an
+// unrelated Append failure — the 507 path must not swallow other errors.
+// Closing the store makes Append fail with store.ErrClosedStore, which is
+// deliberately NOT store.ErrStoreFull.
+func TestHandlePUTShardOtherAppendErrorStaysServerError(t *testing.T) {
+	st, err := store.Open(t.TempDir(), store.WithAEAD(storetest.TestAEAD()))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	qs := &QuicServer{store: st}
+
+	var out bytes.Buffer
+	bw := bufio.NewWriter(&out)
+	br := bufio.NewReader(bytes.NewReader(nil))
+
+	req := quicproto.Header{Version: quicproto.Version1, Method: quicproto.MethodPUT, ReqID: 1, BodyLen: 4}
+	putReq := PutRequest{ObjectHash: [32]byte{0x2}, ShardIndex: 0, ShardSize: 4}
+
+	qs.handlePUTShard(br, bw, req, putReq)
+
+	hdr := readPutResponse(t, &out)
+	if hdr.Status != quicproto.StatusServerError {
+		t.Fatalf("response status = %d, want %d (StatusServerError)", hdr.Status, quicproto.StatusServerError)
+	}
+}

--- a/quic/quicserver/server.go
+++ b/quic/quicserver/server.go
@@ -40,6 +40,14 @@ type QuicServer struct {
 
 	compactionInterval time.Duration
 
+	// Free-space watermark override for the store; see WithFreeSpaceWatermark.
+	// watermarkSet distinguishes "explicitly set to 0" from "unset, use the
+	// store's own defaults" — a zero fullFreeFrac is a legitimate (if
+	// permissive) configuration.
+	nearfullFreeFrac float64
+	fullFreeFrac     float64
+	watermarkSet     bool
+
 	store *store.Store
 
 	// Listener for graceful shutdown
@@ -101,6 +109,18 @@ func WithCompactionInterval(d time.Duration) Option {
 	}
 }
 
+// WithFreeSpaceWatermark overrides the store's pool free-space watermark
+// fractions (see store.WithFreeSpaceWatermark). Without this option the
+// store's built-in defaults apply (nearfull 0.15 / full 0.05 free).
+func WithFreeSpaceWatermark(nearfullFreeFrac, fullFreeFrac float64) Option {
+	return func(qs *QuicServer) error {
+		qs.nearfullFreeFrac = nearfullFreeFrac
+		qs.fullFreeFrac = fullFreeFrac
+		qs.watermarkSet = true
+		return nil
+	}
+}
+
 type ObjectRequest struct {
 	Bucket     string `json:"bucket"`
 	Object     string `json:"object"`
@@ -121,8 +141,15 @@ type PutRequest struct {
 
 // PutResponse contains the result of a QUIC PUT operation.
 type PutResponse struct {
-	ShardSize int64  `json:"shard_size"`
-	Error     string `json:"error,omitempty"`
+	ShardSize int64 `json:"shard_size"`
+	// PoolNearFull reports whether this node's store was in the nearfull
+	// free-space band (accepted the write but under pressure) at commit time.
+	// Only ever set on a successful response — a rejected write fails with
+	// StatusInsufficientStorage instead. Aggregated across shards by the
+	// distributed backend into PutObjectResponse.PoolNearFull so callers see
+	// the pressure signal before any node actually goes full.
+	PoolNearFull bool   `json:"pool_near_full,omitempty"`
+	Error        string `json:"error,omitempty"`
 }
 
 // DeleteRequest contains metadata for deleting a shard via QUIC DELETE.
@@ -172,7 +199,11 @@ func NewWithRetry(walDir string, addr string, maxRetries int, opts ...Option) (*
 		return nil, fmt.Errorf("quicserver: tls cert and key are required (use WithTLSCertFiles)")
 	}
 
-	s, err := store.Open(walDir, store.WithAEAD(qs.aead), store.WithCompaction(qs.compactionInterval))
+	storeOpts := []store.Option{store.WithAEAD(qs.aead), store.WithCompaction(qs.compactionInterval)}
+	if qs.watermarkSet {
+		storeOpts = append(storeOpts, store.WithFreeSpaceWatermark(qs.nearfullFreeFrac, qs.fullFreeFrac))
+	}
+	s, err := store.Open(walDir, storeOpts...)
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("open store in %s: %w", walDir, err)

--- a/quic/quicserver/server.go
+++ b/quic/quicserver/server.go
@@ -41,9 +41,8 @@ type QuicServer struct {
 	compactionInterval time.Duration
 
 	// Free-space watermark override for the store; see WithFreeSpaceWatermark.
-	// watermarkSet distinguishes "explicitly set to 0" from "unset, use the
-	// store's own defaults" — a zero fullFreeFrac is a legitimate (if
-	// permissive) configuration.
+	// watermarkSet distinguishes "explicitly set to 0" from "unset, use
+	// store defaults", since a zero fullFreeFrac is otherwise legitimate.
 	nearfullFreeFrac float64
 	fullFreeFrac     float64
 	watermarkSet     bool
@@ -143,11 +142,8 @@ type PutRequest struct {
 type PutResponse struct {
 	ShardSize int64 `json:"shard_size"`
 	// PoolNearFull reports whether this node's store was in the nearfull
-	// free-space band (accepted the write but under pressure) at commit time.
-	// Only ever set on a successful response — a rejected write fails with
-	// StatusInsufficientStorage instead. Aggregated across shards by the
-	// distributed backend into PutObjectResponse.PoolNearFull so callers see
-	// the pressure signal before any node actually goes full.
+	// free-space band at commit time. Only set on success — a rejected
+	// write fails with StatusInsufficientStorage instead.
 	PoolNearFull bool   `json:"pool_near_full,omitempty"`
 	Error        string `json:"error,omitempty"`
 }

--- a/s3/handleerror_test.go
+++ b/s3/handleerror_test.go
@@ -36,8 +36,7 @@ func TestHandleError_BackendS3Error(t *testing.T) {
 	assert.Equal(t, "NoSuchBucket", s3error.Code)
 }
 
-// The pool free-space watermark's 507 must reach the HTTP client verbatim,
-// the same forwarding path any other *backend.S3Error takes.
+// The 507 must reach the HTTP client verbatim, like any other *backend.S3Error.
 func TestHandleError_InsufficientStorage(t *testing.T) {
 	server := setupHandleErrorServer(t)
 	req := httptest.NewRequest(http.MethodPut, "/bucket/key", nil)

--- a/s3/handleerror_test.go
+++ b/s3/handleerror_test.go
@@ -36,6 +36,22 @@ func TestHandleError_BackendS3Error(t *testing.T) {
 	assert.Equal(t, "NoSuchBucket", s3error.Code)
 }
 
+// The pool free-space watermark's 507 must reach the HTTP client verbatim,
+// the same forwarding path any other *backend.S3Error takes.
+func TestHandleError_InsufficientStorage(t *testing.T) {
+	server := setupHandleErrorServer(t)
+	req := httptest.NewRequest(http.MethodPut, "/bucket/key", nil)
+	rr := httptest.NewRecorder()
+
+	server.handleError(rr, req, backend.ErrInsufficientStorageError)
+
+	assert.Equal(t, http.StatusInsufficientStorage, rr.Code)
+
+	var s3error S3Error
+	require.NoError(t, xml.Unmarshal(rr.Body.Bytes(), &s3error))
+	assert.Equal(t, "InsufficientStorage", s3error.Code)
+}
+
 func TestHandleError_NoSuchBucketString(t *testing.T) {
 	server := setupHandleErrorServer(t)
 	req := httptest.NewRequest(http.MethodGet, "/bucket/key", nil)

--- a/s3/httpserver.go
+++ b/s3/httpserver.go
@@ -662,9 +662,8 @@ func (s *HTTP2Server) putObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Pool free-space watermark: a nearfull node still accepted this write,
-	// but a client (e.g. viperblock) that sees this header can stop admitting
-	// new work early rather than waiting to hit the hard 507 full rejection.
+	// Nearfull writes still succeed; the header lets clients back off before
+	// hitting the hard 507 rejection.
 	if resp.PoolNearFull {
 		w.Header().Set("X-Predastore-Pool-Pressure", "nearfull")
 	}

--- a/s3/httpserver.go
+++ b/s3/httpserver.go
@@ -662,6 +662,12 @@ func (s *HTTP2Server) putObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Pool free-space watermark: a nearfull node still accepted this write,
+	// but a client (e.g. viperblock) that sees this header can stop admitting
+	// new work early rather than waiting to hit the hard 507 full rejection.
+	if resp.PoolNearFull {
+		w.Header().Set("X-Predastore-Pool-Pressure", "nearfull")
+	}
 	w.Header().Set("ETag", resp.ETag)
 	w.WriteHeader(http.StatusOK)
 }

--- a/store/compaction.go
+++ b/store/compaction.go
@@ -32,8 +32,8 @@ type compactor struct {
 
 	// kick requests an out-of-cycle compaction pass. Buffered to 1 so a
 	// non-blocking send never stalls the caller (Append holds store.mutex
-	// while it sends); a pending kick already covers any kick that arrives
-	// before the loop drains it, so coalescing is correct, not lossy.
+	// while it sends); a pending kick already covers one that arrives
+	// before the loop drains it.
 	kick chan struct{}
 
 	wg sync.WaitGroup
@@ -68,12 +68,10 @@ func (c *compactor) loop() {
 	}
 }
 
-// kickCompaction requests an immediate compaction pass without blocking the
-// caller. compactOnce takes store.mutex, which Append (the caller on the
-// nearfull path) already holds for its whole body, so this can never call
-// compactOnce inline — it only signals the independent compactor goroutine,
-// which picks the kick up on its own schedule. A no-op if compaction is
-// disabled (no WithCompaction) or a kick is already pending.
+// kickCompaction signals the compactor goroutine to run an immediate pass,
+// without calling compactOnce inline — Append (its caller on the nearfull
+// path) already holds store.mutex, which compactOnce also needs. A no-op if
+// compaction is disabled or a kick is already pending.
 func (store *Store) kickCompaction() {
 	if store.compactor == nil {
 		return

--- a/store/compaction.go
+++ b/store/compaction.go
@@ -29,11 +29,18 @@ const (
 type compactor struct {
 	store *Store
 	done  chan struct{}
-	wg    sync.WaitGroup
+
+	// kick requests an out-of-cycle compaction pass. Buffered to 1 so a
+	// non-blocking send never stalls the caller (Append holds store.mutex
+	// while it sends); a pending kick already covers any kick that arrives
+	// before the loop drains it, so coalescing is correct, not lossy.
+	kick chan struct{}
+
+	wg sync.WaitGroup
 }
 
 func (store *Store) startCompactor() {
-	c := &compactor{store: store, done: make(chan struct{})}
+	c := &compactor{store: store, done: make(chan struct{}), kick: make(chan struct{}, 1)}
 	store.compactor = c
 	c.wg.Add(1)
 	slog.Info("compactor started")
@@ -53,7 +60,27 @@ func (c *compactor) loop() {
 			if err := c.store.compactOnce(); err != nil {
 				slog.Error("compaction cycle failed", "error", err)
 			}
+		case <-c.kick:
+			if err := c.store.compactOnce(); err != nil {
+				slog.Error("kicked compaction cycle failed", "error", err)
+			}
 		}
+	}
+}
+
+// kickCompaction requests an immediate compaction pass without blocking the
+// caller. compactOnce takes store.mutex, which Append (the caller on the
+// nearfull path) already holds for its whole body, so this can never call
+// compactOnce inline — it only signals the independent compactor goroutine,
+// which picks the kick up on its own schedule. A no-op if compaction is
+// disabled (no WithCompaction) or a kick is already pending.
+func (store *Store) kickCompaction() {
+	if store.compactor == nil {
+		return
+	}
+	select {
+	case store.compactor.kick <- struct{}{}:
+	default:
 	}
 }
 

--- a/store/compaction_internal_test.go
+++ b/store/compaction_internal_test.go
@@ -25,7 +25,14 @@ func testAEAD(t *testing.T) cipher.AEAD {
 func openTestStore(t *testing.T, opts ...Option) (*Store, string) {
 	t.Helper()
 	dir := t.TempDir()
-	st, err := Open(dir, append(opts, WithAEAD(testAEAD(t)))...)
+	// Tests share a host whose real free-space fraction is outside this
+	// suite's control (CI runners, busy dev boxes, tmpfs-backed TempDir all
+	// fluctuate). Default the watermark off (0, 0 never crosses either
+	// threshold) so ordinary tests don't flake on ambient disk pressure;
+	// callers that actually want to exercise the watermark pass their own
+	// WithFreeSpaceWatermark in opts, which is applied after and wins.
+	base := append([]Option{WithFreeSpaceWatermark(0, 0)}, opts...)
+	st, err := Open(dir, append(base, WithAEAD(testAEAD(t)))...)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}

--- a/store/compaction_internal_test.go
+++ b/store/compaction_internal_test.go
@@ -25,12 +25,9 @@ func testAEAD(t *testing.T) cipher.AEAD {
 func openTestStore(t *testing.T, opts ...Option) (*Store, string) {
 	t.Helper()
 	dir := t.TempDir()
-	// Tests share a host whose real free-space fraction is outside this
-	// suite's control (CI runners, busy dev boxes, tmpfs-backed TempDir all
-	// fluctuate). Default the watermark off (0, 0 never crosses either
-	// threshold) so ordinary tests don't flake on ambient disk pressure;
-	// callers that actually want to exercise the watermark pass their own
-	// WithFreeSpaceWatermark in opts, which is applied after and wins.
+	// Default the watermark off (0, 0 never crosses either threshold) so
+	// ordinary tests don't flake on ambient disk pressure; callers that want
+	// to exercise it pass their own WithFreeSpaceWatermark, applied after.
 	base := append([]Option{WithFreeSpaceWatermark(0, 0)}, opts...)
 	st, err := Open(dir, append(base, WithAEAD(testAEAD(t)))...)
 	if err != nil {

--- a/store/freespace.go
+++ b/store/freespace.go
@@ -12,34 +12,26 @@ const (
 	defaultNearfullFreeFrac = 0.15
 
 	// defaultFullFreeFrac is the free-space fraction below which Append
-	// rejects writes with ErrStoreFull. The 5% reserve protects the OS
-	// (journald, process forking, OVN/OVS) and leaves compaction its own
-	// read-modify-write scratch space.
+	// rejects writes with ErrStoreFull, reserving headroom for the OS and
+	// for compaction's own read-modify-write scratch space.
 	defaultFullFreeFrac = 0.05
 
-	// statfsThrottleInterval bounds how often Append pays for a statfs
-	// syscall. Free space does not move fast enough at shard-write
-	// granularity to justify measuring it on every call.
+	// statfsThrottleInterval bounds how often Append pays for a statfs syscall.
 	statfsThrottleInterval = 1 * time.Second
 
 	// statfsBytesInterval forces a fresh statfs once this many bytes have been
 	// reserved since the last measurement, regardless of statfsThrottleInterval.
-	// Free space tracks write volume, not wall-clock time: a burst writing
-	// hundreds of MB/s blows straight through the full watermark inside a single
-	// throttle window if the reading is only refreshed on the timer. Bounding it
-	// by bytes caps the worst-case overshoot between measurements at roughly this
-	// value, well inside the reserve the full watermark protects.
+	// Free space tracks write volume, not wall-clock time, so a fast burst
+	// needs a byte bound to keep from overshooting the watermark between
+	// timed refreshes.
 	statfsBytesInterval = 64 << 20 // 64 MiB
 )
 
 // statfsFree reports the free-space fraction of the filesystem backing dir,
-// as Bavail/Blocks — space available to an unprivileged writer over total
-// capacity. Using Bavail rather than Bfree means a filesystem's own reserved-
-// blocks headroom (e.g. ext4's default 5% root reserve) is already excluded,
-// so the watermark measures the same budget an actual write would see.
+// as Bavail/Blocks — space available to an unprivileged writer, excluding a
+// filesystem's own reserved-blocks headroom.
 //
-// A package-level var so tests can substitute a synthetic implementation
-// without depending on the real disk's free space.
+// A package-level var so tests can substitute a synthetic implementation.
 var statfsFree = func(dir string) (float64, error) {
 	var stat syscall.Statfs_t
 	if err := syscall.Statfs(dir, &stat); err != nil {
@@ -56,12 +48,7 @@ var statfsFree = func(dir string) (float64, error) {
 // hold store.mutex — Append is the only caller today, and it already does.
 func (store *Store) freeSpaceFraction() (float64, error) {
 	now := time.Now()
-	// Serve the cache only while BOTH bounds hold: the throttle interval has not
-	// elapsed AND not enough bytes have been reserved since the last measurement
-	// to have moved free space materially. The byte bound is what stops a fast
-	// write burst from racing past the watermark inside the 1s window — statfs
-	// alone lags the reserve rate, and the store can reach 0 free before the next
-	// timed refresh fires.
+	// Cache is valid only while both the time and byte bounds hold.
 	if !store.statfsAt.IsZero() &&
 		now.Sub(store.statfsAt) < statfsThrottleInterval &&
 		store.bytesSinceStatfs < statfsBytesInterval {

--- a/store/freespace.go
+++ b/store/freespace.go
@@ -1,0 +1,94 @@
+package store
+
+import (
+	"fmt"
+	"syscall"
+	"time"
+)
+
+const (
+	// defaultNearfullFreeFrac is the free-space fraction below which Append
+	// kicks an immediate compaction pass but still accepts writes.
+	defaultNearfullFreeFrac = 0.15
+
+	// defaultFullFreeFrac is the free-space fraction below which Append
+	// rejects writes with ErrStoreFull. The 5% reserve protects the OS
+	// (journald, process forking, OVN/OVS) and leaves compaction its own
+	// read-modify-write scratch space.
+	defaultFullFreeFrac = 0.05
+
+	// statfsThrottleInterval bounds how often Append pays for a statfs
+	// syscall. Free space does not move fast enough at shard-write
+	// granularity to justify measuring it on every call.
+	statfsThrottleInterval = 1 * time.Second
+
+	// statfsBytesInterval forces a fresh statfs once this many bytes have been
+	// reserved since the last measurement, regardless of statfsThrottleInterval.
+	// Free space tracks write volume, not wall-clock time: a burst writing
+	// hundreds of MB/s blows straight through the full watermark inside a single
+	// throttle window if the reading is only refreshed on the timer. Bounding it
+	// by bytes caps the worst-case overshoot between measurements at roughly this
+	// value, well inside the reserve the full watermark protects.
+	statfsBytesInterval = 64 << 20 // 64 MiB
+)
+
+// statfsFree reports the free-space fraction of the filesystem backing dir,
+// as Bavail/Blocks — space available to an unprivileged writer over total
+// capacity. Using Bavail rather than Bfree means a filesystem's own reserved-
+// blocks headroom (e.g. ext4's default 5% root reserve) is already excluded,
+// so the watermark measures the same budget an actual write would see.
+//
+// A package-level var so tests can substitute a synthetic implementation
+// without depending on the real disk's free space.
+var statfsFree = func(dir string) (float64, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(dir, &stat); err != nil {
+		return 0, fmt.Errorf("statfs %s: %w", dir, err)
+	}
+	if stat.Blocks == 0 {
+		return 1, nil
+	}
+	return float64(stat.Bavail) / float64(stat.Blocks), nil
+}
+
+// freeSpaceFraction returns the store's cached free-space fraction, refreshing
+// it via statfsFree at most once per statfsThrottleInterval. Callers must
+// hold store.mutex — Append is the only caller today, and it already does.
+func (store *Store) freeSpaceFraction() (float64, error) {
+	now := time.Now()
+	// Serve the cache only while BOTH bounds hold: the throttle interval has not
+	// elapsed AND not enough bytes have been reserved since the last measurement
+	// to have moved free space materially. The byte bound is what stops a fast
+	// write burst from racing past the watermark inside the 1s window — statfs
+	// alone lags the reserve rate, and the store can reach 0 free before the next
+	// timed refresh fires.
+	if !store.statfsAt.IsZero() &&
+		now.Sub(store.statfsAt) < statfsThrottleInterval &&
+		store.bytesSinceStatfs < statfsBytesInterval {
+		return store.freeFrac, nil
+	}
+
+	frac, err := statfsFree(store.dir)
+	if err != nil {
+		return 0, err
+	}
+
+	store.freeFrac = frac
+	store.statfsAt = now
+	store.bytesSinceStatfs = 0
+	return frac, nil
+}
+
+// NearFull reports whether the store's backing filesystem is in the
+// nearfull band: below the nearfull watermark but still above full, so
+// writes are still accepted. Used to signal early backpressure to clients.
+func (store *Store) NearFull() bool {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+
+	frac, err := store.freeSpaceFraction()
+	if err != nil {
+		return false
+	}
+	return frac < store.nearfullFreeFrac && frac >= store.fullFreeFrac
+}

--- a/store/store.go
+++ b/store/store.go
@@ -67,14 +67,12 @@ type Store struct {
 	nearfullFreeFrac float64
 	fullFreeFrac     float64
 
-	// statfs cache backing freeSpaceFraction, throttled to statfsThrottleInterval
-	// so Append's hot path pays for at most one syscall per interval.
+	// statfs cache backing freeSpaceFraction; see statfsThrottleInterval.
 	statfsAt time.Time
 	freeFrac float64
 
-	// bytesSinceStatfs accumulates reserved extent bytes since the last statfs,
-	// forcing a refresh once it crosses statfsBytesInterval so the watermark
-	// tracks a fast write burst instead of serving a stale reading.
+	// bytesSinceStatfs accumulates reserved extent bytes since the last
+	// statfs; see statfsBytesInterval.
 	bytesSinceStatfs uint64
 
 	closed bool
@@ -98,12 +96,8 @@ var (
 	ErrKeyNotFound = errors.New("key not found")
 	ErrShardFull   = errors.New("shard full")
 
-	// ErrStoreFull is returned by Append when the store's backing filesystem
-	// free-space fraction has dropped below the full watermark (see
-	// WithFreeSpaceWatermark). It is the store-side half of the pool
-	// free-space watermark: callers translate it into a client-visible
-	// out-of-space error (e.g. a 507 S3 response) at the seam where a store
-	// error crosses into a wire protocol.
+	// ErrStoreFull is returned by Append when free space has dropped below
+	// the full watermark (see WithFreeSpaceWatermark).
 	ErrStoreFull = errors.New("store full")
 )
 
@@ -133,15 +127,11 @@ func WithCompaction(interval time.Duration) Option {
 	}
 }
 
-// WithFreeSpaceWatermark overrides the free-space watermark fractions that
-// gate Append (see freeSpaceFraction in freespace.go). Both are free-space
-// fractions of the store's backing filesystem, not used-space fractions:
+// WithFreeSpaceWatermark overrides the free-space fractions that gate Append:
 // crossing below nearfullFreeFrac kicks an immediate compaction pass but
-// still accepts the write; crossing below fullFreeFrac rejects the write
-// with ErrStoreFull. fullFreeFrac must not exceed nearfullFreeFrac — full is
-// the stricter, lower threshold. Without this option the store defaults to
-// nearfull 0.15 (85% used) / full 0.05 (95% used), following Ceph's
-// nearfull/full watermarks.
+// still accepts the write; crossing below fullFreeFrac rejects it with
+// ErrStoreFull. fullFreeFrac must not exceed nearfullFreeFrac. Defaults to
+// nearfull 0.15 / full 0.05 if unset.
 func WithFreeSpaceWatermark(nearfullFreeFrac, fullFreeFrac float64) Option {
 	return func(s *Store) error {
 		if nearfullFreeFrac < 0 || nearfullFreeFrac > 1 || fullFreeFrac < 0 || fullFreeFrac > 1 {
@@ -288,17 +278,14 @@ func (store *Store) Append(objectHash [32]byte, shardIndex uint32, size int64) (
 		return nil, ErrClosedStore
 	}
 
-	// Pool free-space watermark: reject before reserving any extent so a full
-	// store fails fast rather than partially committing. A statfs error is
-	// logged and treated as permissive — a monitoring hiccup must not itself
-	// take writes down.
+	// Check the watermark before reserving any extent so a full store fails
+	// fast. Treat a statfs error as permissive — a monitoring hiccup must not
+	// itself take writes down.
 	if frac, err := store.freeSpaceFraction(); err != nil {
 		slog.Warn("free-space check failed, proceeding without a watermark decision", "dir", store.dir, "error", err)
 	} else if frac < store.fullFreeFrac {
 		return nil, ErrStoreFull
 	} else if frac < store.nearfullFreeFrac {
-		// Still under budget: accept the write but kick reclaim now rather
-		// than waiting for the next ticker cycle.
 		store.kickCompaction()
 	}
 
@@ -352,8 +339,7 @@ func (store *Store) Append(objectHash [32]byte, shardIndex uint32, size int64) (
 	store.shardNum += 1
 	store.fragNum += fragCount
 
-	// Count the reserved bytes toward the statfs byte bound so a burst of
-	// Appends forces a fresh free-space reading before it can overshoot full.
+	// Count toward the statfs byte bound; see statfsBytesInterval.
 	store.bytesSinceStatfs += uint64(ext.PSize) //nolint:gosec // PSize is a non-negative on-disk byte count.
 
 	return w, nil

--- a/store/store.go
+++ b/store/store.go
@@ -63,6 +63,20 @@ type Store struct {
 	compactionInterval time.Duration
 	compactor          *compactor
 
+	// Free-space watermark fractions gating Append; see WithFreeSpaceWatermark.
+	nearfullFreeFrac float64
+	fullFreeFrac     float64
+
+	// statfs cache backing freeSpaceFraction, throttled to statfsThrottleInterval
+	// so Append's hot path pays for at most one syscall per interval.
+	statfsAt time.Time
+	freeFrac float64
+
+	// bytesSinceStatfs accumulates reserved extent bytes since the last statfs,
+	// forcing a refresh once it crosses statfsBytesInterval so the watermark
+	// tracks a fast write burst instead of serving a stale reading.
+	bytesSinceStatfs uint64
+
 	closed bool
 }
 
@@ -83,6 +97,14 @@ var (
 	ErrClosedStore = errors.New("closed store")
 	ErrKeyNotFound = errors.New("key not found")
 	ErrShardFull   = errors.New("shard full")
+
+	// ErrStoreFull is returned by Append when the store's backing filesystem
+	// free-space fraction has dropped below the full watermark (see
+	// WithFreeSpaceWatermark). It is the store-side half of the pool
+	// free-space watermark: callers translate it into a client-visible
+	// out-of-space error (e.g. a 507 S3 response) at the seam where a store
+	// error crosses into a wire protocol.
+	ErrStoreFull = errors.New("store full")
 )
 
 // Option configures a Store at Open time. Options may fail (e.g. invalid key
@@ -111,6 +133,29 @@ func WithCompaction(interval time.Duration) Option {
 	}
 }
 
+// WithFreeSpaceWatermark overrides the free-space watermark fractions that
+// gate Append (see freeSpaceFraction in freespace.go). Both are free-space
+// fractions of the store's backing filesystem, not used-space fractions:
+// crossing below nearfullFreeFrac kicks an immediate compaction pass but
+// still accepts the write; crossing below fullFreeFrac rejects the write
+// with ErrStoreFull. fullFreeFrac must not exceed nearfullFreeFrac — full is
+// the stricter, lower threshold. Without this option the store defaults to
+// nearfull 0.15 (85% used) / full 0.05 (95% used), following Ceph's
+// nearfull/full watermarks.
+func WithFreeSpaceWatermark(nearfullFreeFrac, fullFreeFrac float64) Option {
+	return func(s *Store) error {
+		if nearfullFreeFrac < 0 || nearfullFreeFrac > 1 || fullFreeFrac < 0 || fullFreeFrac > 1 {
+			return fmt.Errorf("free-space watermark fractions must be in [0,1], got nearfull=%v full=%v", nearfullFreeFrac, fullFreeFrac)
+		}
+		if fullFreeFrac > nearfullFreeFrac {
+			return fmt.Errorf("full watermark (%v) must not exceed nearfull watermark (%v)", fullFreeFrac, nearfullFreeFrac)
+		}
+		s.nearfullFreeFrac = nearfullFreeFrac
+		s.fullFreeFrac = fullFreeFrac
+		return nil
+	}
+}
+
 // WithAEAD sets the cipher sealing every fragment, and is mandatory. The nonce
 // layout fixes NonceSize at 12. Callers build the cipher themselves, so the
 // store never sees raw key bytes.
@@ -135,6 +180,8 @@ func Open(dir string, opts ...Option) (store *Store, err error) {
 		segCache:           make(map[uint64]*segment),
 		maxSegSize:         DefaultMaxSegSize,
 		compactionInterval: defaultCompactionInterval,
+		nearfullFreeFrac:   defaultNearfullFreeFrac,
+		fullFreeFrac:       defaultFullFreeFrac,
 	}
 
 	for _, opt := range opts {
@@ -241,6 +288,20 @@ func (store *Store) Append(objectHash [32]byte, shardIndex uint32, size int64) (
 		return nil, ErrClosedStore
 	}
 
+	// Pool free-space watermark: reject before reserving any extent so a full
+	// store fails fast rather than partially committing. A statfs error is
+	// logged and treated as permissive — a monitoring hiccup must not itself
+	// take writes down.
+	if frac, err := store.freeSpaceFraction(); err != nil {
+		slog.Warn("free-space check failed, proceeding without a watermark decision", "dir", store.dir, "error", err)
+	} else if frac < store.fullFreeFrac {
+		return nil, ErrStoreFull
+	} else if frac < store.nearfullFreeFrac {
+		// Still under budget: accept the write but kick reclaim now rather
+		// than waiting for the next ticker cycle.
+		store.kickCompaction()
+	}
+
 	// Ceiling division; size == 0 yields an empty extent the writer never fills.
 	fragCount := (uint64(size) + fragBodySize - 1) / fragBodySize
 
@@ -290,6 +351,10 @@ func (store *Store) Append(objectHash [32]byte, shardIndex uint32, size int64) (
 
 	store.shardNum += 1
 	store.fragNum += fragCount
+
+	// Count the reserved bytes toward the statfs byte bound so a burst of
+	// Appends forces a fresh free-space reading before it can overshoot full.
+	store.bytesSinceStatfs += uint64(ext.PSize) //nolint:gosec // PSize is a non-negative on-disk byte count.
 
 	return w, nil
 }

--- a/store/watermark_internal_test.go
+++ b/store/watermark_internal_test.go
@@ -1,0 +1,294 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// A fullFreeFrac this close to 1 is guaranteed to sit above any real disk's
+// free-space fraction, so Append must reject deterministically without
+// mocking statfs — exactly the property the watermark exists to guarantee.
+func TestAppendRejectsWhenFull(t *testing.T) {
+	st, _ := openTestStore(t, WithFreeSpaceWatermark(0.9999, 0.9999))
+
+	_, err := st.Append([32]byte{0x1}, 0, 16)
+	if !errors.Is(err, ErrStoreFull) {
+		t.Fatalf("Append err = %v, want ErrStoreFull", err)
+	}
+}
+
+// Zero thresholds accept any positive free-space fraction, which every real
+// filesystem this test can run on has.
+func TestAppendAcceptsWhenPermissive(t *testing.T) {
+	st, _ := openTestStore(t, WithFreeSpaceWatermark(0, 0))
+
+	w, err := st.Append([32]byte{0x2}, 0, 16)
+	if err != nil {
+		t.Fatalf("Append err = %v, want nil", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+}
+
+// Fail-without: with the watermark check removed (or with a fullFreeFrac
+// that can never be crossed), Append must NOT return ErrStoreFull even
+// though the configured "full" threshold is nominally in force everywhere
+// else in this file — this pins down that WithFreeSpaceWatermark(0, 0) is
+// truly a no-op, not accidentally permissive by some other path.
+func TestAppendNotFullByDefaultOnDevDisk(t *testing.T) {
+	// openTestStore defaults the watermark off for test isolation (see its
+	// comment), so this test opens directly to get the real package
+	// defaults (nearfull 0.15 / full 0.05) unmasked by that helper.
+	st, err := Open(t.TempDir(), WithAEAD(testAEAD(t)))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	w, err := st.Append([32]byte{0x3}, 0, 16)
+	if err != nil {
+		t.Fatalf("Append err = %v, want nil (dev disk should not be at the 5%% free default)", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+}
+
+func TestWithFreeSpaceWatermarkRejectsInvertedThresholds(t *testing.T) {
+	_, err := Open(t.TempDir(), WithAEAD(testAEAD(t)), WithFreeSpaceWatermark(0.05, 0.15))
+	if err == nil {
+		t.Fatalf("Open succeeded with full (0.15) > nearfull (0.05), want error")
+	}
+}
+
+func TestWithFreeSpaceWatermarkRejectsOutOfRange(t *testing.T) {
+	_, err := Open(t.TempDir(), WithAEAD(testAEAD(t)), WithFreeSpaceWatermark(0.15, -0.1))
+	if err == nil {
+		t.Fatalf("Open succeeded with a negative fraction, want error")
+	}
+}
+
+// freeSpaceFraction must reuse the cached value within statfsThrottleInterval
+// rather than paying for a statfs syscall on every Append.
+func TestFreeSpaceFractionThrottled(t *testing.T) {
+	st, _ := openTestStore(t)
+
+	calls := 0
+	orig := statfsFree
+	statfsFree = func(string) (float64, error) {
+		calls++
+		return 0.5, nil
+	}
+	defer func() { statfsFree = orig }()
+
+	if _, err := st.freeSpaceFraction(); err != nil {
+		t.Fatalf("freeSpaceFraction: %v", err)
+	}
+	if _, err := st.freeSpaceFraction(); err != nil {
+		t.Fatalf("freeSpaceFraction: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("statfsFree called %d times for 2 calls within %s, want 1 (throttle not applied)", calls, statfsThrottleInterval)
+	}
+}
+
+// Once the throttle interval elapses, the next call must re-measure rather
+// than serve a value that could be arbitrarily stale.
+func TestFreeSpaceFractionRefreshesAfterInterval(t *testing.T) {
+	st, _ := openTestStore(t)
+
+	calls := 0
+	orig := statfsFree
+	statfsFree = func(string) (float64, error) {
+		calls++
+		return 0.5, nil
+	}
+	defer func() { statfsFree = orig }()
+
+	if _, err := st.freeSpaceFraction(); err != nil {
+		t.Fatalf("freeSpaceFraction: %v", err)
+	}
+	// Force the cache to look stale without sleeping the test.
+	st.statfsAt = st.statfsAt.Add(-2 * statfsThrottleInterval)
+	if _, err := st.freeSpaceFraction(); err != nil {
+		t.Fatalf("freeSpaceFraction: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("statfsFree called %d times across the throttle boundary, want 2", calls)
+	}
+}
+
+// A large write burst must not outrun the watermark inside the throttle
+// window: once statfsBytesInterval bytes have been reserved, freeSpaceFraction
+// re-measures even though statfsThrottleInterval has not elapsed. Without this
+// the store can race from below-threshold to 0 free between timed refreshes.
+func TestFreeSpaceFractionRefreshesAfterByteThreshold(t *testing.T) {
+	st, _ := openTestStore(t)
+
+	calls := 0
+	orig := statfsFree
+	statfsFree = func(string) (float64, error) {
+		calls++
+		return 0.5, nil
+	}
+	defer func() { statfsFree = orig }()
+
+	if _, err := st.freeSpaceFraction(); err != nil {
+		t.Fatalf("freeSpaceFraction: %v", err)
+	}
+	// statfsAt is fresh, so only the byte bound can force the second measure.
+	st.bytesSinceStatfs = statfsBytesInterval
+	if _, err := st.freeSpaceFraction(); err != nil {
+		t.Fatalf("freeSpaceFraction: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("statfsFree called %d times, want 2 (byte threshold must force a refresh)", calls)
+	}
+	if st.bytesSinceStatfs != 0 {
+		t.Fatalf("bytesSinceStatfs = %d after refresh, want 0", st.bytesSinceStatfs)
+	}
+}
+
+// Append must count the bytes it reserves toward the statfs byte bound, so a
+// run of writes eventually forces a fresh measurement even within one second.
+func TestAppendAccumulatesBytesSinceStatfs(t *testing.T) {
+	st, _ := openTestStore(t)
+
+	w, err := st.Append([32]byte{0x7}, 0, 16)
+	if err != nil {
+		t.Fatalf("Append err = %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	// Append re-measured at entry (resetting the counter to 0), then reserved an
+	// extent — so the counter must reflect that reservation.
+	if st.bytesSinceStatfs == 0 {
+		t.Fatalf("bytesSinceStatfs = 0 after Append, want the reserved extent size")
+	}
+}
+
+// kickCompaction must send without blocking, whether or not a kick is
+// already pending — Append holds store.mutex while it calls this, so any
+// blocking here is a deadlock waiting to happen.
+func TestKickCompactionNonBlockingSend(t *testing.T) {
+	st, _ := openTestStore(t)
+	st.compactor = &compactor{store: st, done: make(chan struct{}), kick: make(chan struct{}, 1)}
+
+	st.kickCompaction()
+
+	select {
+	case <-st.compactor.kick:
+	default:
+		t.Fatalf("kickCompaction did not send on the kick channel")
+	}
+}
+
+func TestKickCompactionCoalescesWithoutBlocking(t *testing.T) {
+	st, _ := openTestStore(t)
+	st.compactor = &compactor{store: st, done: make(chan struct{}), kick: make(chan struct{}, 1)}
+
+	st.kickCompaction() // fills the buffered channel
+
+	done := make(chan struct{})
+	go func() {
+		st.kickCompaction() // must not block even though the channel is full
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("second kickCompaction blocked instead of coalescing")
+	}
+}
+
+// A no-op when compaction was never enabled: nothing to kick, and Append
+// must not panic reaching for a nil compactor.
+func TestKickCompactionNoopWithoutCompactor(t *testing.T) {
+	st, _ := openTestStore(t)
+	st.kickCompaction() // must not panic
+}
+
+// Crossing the nearfull threshold on Append must kick the compactor while
+// still accepting the write — nearfull is advisory pressure, not a reject.
+func TestAppendKicksCompactorOnNearfullButAccepts(t *testing.T) {
+	st, _ := openTestStore(t, WithFreeSpaceWatermark(0.9999, 0))
+	st.compactor = &compactor{store: st, done: make(chan struct{}), kick: make(chan struct{}, 1)}
+
+	w, err := st.Append([32]byte{0x4}, 0, 16)
+	if err != nil {
+		t.Fatalf("Append err = %v, want nil (nearfull must still accept)", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	select {
+	case <-st.compactor.kick:
+	default:
+		t.Fatalf("nearfull Append did not kick the compactor")
+	}
+}
+
+// Append below the full threshold must NOT kick the compactor — only
+// crossing nearfull-but-not-full should trigger reclaim pressure.
+func TestAppendDoesNotKickCompactorWhenPermissive(t *testing.T) {
+	st, _ := openTestStore(t, WithFreeSpaceWatermark(0, 0))
+	st.compactor = &compactor{store: st, done: make(chan struct{}), kick: make(chan struct{}, 1)}
+
+	w, err := st.Append([32]byte{0x5}, 0, 16)
+	if err != nil {
+		t.Fatalf("Append err = %v, want nil", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	select {
+	case <-st.compactor.kick:
+		t.Fatalf("permissive Append kicked the compactor, want no-op")
+	default:
+	}
+}
+
+// The compactor's own goroutine must react to a kick, not just the helper
+// that sends on the channel — this exercises the real select-case wiring in
+// loop() with WithCompaction actually running.
+func TestCompactorLoopRunsOnKick(t *testing.T) {
+	st, dir := openTestStore(t, WithMaxSegSize(40*KiB), WithCompaction(time.Hour))
+	oh := [32]byte{0x66}
+	body := make([]byte, 12*KiB)
+	for i := range body {
+		body[i] = 0xaa
+	}
+	putShard(t, st, oh, 0, body)
+	putShard(t, st, oh, 1, body)
+	putShard(t, st, oh, 2, body) // rolls into segment 1
+
+	if _, err := st.Delete(oh, 0); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	// The ticker won't fire for an hour; only the kick can drive this
+	// compaction pass. Segment 0 is now under the live threshold and must
+	// drop once the kicked cycle runs.
+	st.compactor.kick <- struct{}{}
+
+	segPath := filepath.Join(dir, fmt.Sprintf(segFilename, uint64(0)))
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(segPath); os.IsNotExist(err) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("kicked compaction did not drop segment 0 in time")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/store/watermark_internal_test.go
+++ b/store/watermark_internal_test.go
@@ -9,9 +9,8 @@ import (
 	"time"
 )
 
-// A fullFreeFrac this close to 1 is guaranteed to sit above any real disk's
-// free-space fraction, so Append must reject deterministically without
-// mocking statfs — exactly the property the watermark exists to guarantee.
+// A fullFreeFrac this close to 1 sits above any real disk's free-space
+// fraction, so this rejects deterministically without mocking statfs.
 func TestAppendRejectsWhenFull(t *testing.T) {
 	st, _ := openTestStore(t, WithFreeSpaceWatermark(0.9999, 0.9999))
 
@@ -21,8 +20,7 @@ func TestAppendRejectsWhenFull(t *testing.T) {
 	}
 }
 
-// Zero thresholds accept any positive free-space fraction, which every real
-// filesystem this test can run on has.
+// Zero thresholds accept any positive free-space fraction.
 func TestAppendAcceptsWhenPermissive(t *testing.T) {
 	st, _ := openTestStore(t, WithFreeSpaceWatermark(0, 0))
 
@@ -35,15 +33,9 @@ func TestAppendAcceptsWhenPermissive(t *testing.T) {
 	}
 }
 
-// Fail-without: with the watermark check removed (or with a fullFreeFrac
-// that can never be crossed), Append must NOT return ErrStoreFull even
-// though the configured "full" threshold is nominally in force everywhere
-// else in this file — this pins down that WithFreeSpaceWatermark(0, 0) is
-// truly a no-op, not accidentally permissive by some other path.
+// Opens directly (bypassing openTestStore's watermark override) to check the
+// real package defaults against a dev disk.
 func TestAppendNotFullByDefaultOnDevDisk(t *testing.T) {
-	// openTestStore defaults the watermark off for test isolation (see its
-	// comment), so this test opens directly to get the real package
-	// defaults (nearfull 0.15 / full 0.05) unmasked by that helper.
 	st, err := Open(t.TempDir(), WithAEAD(testAEAD(t)))
 	if err != nil {
 		t.Fatalf("open: %v", err)
@@ -73,8 +65,6 @@ func TestWithFreeSpaceWatermarkRejectsOutOfRange(t *testing.T) {
 	}
 }
 
-// freeSpaceFraction must reuse the cached value within statfsThrottleInterval
-// rather than paying for a statfs syscall on every Append.
 func TestFreeSpaceFractionThrottled(t *testing.T) {
 	st, _ := openTestStore(t)
 
@@ -97,8 +87,6 @@ func TestFreeSpaceFractionThrottled(t *testing.T) {
 	}
 }
 
-// Once the throttle interval elapses, the next call must re-measure rather
-// than serve a value that could be arbitrarily stale.
 func TestFreeSpaceFractionRefreshesAfterInterval(t *testing.T) {
 	st, _ := openTestStore(t)
 
@@ -123,10 +111,8 @@ func TestFreeSpaceFractionRefreshesAfterInterval(t *testing.T) {
 	}
 }
 
-// A large write burst must not outrun the watermark inside the throttle
-// window: once statfsBytesInterval bytes have been reserved, freeSpaceFraction
-// re-measures even though statfsThrottleInterval has not elapsed. Without this
-// the store can race from below-threshold to 0 free between timed refreshes.
+// Crossing statfsBytesInterval must force a re-measure even though
+// statfsThrottleInterval has not elapsed.
 func TestFreeSpaceFractionRefreshesAfterByteThreshold(t *testing.T) {
 	st, _ := openTestStore(t)
 
@@ -154,8 +140,6 @@ func TestFreeSpaceFractionRefreshesAfterByteThreshold(t *testing.T) {
 	}
 }
 
-// Append must count the bytes it reserves toward the statfs byte bound, so a
-// run of writes eventually forces a fresh measurement even within one second.
 func TestAppendAccumulatesBytesSinceStatfs(t *testing.T) {
 	st, _ := openTestStore(t)
 
@@ -166,16 +150,15 @@ func TestAppendAccumulatesBytesSinceStatfs(t *testing.T) {
 	if err := w.Close(); err != nil {
 		t.Fatalf("close writer: %v", err)
 	}
-	// Append re-measured at entry (resetting the counter to 0), then reserved an
-	// extent — so the counter must reflect that reservation.
+	// Append re-measures at entry (resetting the counter), then reserves an
+	// extent, so the counter must reflect that reservation.
 	if st.bytesSinceStatfs == 0 {
 		t.Fatalf("bytesSinceStatfs = 0 after Append, want the reserved extent size")
 	}
 }
 
-// kickCompaction must send without blocking, whether or not a kick is
-// already pending — Append holds store.mutex while it calls this, so any
-// blocking here is a deadlock waiting to happen.
+// Append holds store.mutex while calling kickCompaction, so a blocking send
+// here would deadlock.
 func TestKickCompactionNonBlockingSend(t *testing.T) {
 	st, _ := openTestStore(t)
 	st.compactor = &compactor{store: st, done: make(chan struct{}), kick: make(chan struct{}, 1)}
@@ -208,15 +191,12 @@ func TestKickCompactionCoalescesWithoutBlocking(t *testing.T) {
 	}
 }
 
-// A no-op when compaction was never enabled: nothing to kick, and Append
-// must not panic reaching for a nil compactor.
 func TestKickCompactionNoopWithoutCompactor(t *testing.T) {
 	st, _ := openTestStore(t)
 	st.kickCompaction() // must not panic
 }
 
-// Crossing the nearfull threshold on Append must kick the compactor while
-// still accepting the write — nearfull is advisory pressure, not a reject.
+// nearfull is advisory pressure, not a reject.
 func TestAppendKicksCompactorOnNearfullButAccepts(t *testing.T) {
 	st, _ := openTestStore(t, WithFreeSpaceWatermark(0.9999, 0))
 	st.compactor = &compactor{store: st, done: make(chan struct{}), kick: make(chan struct{}, 1)}
@@ -236,8 +216,6 @@ func TestAppendKicksCompactorOnNearfullButAccepts(t *testing.T) {
 	}
 }
 
-// Append below the full threshold must NOT kick the compactor — only
-// crossing nearfull-but-not-full should trigger reclaim pressure.
 func TestAppendDoesNotKickCompactorWhenPermissive(t *testing.T) {
 	st, _ := openTestStore(t, WithFreeSpaceWatermark(0, 0))
 	st.compactor = &compactor{store: st, done: make(chan struct{}), kick: make(chan struct{}, 1)}
@@ -257,9 +235,8 @@ func TestAppendDoesNotKickCompactorWhenPermissive(t *testing.T) {
 	}
 }
 
-// The compactor's own goroutine must react to a kick, not just the helper
-// that sends on the channel — this exercises the real select-case wiring in
-// loop() with WithCompaction actually running.
+// Exercises the real select-case wiring in loop(), not just the helper that
+// sends on the channel.
 func TestCompactorLoopRunsOnKick(t *testing.T) {
 	st, dir := openTestStore(t, WithMaxSegSize(40*KiB), WithCompaction(time.Hour))
 	oh := [32]byte{0x66}
@@ -275,9 +252,7 @@ func TestCompactorLoopRunsOnKick(t *testing.T) {
 		t.Fatalf("delete: %v", err)
 	}
 
-	// The ticker won't fire for an hour; only the kick can drive this
-	// compaction pass. Segment 0 is now under the live threshold and must
-	// drop once the kicked cycle runs.
+	// The ticker won't fire for an hour; only the kick drives this pass.
 	st.compactor.kick <- struct{}{}
 
 	segPath := filepath.Join(dir, fmt.Sprintf(segFilename, uint64(0)))


### PR DESCRIPTION
## TL;DR

This PR gives predastore a pool free-space watermark that gates `store.Append`: writes are shed with HTTP 507 once the backing filesystem crosses a 5% free reserve, and an early "nearfull" signal (15% free) kicks compaction and warns callers before that happens. It also fixes two bugs found during live exhaustion testing on env12 — a statfs cache that let a fast write burst blow straight through the reserve, and a 507 response that never reached the client because the request body wasn't drained first.

## Background

An EKS GPU worker with a 16 GiB root volume pulled a vLLM image (~13 GB payload) in a containerd retry loop. Every retry rewrote the whole image and nothing reclaimed the superseded chunks, so the predastore backend grew to ~156 GB — roughly 11x the payload — with nothing in the stack modelling "the pool is full." On an undersized volume or a node whose store shares the OS root, that exhaustion wedges the whole node: journald, `systemd`, OVN/OVS, and process `fork` all need a writable root, and predastore's own raft/compaction/state writes fail at 0 bytes free.

The primary fix for unbounded growth is chunk GC and coalescing in viperblock, which converts the linear runaway into a bounded, self-reclaiming band. This predastore change is the physical backstop underneath that: even with GC on, a sufficiently aggressive or misconfigured workload can still outrun reclamation, and predastore itself never had any notion of "full" — it wrote straight to 0 bytes free. This PR's job is node survival when that happens, not primary capacity bounding.

## What this PR changes

**1. Pool free-space watermark gating `store.Append`.** New `store/freespace.go` defines two free-space fractions of the store's backing filesystem: `defaultNearfullFreeFrac = 0.15` (85% used) and `defaultFullFreeFrac = 0.05` (95% used) (store/freespace.go:12,18). `Append` (store/store.go:279) checks the fraction before reserving any extent (store/store.go:295-303): below `fullFreeFrac` it returns the new `ErrStoreFull` (store/store.go:107) without writing anything; below `nearfullFreeFrac` it still accepts the write but calls `store.kickCompaction()` (store/compaction.go:77) to trigger an out-of-cycle compaction pass instead of waiting for the next timer tick. The 5% full reserve is sized to cover two things at once: the OS's own need for a writable root (journald, process forking, OVN/OVS all need scratch space even when the "data" disk is what's full) and compaction's own read-modify-write scratch, since `relocateExtent` needs somewhere to write a relocated extent before it can free the old one. `statfsFree` (store/freespace.go:34) reads `Bavail/Blocks`, not `Bfree/Blocks`, so a filesystem's own reserved-blocks headroom (e.g. ext4's default 5% root reserve) is already excluded from the fraction the watermark measures — it reflects the same budget an actual write would see, not a double-counted reserve.

**2. Byte-counted statfs refresh.** `statfsThrottleInterval = 1 * time.Second` caches the free-space reading to keep `Append` off a syscall on every call, which is correct for slow drift and wrong for a burst: a guest write pattern hitting hundreds of MB/s can cross the entire 5% reserve inside a single stale window, so the gate reads "plenty free" right up until the store hits 0 bytes free. This was found live: an env12 run walked the store 84% -> 92% -> 100% in about 90 seconds with the data-path gate never rejecting once, because free space was being sampled on a clock, not on the rate of the thing it was guarding. The fix (store/freespace.go:25-32, store/store.go:357) adds `statfsBytesInterval = 64 << 20` (64 MiB): `Append` accumulates reserved bytes into `store.bytesSinceStatfs`, and `freeSpaceFraction` (store/store.go:295, freespace.go:57-73) only serves the cached value while *both* the time bound and the byte bound hold. Crossing either forces a fresh `statfs`. This bounds worst-case overshoot on write volume rather than wall-clock time, which is the correct axis for a quantity that only moves because of writes.

**3. Nearfull backpressure signal.** When a target node's store is in the nearfull band, `PutResponse.PoolNearFull` is set on a *successful* PUT (quic/quicserver/put.go:69, quic/quicserver/server.go:151) and plumbed all the way through: `shardWriteOutcome.poolNearFull` (backend/distributed/distributed.go:119) is OR'd across every shard in `putObjectViaQUIC` (backend/distributed/distributed.go:304,399-400,483-484) — one node under pressure is enough to warn the caller even though the object as a whole wrote fine — into `PutObjectResponse.PoolNearFull` (backend/types.go:64, backend/distributed/put.go:133), and the S3 handler sets `X-Predastore-Pool-Pressure: nearfull` (s3/httpserver.go:668-669) on the response. This is advisory early backpressure: nothing rejects on it. It exists so a consumer (viperblock, cross-repo) can stop admitting new guest writes before this node ever hits the hard 507, rather than only reacting once a write has already failed.

**4. Drain-before-reject.** `handlePUTShard` (quic/quicserver/put.go) previously wrote the 507 status as soon as `Append` returned `ErrStoreFull`, without first reading the client's in-flight shard body off the QUIC stream. The un-drained stream then got reset by the server's own cleanup, so the client saw a QUIC stream cancellation, not the 507 — the out-of-space signal was lost at exactly the boundary that mattered. The fix drains and discards the body first (`io.Copy(io.Discard, io.LimitReader(br, bodyLen))`, quic/quicserver/put.go:38) and only then classifies the error: `errors.Is(err, store.ErrStoreFull)` maps to `quicproto.StatusInsufficientStorage` (507) (quic/quicserver/put.go:44-48); every other `Append` error still gets a generic 500.

**5. Compaction is deliberately not gated by the watermark.** `relocateExtent` (store/compaction.go:284) calls `reserveExtent` (store/store.go:366) directly rather than going through `Append`, so it never touches the free-space check — this is by construction, not an explicit bypass flag. Gating reclaim on the same watermark that gates guest writes would deadlock the store: compaction cannot free space without first writing the relocated extent's destination, so if the reserve it needs is also the reserve blocking it, a full store could never dig itself out. The 5% full reserve exists specifically as that scratch space, and compaction is exempt so it can always spend it.

## Design rationale / trade-offs

- **5% reserve, not a bigger or smaller number.** It follows Ceph's nearfull/full convention (0.85/0.95) and matches roughly what's needed for the OS to keep functioning plus one compaction relocation's worth of scratch. A larger reserve wastes usable capacity for no correctness gain; a smaller one risks colliding with the OS's own needs under concurrent control-plane writes.
- **Compaction stays ungated.** See item 5 above — gating it is a deadlock, not a safety improvement.
- **Byte-counted sampling, not just a shorter timer.** A shorter timer (e.g. 100ms) still has the same structural flaw at a higher write rate; sampling on bytes reserved ties the refresh to the actual quantity being protected, so the overshoot bound is a constant (~64 MiB) regardless of how fast a client writes.
- **Advisory header vs. hard 507 for nearfull.** Nearfull still accepts the write on purpose. A client backing off early (e.g. viperblock refusing new guest writes) can avoid the hard rejection to begin with, but a false-positive or slow-to-react consumer at nearfull must not lose availability — only crossing the full watermark should ever fail a write outright.

## What this PR does NOT do

- No admission control at volume/instance provisioning time — this is a runtime backstop, not a guarantee that a volume was sized correctly for the pool. Provisioning-time capacity accounting is a separate, larger scheduler-level change.
- No attempt to deliver a typed ENOSPC to the guest through virtio-blk — its status field is a single generic I/O-error bit and cannot carry one. That's handled (accepted, not fixed) at the viperblock/spinifex layer: the guest sees a generic I/O error, its filesystem remounts read-only, and that's the same shape AWS itself produces once you're off the "clean ENOSPC from the guest's own filesystem" path.
- No tier-3 partial-chunk compaction (read-modify-write repacking of partially-superseded chunks). That's a viperblock reclaim-headroom optimization tracked separately; it's not required for this backstop to hold.

## Testing

New tests, all passing locally (`go build ./...` clean; full package suite green except one pre-existing environment artifact noted below):

- `store/watermark_internal_test.go` (294 lines, 15 test funcs): `TestAppendRejectsWhenFull` / `TestAppendAcceptsWhenPermissive` pin the Append gate at the boundary with a deterministic, unmocked `statfs` (a 0.9999 threshold guarantees rejection on any real disk; 0/0 guarantees acceptance). `TestAppendNotFullByDefaultOnDevDisk` confirms the shipped defaults (0.15/0.05) don't reject writes on a normal dev disk. `TestWithFreeSpaceWatermarkRejectsInvertedThresholds` / `RejectsOutOfRange` cover the option's input validation. `TestFreeSpaceFractionThrottled` / `RefreshesAfterInterval` / `RefreshesAfterByteThreshold` and `TestAppendAccumulatesBytesSinceStatfs` directly test the dual time/byte cache bound that fixes the 84%->92%->100% overshoot. `TestKickCompactionNonBlockingSend` / `CoalescesWithoutBlocking` / `NoopWithoutCompactor`, `TestAppendKicksCompactorOnNearfullButAccepts` / `DoesNotKickCompactorWhenPermissive`, and `TestCompactorLoopRunsOnKick` cover the nearfull->compaction trigger end to end.
- `quic/quicserver/put_test.go`: `TestHandlePUTShardStoreFullReturnsInsufficientStorage` / `TestHandlePUTShardOtherAppendErrorStaysServerError` confirm the 507-vs-500 classification.
- `quic/quicserver/put_e2e_test.go`: `TestHandlePUTShardDrainsBodyBeforeRejectingOverQUIC` is a real regression test for the drain-before-reject fix — it sizes the body (4 MiB) past the QUIC flow-control window (2 MiB) specifically so the pre-fix code path reproduces as a transport-level stream error instead of a 507; it fails without the fix and passes with it.
- `quic/quicclient/quicclient_test.go`: `TestClassifyPutStatusInsufficientStorageIsDistinguishable` / `OtherStatusIsNotInsufficientStorage` cover the client-side 507 sentinel (`ErrInsufficientStorage`).
- `backend/distributed/put_test.go`: `TestMapPutErrInsufficientStorage` / `TestMapPutErrOtherErrorStaysInternalError` cover the S3-facing error mapping; `TestPutObjectFullPoolReturns507EndToEnd` drives a full 5-node distributed PutObject against a saturated store and asserts the client actually observes 507, exercising the whole store -> QUIC -> distributed -> S3 chain in one test.
- `s3/handleerror_test.go`: `TestHandleError_InsufficientStorage` confirms the 507 forwards through `handleError` with the `InsufficientStorage` S3 error code, the same path any other typed `S3Error` takes.

One pre-existing, unrelated test — `TestDistributed_MultipartUpload_ConcurrentParts_Contention` — failed in this sandbox because the sandbox's own `/tmp` filesystem was genuinely at 0 bytes free at the time (confirmed via `df`), which is this watermark correctly doing its job against a real full disk rather than a code defect; it is not exercised by this PR's logic beyond that.

**Live env12 validation** (three exhaustion cycles against the full stack, culminating in this branch): the store climbed 25% -> 85% used, nearfull kicked compaction, and usage dropped 85% -> 63% in about 2 seconds and held — it never approached 100% (a prior cycle without the byte-counted fix had walked to 100% and degraded the control plane). Across the run, all 83/83 health-check polls came back healthy with zero raft/badger errors, and the data-path gate rejected cleanly: 471 "backend out of space" (507) responses landed in a tight ~15 second burst across ~16 parallel writers, then went silent — no retry spin. A separate positive-path run (a correctly-sized 60 GiB root guest pulling a full ~30 GB image) completed successfully with zero false watermark triggers, ending at 104 GB/197 GB (55%) used.

## Cross-repo dependency & merge order

viperblock has a companion PR that reads `X-Predastore-Pool-Pressure: nearfull` and the 507/`ErrStoreFull` classification to gate new guest writes ahead of a hard backend rejection. spinifex repins both submodules to pick up the combined behavior. Recommended merge order: this PR, then the viperblock PR, then the spinifex repin — merging spinifex first would leave it pointed at a viperblock that expects headers/statuses this predastore version doesn't yet emit.

## Risk & rollback

Single commit (831a8db), cleanly revertable. All new gating is off the hot path in the common case (compaction ungated, statfs cached, watermark defaults conservative at 85%/95% used) so the positive-capacity-remaining path is unaffected in shape or performance; the only new behavior a healthy pool observes is one extra cached-fraction comparison per `Append`.
