### PR TITLE
fix: batch FSM.Restore so a grown store can still start (mulga-tjoz9)

### DIFF
--- a/s3db/fsm.go
+++ b/s3db/fsm.go
@@ -131,32 +131,42 @@ func (f *FSM) Restore(rc io.ReadCloser) error {
 		return err
 	}
 
-	// Clear existing data and restore from snapshot
-	return f.db.Update(func(txn *badger.Txn) error {
-		// Drop all existing data
-		opts := badger.DefaultIteratorOptions
-		opts.PrefetchValues = false
-		it := txn.NewIterator(opts)
-		var keysToDelete [][]byte
-		for it.Rewind(); it.Valid(); it.Next() {
-			keysToDelete = append(keysToDelete, it.Item().KeyCopy(nil))
-		}
-		it.Close()
+	// Clear, then rewrite in batches.
+	//
+	// Both halves used to run inside a single db.Update. Badger caps how much
+	// one transaction may hold, so once the metadata set outgrew that cap every
+	// snapshot became permanently unrestorable:
+	//
+	//   raft: snapshot restore progress: ... percent-complete="100.00%"
+	//   raft: failed to restore snapshot: error="Txn is too big to fit into one request"
+	//   failed to create raft node: failed to load any existing snapshots
+	//
+	// and the node could never start again — on every node at once, since they
+	// all restore the same oversized snapshot, taking the metadata plane (and
+	// with it the AMI catalogue, so DescribeImages) down with it. The write path
+	// has no matching limit, so snapshots that cannot be read back are written
+	// happily. See mulga-tjoz9.
+	//
+	// DropAll is badger's own bulk clear and is not bounded by a transaction;
+	// WriteBatch commits in chunks as it fills, so restore cost no longer scales
+	// into a hard wall.
+	if err := f.db.DropAll(); err != nil {
+		return fmt.Errorf("restore: drop existing data: %w", err)
+	}
 
-		for _, key := range keysToDelete {
-			if err := txn.Delete(key); err != nil {
-				return err
-			}
-		}
+	wb := f.db.NewWriteBatch()
+	defer wb.Cancel()
 
-		// Restore snapshot data
-		for _, e := range entries {
-			if err := txn.Set(e.key, e.value); err != nil {
-				return err
-			}
+	for _, e := range entries {
+		if err := wb.Set(e.key, e.value); err != nil {
+			return fmt.Errorf("restore: set key: %w", err)
 		}
-		return nil
-	})
+	}
+
+	if err := wb.Flush(); err != nil {
+		return fmt.Errorf("restore: flush batch: %w", err)
+	}
+	return nil
 }
 
 // readSnapshot reads snapshot entries, accepting both the current binary frame

--- a/s3db/fsm_restore_batch_test.go
+++ b/s3db/fsm_restore_batch_test.go
@@ -1,0 +1,92 @@
+package s3db
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFSM_Restore_ExceedsSingleTransaction pins mulga-tjoz9: Restore must not be
+// bounded by badger's per-transaction cap.
+//
+// Restore used to drop and rewrite every key inside one db.Update. Badger limits
+// how much a single transaction may hold, so once a store's metadata set grew
+// past that cap its snapshots became permanently unrestorable — the node failed
+// to start with
+//
+//	raft: failed to restore snapshot: error="Txn is too big to fit into one request"
+//	failed to create raft node: failed to load any existing snapshots
+//
+// and because every node restores the same oversized snapshot, they all failed
+// together, taking the metadata plane (and the AMI catalogue behind
+// DescribeImages) with them. This is a latent trap rather than a race: any
+// restart trips it once the store is large enough, and the snapshot WRITE path
+// has no matching limit, so unrestorable snapshots get written happily.
+func TestFSM_Restore_ExceedsSingleTransaction(t *testing.T) {
+	// Comfortably past badger's default per-transaction ceiling (~15% of a
+	// 64MiB memtable), so the restore has to span multiple commits.
+	const (
+		entryCount = 2048
+		valueSize  = 8 << 10 // 16MiB total
+	)
+
+	data := make(map[string][]byte, entryCount)
+	for i := range entryCount {
+		v := bytes.Repeat([]byte{byte(i % 251)}, valueSize)
+		data[fmt.Sprintf("objects/blob-%06d", i)] = v
+	}
+
+	sink := &mockSnapshotSink{}
+	require.NoError(t, (&FSMSnapshot{data: data}).Persist(sink))
+
+	db := newTestDB(t)
+
+	// Guard the premise: this payload genuinely cannot fit in one transaction,
+	// so the test would still fail if the old single-Update Restore came back.
+	err := db.Badger.Update(func(txn *badger.Txn) error {
+		for k, v := range data {
+			if err := txn.Set([]byte(k), v); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	require.ErrorIs(t, err, badger.ErrTxnTooBig,
+		"premise broken: payload now fits one txn, so this test no longer exercises the bug")
+
+	require.NoError(t, NewFSM(db.Badger).Restore(io.NopCloser(bytes.NewReader(sink.buf))))
+
+	for k, want := range data {
+		got, err := db.Get([]byte(k))
+		require.NoError(t, err, "key %s missing after restore", k)
+		assert.Equal(t, want, got)
+	}
+}
+
+// TestFSM_Restore_ClearsPriorState pins the other half of Restore's contract:
+// the snapshot replaces existing state rather than merging into it. The clear
+// moved from an in-transaction delete loop to badger's DropAll, so it needs its
+// own guard.
+func TestFSM_Restore_ClearsPriorState(t *testing.T) {
+	db := newTestDB(t)
+	require.NoError(t, db.Set([]byte("stale/key"), []byte("must not survive")))
+
+	sink := &mockSnapshotSink{}
+	require.NoError(t, (&FSMSnapshot{data: map[string][]byte{
+		"fresh/key": []byte("from snapshot"),
+	}}).Persist(sink))
+
+	require.NoError(t, NewFSM(db.Badger).Restore(io.NopCloser(bytes.NewReader(sink.buf))))
+
+	got, err := db.Get([]byte("fresh/key"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("from snapshot"), got)
+
+	_, err = db.Get([]byte("stale/key"))
+	assert.Error(t, err, "state absent from the snapshot must not survive a restore")
+}


### PR DESCRIPTION
`FSM.Restore` dropped every existing key and wrote every snapshot entry inside a **single** `db.Update`. Badger caps how much one transaction may hold, so once a store's metadata set outgrew that cap its snapshots became permanently unrestorable and the node could never start again:

```
raft: snapshot restore progress: ... percent-complete="100.00%"
raft: failed to restore snapshot: error="Txn is too big to fit into one request"
failed to create raft node: failed to create raft: failed to load any existing snapshots
```

## Why this is P0

Hit on env19 during a routine rolling `make cluster-deploy`. All three nodes failed **independently**, each at its own restart — they restore the same oversized snapshot, so there is no quorum to survive it. That took the metadata plane down, and with it the AMI catalogue: `DescribeImages` returned `ServerInternal` on every host and EKS cluster creation failed outright.

It is a latent trap, not a race. Any restart trips it once the store is large enough — upgrade, reboot, crash, power loss — and it only worsens as the store grows. `retain=2` does not help: both retained snapshots exceed the limit together. The snapshot **write** path has no matching bound, so predastore happily writes snapshots it can never read back.

## The fix

Clear with `DropAll` (not transaction-bounded) and rewrite through a `WriteBatch`, which commits in chunks as it fills.

## Verification

The new test builds a snapshot past the per-transaction ceiling and **asserts the payload genuinely cannot fit one txn** before testing the restore — so it still exercises the bug if the old single-`Update` shape ever returns, rather than silently passing on a payload that now fits. It fails with the production error before the change:

```
--- FAIL: TestFSM_Restore_ExceedsSingleTransaction
    Error: Received unexpected error: Txn is too big to fit into one request
```

A second test pins the other half of the contract — a restore replaces prior state rather than merging into it — since the clear moved from an explicit delete loop to `DropAll`.

Also verified on the real thing: env19's previously-unrestorable snapshots (`state.bin` ~19MB) now load, `raft: restored from snapshot`, all three nodes active, AMI catalogue readable, no metadata lost.

## Operational note worth carrying into the docs

The intuitive recovery — move the snapshots aside and let raft replay the log — **destroys the metadata**. The log is compacted past the snapshot point, so nodes come back with `failed to get log: index=1 error="log not found"`. Only the code fix recovers such a store.