### PR TITLE
fix: allocate test listener ports below the ephemeral range

### DIFF
--- a/backend/distributed/distributed_putobject_test.go
+++ b/backend/distributed/distributed_putobject_test.go
@@ -13,6 +13,7 @@ import (
 	s3backend "github.com/mulgadc/predastore/backend"
 	"github.com/mulgadc/predastore/internal/storetest"
 	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/internal/testport"
 	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/quic/quicserver"
 	"github.com/stretchr/testify/require"
@@ -28,8 +29,7 @@ func TestPutObjectWithTempFile(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	// Use high ports to avoid conflicts with running services
-	testBasePort := 29991
+	testBasePort := testport.Block(t, 5)
 
 	cfg := &Config{
 		BadgerDir:      tmpDir,

--- a/backend/distributed/distributed_test.go
+++ b/backend/distributed/distributed_test.go
@@ -14,6 +14,7 @@ import (
 	s3backend "github.com/mulgadc/predastore/backend"
 	"github.com/mulgadc/predastore/internal/storetest"
 	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/internal/testport"
 	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/quic/quicserver"
 	"github.com/mulgadc/predastore/s3db"
@@ -30,10 +31,10 @@ func TestPutObject_ShardPlacementAndReconstruction(t *testing.T) {
 	const (
 		bucket         = "test-bucket"
 		partitionCount = 5
-		testBasePort   = 59991
 		objectSize     = 256*1024 + 123
 	)
 
+	testBasePort := testport.Block(t, partitionCount)
 	tmpDir := t.TempDir()
 	cfg := &Config{
 		BadgerDir:      tmpDir,
@@ -142,10 +143,10 @@ func TestPutGetRoundTrip(t *testing.T) {
 	const (
 		bucket         = "test-bucket"
 		partitionCount = 11
-		testBasePort   = 49991
 		objectSize     = 128 * 1024
 	)
 
+	testBasePort := testport.Block(t, partitionCount)
 	tmpDir := t.TempDir()
 	cfg := &Config{
 		BadgerDir:      tmpDir,
@@ -342,7 +343,7 @@ func TestGetObjectByteRange(t *testing.T) {
 	const objectSize = 128 * 1024
 
 	tmpDir := t.TempDir()
-	testBasePort := 19991
+	testBasePort := testport.Block(t, 5)
 
 	cfg := &Config{
 		BadgerDir:      tmpDir,

--- a/backend/distributed/multipart_test.go
+++ b/backend/distributed/multipart_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,15 +17,12 @@ import (
 	"github.com/mulgadc/predastore/backend/multipart"
 	"github.com/mulgadc/predastore/internal/storetest"
 	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/internal/testport"
 	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/quic/quicserver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// multipartPortCounter gives each test invocation a unique port range to avoid
-// bind conflicts when the OS hasn't fully released UDP ports from the prior test.
-var multipartPortCounter atomic.Int32
 
 // setupMultipartTestBackend creates a distributed backend with QUIC servers for testing.
 // The returned slice exposes the per-node QUIC servers (indexed by node number) so tests
@@ -36,9 +32,7 @@ func setupMultipartTestBackend(t *testing.T) (*Backend, []*quicserver.QuicServer
 
 	tmpDir := t.TempDir()
 
-	// Each invocation gets a unique port range to avoid bind conflicts.
-	// Spacing of 20 (with 5 nodes per test) leaves headroom for OS socket teardown on CI.
-	testBasePort := 39991 + int(multipartPortCounter.Add(1)-1)*20
+	testBasePort := testport.Block(t, 5)
 
 	cfg := &Config{
 		BadgerDir:      tmpDir,
@@ -79,6 +73,10 @@ func setupMultipartTestBackend(t *testing.T) (*Backend, []*quicserver.QuicServer
 	time.Sleep(200 * time.Millisecond)
 
 	cleanup := func() {
+		// Drop pooled client connections first: they are keyed by node address in a
+		// package global, so leaving them open outlives the servers they point at
+		// and leaks a socket (and its goroutines) for the rest of the test binary.
+		quicclient.DefaultPool.Close()
 		for _, qs := range quicServers {
 			if qs != nil {
 				_ = qs.Close()

--- a/backend/distributed/operations_test.go
+++ b/backend/distributed/operations_test.go
@@ -6,29 +6,25 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/mulgadc/predastore/backend"
 	"github.com/mulgadc/predastore/internal/storetest"
 	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/internal/testport"
 	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/quic/quicserver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// operationsPortCounter gives each test invocation a unique port range to
-// avoid bind conflicts when the OS hasn't released UDP ports from the prior test.
-var operationsPortCounter atomic.Int32
-
 // setupTestBackend creates a distributed backend with QUIC servers for testing.
 func setupTestBackend(t *testing.T) *Backend {
 	t.Helper()
 	tmpDir := t.TempDir()
 
-	testBasePort := 24991 + int(operationsPortCounter.Add(1)-1)*20
+	testBasePort := testport.Block(t, 5)
 
 	cfg := &Config{
 		BadgerDir:      tmpDir,
@@ -67,6 +63,9 @@ func setupTestBackend(t *testing.T) *Backend {
 	time.Sleep(200 * time.Millisecond)
 
 	t.Cleanup(func() {
+		// Pooled client connections are keyed by node address in a package global,
+		// so they must go before the servers they point at.
+		quicclient.DefaultPool.Close()
 		for _, qs := range quicServers {
 			if qs != nil {
 				_ = qs.Close()

--- a/backend/distributed/put_test.go
+++ b/backend/distributed/put_test.go
@@ -14,6 +14,7 @@ import (
 	s3backend "github.com/mulgadc/predastore/backend"
 	"github.com/mulgadc/predastore/internal/storetest"
 	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/internal/testport"
 	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/quic/quicserver"
 	"github.com/stretchr/testify/require"
@@ -50,7 +51,7 @@ func TestPutObjectFullPoolReturns507EndToEnd(t *testing.T) {
 	const bucket = "test-bucket-full"
 
 	tmpDir := t.TempDir()
-	testBasePort := 29981
+	testBasePort := testport.Block(t, 5)
 
 	cfg := &Config{
 		BadgerDir:      tmpDir,

--- a/internal/testport/testport.go
+++ b/internal/testport/testport.go
@@ -1,0 +1,84 @@
+// Package testport allocates blocks of localhost ports for tests that bind real
+// listeners. Production code never imports this.
+//
+// Ports come from below the kernel's ephemeral range (net.ipv4.ip_local_port_range,
+// 32768-60999 on Linux by default). A listener port picked from inside that range
+// can already be held by an autobound client socket — notably this process's own
+// pooled QUIC clients, which keep their ports for the life of the test binary —
+// which turns a fixed port into an intermittent "bind: address already in use".
+package testport
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"net"
+	"sync/atomic"
+	"testing"
+)
+
+const (
+	bandStart   = 10000
+	bandEnd     = 32768
+	blockStride = 32
+	blocks      = (bandEnd - bandStart) / blockStride
+)
+
+// nextBlock is process-wide, so blocks never overlap within one test binary. It
+// starts somewhere random in the band so concurrent package binaries under
+// `go test ./...` don't all contend for the bottom of it.
+var nextBlock atomic.Int32
+
+func init() {
+	nextBlock.Store(rand.Int32N(blocks)) //nolint:gosec // spaces out test port blocks, not security-sensitive.
+}
+
+// Block reserves size consecutive ports and returns the first. The block lies
+// below the ephemeral floor, is disjoint from every other block this process has
+// handed out, and was free when returned.
+//
+// Ports are probed rather than held, so a concurrent test binary could still take
+// one before the caller binds. That residual race is unavoidable without a
+// cross-process lock.
+func Block(t *testing.T, size int) int {
+	t.Helper()
+
+	if size <= 0 || size > blockStride {
+		t.Fatalf("testport: block size must be in [1, %d], got %d", blockStride, size)
+	}
+
+	// One full lap of the band: if every block is occupied, fail rather than spin.
+	for range blocks {
+		base := bandStart + int(nextBlock.Add(1)-1)%blocks*blockStride
+		if blockFree(base, size) {
+			return base
+		}
+	}
+
+	t.Fatalf("testport: no free block of %d ports in [%d, %d)", size, bandStart, bandEnd)
+	return 0
+}
+
+// blockFree reports whether every port in the block is bindable. TCP and UDP have
+// separate port spaces and callers use both, so a block must be clean for each.
+func blockFree(base, size int) bool {
+	for port := base; port < base+size; port++ {
+		addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+		ln, err := net.Listen("tcp4", addr)
+		if err != nil {
+			return false
+		}
+		if err := ln.Close(); err != nil {
+			return false
+		}
+
+		pc, err := net.ListenPacket("udp4", addr)
+		if err != nil {
+			return false
+		}
+		if err := pc.Close(); err != nil {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/testport/testport_test.go
+++ b/internal/testport/testport_test.go
@@ -1,0 +1,68 @@
+package testport
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlockStaysBelowEphemeralFloor is the invariant the package exists for: an
+// allocated port must never be one the kernel could autobind a client socket to.
+func TestBlockStaysBelowEphemeralFloor(t *testing.T) {
+	for range 50 {
+		base := Block(t, 5)
+		assert.GreaterOrEqual(t, base, bandStart)
+		assert.Less(t, base+5, bandEnd)
+	}
+}
+
+// TestBlocksAreDisjoint covers the collision mode that the per-suite counters it
+// replaces got wrong: two setups in one binary must not share a port.
+func TestBlocksAreDisjoint(t *testing.T) {
+	seen := make(map[int]bool)
+	for range 50 {
+		base := Block(t, 5)
+		for port := base; port < base+5; port++ {
+			require.False(t, seen[port], "port %d handed out twice", port)
+			seen[port] = true
+		}
+	}
+}
+
+// TestBlockSkipsOccupiedPorts checks the probe: a block whose ports are already
+// taken must not be handed out, whichever protocol holds them.
+func TestBlockSkipsOccupiedPorts(t *testing.T) {
+	// Take the block that would be returned next, on UDP only, to also prove the
+	// probe is not TCP-only.
+	base := Block(t, 5)
+	pc, err := net.ListenPacket("udp4", fmt.Sprintf("127.0.0.1:%d", base+2))
+	require.NoError(t, err)
+	defer func() { _ = pc.Close() }()
+
+	// Rewind so the occupied block is the next candidate.
+	nextBlock.Add(-1)
+
+	assert.NotEqual(t, base, Block(t, 5), "occupied block should have been skipped")
+}
+
+// TestBlockRejectsBadSize guards the two size limits, since exceeding the stride
+// would silently overlap the next block.
+func TestBlockRejectsBadSize(t *testing.T) {
+	for _, size := range []int{0, -1, blockStride + 1} {
+		t.Run(fmt.Sprintf("size=%d", size), func(t *testing.T) {
+			// Block calls t.Fatalf, which only aborts the goroutine it runs on, so
+			// drive it on its own and assert the test was marked failed.
+			fake := &testing.T{}
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				Block(fake, size)
+			}()
+			<-done
+			assert.True(t, fake.Failed(), "size %d should be rejected", size)
+		})
+	}
+}

--- a/quic/quicclient/pool_test.go
+++ b/quic/quicclient/pool_test.go
@@ -4,17 +4,14 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/internal/testport"
 	quic "github.com/quic-go/quic-go"
 	"github.com/stretchr/testify/require"
 )
-
-// poolTestPortCounter hands each test invocation a unique UDP port.
-var poolTestPortCounter atomic.Int32
 
 // startMinimalQUICListener spins up a trivial quic-go listener that accepts
 // connections and streams but never replies. Enough to exercise the pool's
@@ -35,7 +32,7 @@ func startMinimalQUICListener(t *testing.T) (string, func()) {
 	SetDefaultRootCAs(pool)
 	t.Cleanup(func() { SetDefaultRootCAs(nil) })
 
-	port := 47000 + int(poolTestPortCounter.Add(1))
+	port := testport.Block(t, 1)
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 
 	ln, err := quic.ListenAddr(addr, tlsConf, &quic.Config{

--- a/quic/quicserver/put_e2e_test.go
+++ b/quic/quicserver/put_e2e_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mulgadc/predastore/internal/storetest"
 	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/internal/testport"
 	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/quic/quicserver"
 	"github.com/stretchr/testify/require"
@@ -22,7 +23,7 @@ import (
 func newFullTestQuicServer(t *testing.T) (*quicserver.QuicServer, string) {
 	t.Helper()
 	dir := t.TempDir()
-	port := 46000 + int(quicServerTestPortCounter.Add(1))
+	port := testport.Block(t, 1)
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	certPath, keyPath, pool := testcerts.Generate(t)
 	quicclient.SetDefaultRootCAs(pool)

--- a/quic/quicserver/wedge_test.go
+++ b/quic/quicserver/wedge_test.go
@@ -9,25 +9,21 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/mulgadc/predastore/internal/storetest"
 	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/internal/testport"
 	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/quic/quicserver"
 	"github.com/stretchr/testify/require"
 )
 
-// quicServerTestPortCounter hands each test invocation a unique port to avoid
-// UDP bind conflicts when the OS has not fully released prior test sockets.
-var quicServerTestPortCounter atomic.Int32
-
 func newTestQuicServer(t *testing.T) (*quicserver.QuicServer, string) {
 	t.Helper()
 	dir := t.TempDir()
-	port := 46000 + int(quicServerTestPortCounter.Add(1))
+	port := testport.Block(t, 1)
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	certPath, keyPath, pool := testcerts.Generate(t)
 	quicclient.SetDefaultRootCAs(pool)

--- a/s3/backend_test.go
+++ b/s3/backend_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/mulgadc/predastore/backend/distributed"
 	"github.com/mulgadc/predastore/internal/storetest"
 	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/internal/testport"
 	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/quic/quicserver"
 	"github.com/stretchr/testify/require"
@@ -57,11 +57,6 @@ func signTestReq(t *testing.T, req *http.Request, body []byte,
 		aws.Credentials{AccessKeyID: accessKey, SecretAccessKey: secret},
 		req, payloadHash, service, region, o.signingTime))
 }
-
-// s3BackendPortCounter gives each setupDistributedBackend invocation a unique
-// port range so concurrent or rapidly-sequenced test setups don't collide on
-// QUIC (UDP) ports the OS hasn't released yet.
-var s3BackendPortCounter atomic.Int32
 
 // testBucket is the bucket name used by all unit and integration tests.
 const testBucket = "test"
@@ -141,7 +136,7 @@ func setupDistributedBackend(t *testing.T) *TestBackend {
 		})
 	}
 
-	basePort := 14001 + int(s3BackendPortCounter.Add(1)-1)*20
+	basePort := testport.Block(t, nodeCount)
 
 	config := &distributed.Config{
 		BadgerDir:      badgerDir,

--- a/s3/s3_integration_test.go
+++ b/s3/s3_integration_test.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/mulgadc/predastore/backend/distributed"
 	"github.com/mulgadc/predastore/internal/storetest"
 	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/internal/testport"
 	"github.com/mulgadc/predastore/quic/quicclient"
 	"github.com/mulgadc/predastore/quic/quicserver"
 	"github.com/stretchr/testify/assert"
@@ -36,11 +36,6 @@ const (
 	S3_ENDPOINT = "https://localhost:6443"
 	S3_BUCKET   = "test-bucket01"
 )
-
-// s3IntegrationPortCounter gives each setupServer invocation a unique port
-// range so concurrent or rapidly-sequenced test setups don't collide on QUIC
-// (UDP) ports the OS hasn't released yet.
-var s3IntegrationPortCounter atomic.Int32
 
 // setupServer starts an S3 server backed by a distributed backend for testing.
 // Returns the per-node data directory so callers can scan segment files on
@@ -74,7 +69,7 @@ func setupServer(t *testing.T) (cancel context.CancelFunc, wg *sync.WaitGroup, n
 		nodeCount = 5
 	}
 
-	basePort := 17001 + int(s3IntegrationPortCounter.Add(1)-1)*20
+	basePort := testport.Block(t, nodeCount)
 
 	be, err := distributed.New(&distributed.Config{
 		BadgerDir:      badgerDir,


### PR DESCRIPTION
## Problem

The distributed test suites hand-picked QUIC listener base ports, and four of those bases sat inside the Linux ephemeral range (`net.ipv4.ip_local_port_range` = `32768 60999`). The kernel draws from that range whenever it autobinds a socket, so a port chosen at setup time could already be held by something else, and setup failed with `bind: address already in use`.

The most persistent squatter was predastore's own client pool. `quic.DialAddr` (`quic/quicclient/pool.go:133`) autobinds a local ephemeral UDP port, `DefaultPool` (`pool.go:261`) is a package global keyed by remote address, and nothing closed it — the multipart cleanup closed the servers and called `be.Close()`, which only closes `globalState`. Every pooled connection from every earlier test therefore stayed alive holding its port until the test binary exited, so the deeper into a suite the allocator walked, the likelier the collision.

`quicserver.NewWithRetry` cannot rescue it: it retries the *same* address with a 1.0s total backoff, which clears transient socket teardown but never a live socket. The 1.0s budget matches the observed ~1.1s failing-test durations.

A previous fix attempt widened the multipart block spacing to 20 on the theory that the OS had not yet released ports from the prior test. That is the wrong mechanism, hence the recurrence.

## Changes

- New `internal/testport`: hands out non-overlapping port blocks from `[10000, 32768)`, strictly below the ephemeral floor so the kernel can never autobind onto an allocated port. A process-wide counter walks the band from a random start (so concurrent package binaries under `go test ./...` don't contend for the bottom), and each candidate block is probed on both TCP and UDP before being handed out.
- Replaced all eleven hand-picked bases across `backend/distributed`, `quic/quicserver`, `quic/quicclient` and `s3` with `testport.Block(t, n)`.
- Close the QUIC client pool at suite teardown so pooled sockets and their goroutines don't outlive the servers they point at. No test in the repo calls `t.Parallel()`, so touching the global pool at teardown is safe.

Deliberately **not** changing `NewWithRetry` to fall forward onto a different port: that would alter production bind semantics to work around a test-only problem.