### PR TITLE
fix: record and return a real object LastModified in the distributed backend

### DIFF
--- a/backend/distributed/distributed.go
+++ b/backend/distributed/distributed.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/buraksezer/consistent"
 	"github.com/cespare/xxhash/v2"
@@ -88,14 +89,20 @@ type Backend struct {
 	quicBasePort  int
 	nodeAddrs     map[int]string // node ID -> "host:port"
 	buckets       []BucketConfig // bucket configurations
+	clock         func() time.Time
 }
 
 // ObjectToShardNodes maps an object to its shard locations.
+//
+// LastModified is gob-encoded by field name: objects written before this field
+// existed decode with it zeroed rather than erroring, so old objects report the
+// zero time until they are next written (see Backend.now/SetClock).
 type ObjectToShardNodes struct {
 	Object           [32]byte
 	Size             int64
 	DataShardNodes   []uint32
 	ParityShardNodes []uint32
+	LastModified     time.Time
 }
 
 // hasher implements consistent.Hasher using xxhash.
@@ -232,6 +239,7 @@ func New(config any) (backend.Backend, error) {
 		quicBasePort:  quicBasePort,
 		nodeAddrs:     nodeAddrs,
 		buckets:       cfg.Buckets,
+		clock:         time.Now,
 	}, nil
 }
 
@@ -266,6 +274,20 @@ func (b *Backend) DataDir() string {
 // SetDataDir sets the data directory (for testing).
 func (b *Backend) SetDataDir(dir string) {
 	b.dataDir = dir
+}
+
+// now returns the current time via the injectable clock, so writes are
+// tied to a single timestamp source that tests can override.
+func (b *Backend) now() time.Time {
+	if b.clock != nil {
+		return b.clock()
+	}
+	return time.Now()
+}
+
+// SetClock overrides the backend's time source (for testing).
+func (b *Backend) SetClock(clock func() time.Time) {
+	b.clock = clock
 }
 
 // RsDataShard returns the number of data shards (for testing).

--- a/backend/distributed/get.go
+++ b/backend/distributed/get.go
@@ -94,6 +94,7 @@ func (b *Backend) handleRangeRequest(ctx context.Context, req *backend.GetObject
 			ContentRange: contentRange,
 			Size:         int64(len(data)),
 			ETag:         generateDistributedETag(req.Bucket, req.Key),
+			LastModified: shards.LastModified,
 			StatusCode:   206, // Partial Content
 		}, nil
 	}
@@ -227,6 +228,7 @@ func (b *Backend) handleRangeWithFullReconstruction(ctx context.Context, req *ba
 		ContentRange: contentRange,
 		Size:         int64(len(rangeData)),
 		ETag:         generateDistributedETag(req.Bucket, req.Key),
+		LastModified: shards.LastModified,
 		StatusCode:   206, // Partial Content
 	}, nil
 }
@@ -265,11 +267,12 @@ func (b *Backend) getFullObject(ctx context.Context, req *backend.GetObjectReque
 
 	// Create response with io.ReadCloser wrapper
 	return &backend.GetObjectResponse{
-		Body:        io.NopCloser(bytes.NewReader(out.Bytes())),
-		ContentType: "application/octet-stream",
-		Size:        int64(out.Len()),
-		ETag:        generateDistributedETag(req.Bucket, req.Key),
-		StatusCode:  200,
+		Body:         io.NopCloser(bytes.NewReader(out.Bytes())),
+		ContentType:  "application/octet-stream",
+		Size:         int64(out.Len()),
+		ETag:         generateDistributedETag(req.Bucket, req.Key),
+		LastModified: shards.LastModified,
+		StatusCode:   200,
 	}, nil
 }
 
@@ -279,7 +282,7 @@ func (b *Backend) HeadObject(ctx context.Context, bucket, key string) (*backend.
 		return nil, err
 	}
 
-	_, size, err := b.openInput(bucket, key)
+	shards, size, err := b.openInput(bucket, key)
 	if err != nil {
 		return nil, backend.ErrNoSuchKeyError.WithResource(key)
 	}
@@ -288,6 +291,7 @@ func (b *Backend) HeadObject(ctx context.Context, bucket, key string) (*backend.
 		ContentType:   "application/octet-stream",
 		ContentLength: size,
 		ETag:          generateDistributedETag(bucket, key),
+		LastModified:  shards.LastModified,
 	}, nil
 }
 

--- a/backend/distributed/lastmodified_test.go
+++ b/backend/distributed/lastmodified_test.go
@@ -1,0 +1,198 @@
+package distributed
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore/backend"
+	s3db "github.com/mulgadc/predastore/s3db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixedClock returns a clock function that always reports t, so tests can
+// assert on specific instants instead of racing time.Now().
+func fixedClock(t time.Time) func() time.Time {
+	return func() time.Time { return t }
+}
+
+// legacyObjectToShardNodes mirrors the shape of ObjectToShardNodes before
+// LastModified existed. It proves gob decodes old records into the zero
+// time rather than erroring, since gob matches fields by name.
+type legacyObjectToShardNodes struct {
+	Object           [32]byte
+	Size             int64
+	DataShardNodes   []uint32
+	ParityShardNodes []uint32
+}
+
+func TestFreshObjectLastModifiedAgreesAcrossHeadGetList(t *testing.T) {
+	be := setupTestBackend(t)
+	ctx := context.Background()
+
+	writeTime := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	be.SetClock(fixedClock(writeTime))
+	putTestObject(t, be, "test-bucket", "fresh.txt", 4096)
+
+	headResp, err := be.HeadObject(ctx, "test-bucket", "fresh.txt")
+	require.NoError(t, err)
+	assert.True(t, headResp.LastModified.Equal(writeTime),
+		"HeadObject LastModified = %v, want %v", headResp.LastModified, writeTime)
+
+	getResp, err := be.GetObject(ctx, &backend.GetObjectRequest{
+		Bucket:     "test-bucket",
+		Key:        "fresh.txt",
+		RangeStart: -1,
+		RangeEnd:   -1,
+	})
+	require.NoError(t, err)
+	getResp.Body.Close()
+	assert.True(t, getResp.LastModified.Equal(writeTime),
+		"GetObject LastModified = %v, want %v", getResp.LastModified, writeTime)
+
+	listResp, err := be.ListObjects(ctx, &backend.ListObjectsRequest{Bucket: "test-bucket", Prefix: "fresh.txt"})
+	require.NoError(t, err)
+	require.Len(t, listResp.Contents, 1)
+	assert.True(t, listResp.Contents[0].LastModified.Equal(writeTime),
+		"ListObjects LastModified = %v, want %v", listResp.Contents[0].LastModified, writeTime)
+
+	// The three read paths must agree exactly, not just each be individually plausible.
+	assert.True(t, headResp.LastModified.Equal(getResp.LastModified),
+		"HeadObject and GetObject disagree: %v vs %v", headResp.LastModified, getResp.LastModified)
+	assert.True(t, headResp.LastModified.Equal(listResp.Contents[0].LastModified),
+		"HeadObject and ListObjects disagree: %v vs %v", headResp.LastModified, listResp.Contents[0].LastModified)
+}
+
+func TestOverwriteAdvancesLastModified(t *testing.T) {
+	be := setupTestBackend(t)
+	ctx := context.Background()
+
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	be.SetClock(fixedClock(t1))
+	putTestObject(t, be, "test-bucket", "overwrite.txt", 1024)
+
+	head1, err := be.HeadObject(ctx, "test-bucket", "overwrite.txt")
+	require.NoError(t, err)
+	require.True(t, head1.LastModified.Equal(t1))
+
+	t2 := t1.Add(24 * time.Hour)
+	be.SetClock(fixedClock(t2))
+	putTestObject(t, be, "test-bucket", "overwrite.txt", 2048)
+
+	head2, err := be.HeadObject(ctx, "test-bucket", "overwrite.txt")
+	require.NoError(t, err)
+	assert.True(t, head2.LastModified.Equal(t2),
+		"overwrite did not advance LastModified: got %v, want %v", head2.LastModified, t2)
+	assert.False(t, head2.LastModified.Equal(t1), "overwrite must not keep the original timestamp")
+}
+
+func TestListObjectsStableAcrossCalls(t *testing.T) {
+	be := setupTestBackend(t)
+	ctx := context.Background()
+
+	writeTime := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	be.SetClock(fixedClock(writeTime))
+	putTestObject(t, be, "test-bucket", "stable.txt", 512)
+
+	first, err := be.ListObjects(ctx, &backend.ListObjectsRequest{Bucket: "test-bucket", Prefix: "stable.txt"})
+	require.NoError(t, err)
+	require.Len(t, first.Contents, 1)
+
+	second, err := be.ListObjects(ctx, &backend.ListObjectsRequest{Bucket: "test-bucket", Prefix: "stable.txt"})
+	require.NoError(t, err)
+	require.Len(t, second.Contents, 1)
+
+	assert.True(t, first.Contents[0].LastModified.Equal(second.Contents[0].LastModified),
+		"ListObjects LastModified changed between two calls on an unmodified object: %v vs %v",
+		first.Contents[0].LastModified, second.Contents[0].LastModified)
+	assert.True(t, first.Contents[0].LastModified.Equal(writeTime))
+}
+
+// TestObjectToShardNodesDecodesLegacyGobWithZeroLastModified proves the
+// gob-compatibility contract directly: a record encoded before LastModified
+// existed decodes cleanly into the current struct with a zero timestamp.
+func TestObjectToShardNodesDecodesLegacyGobWithZeroLastModified(t *testing.T) {
+	legacy := legacyObjectToShardNodes{
+		Object:           [32]byte{1, 2, 3},
+		Size:             42,
+		DataShardNodes:   []uint32{0, 1, 2},
+		ParityShardNodes: []uint32{3, 4},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&buf).Encode(legacy))
+
+	var decoded ObjectToShardNodes
+	require.NoError(t, gob.NewDecoder(&buf).Decode(&decoded))
+
+	assert.True(t, decoded.LastModified.IsZero(),
+		"legacy record without LastModified must decode to the zero time, got %v", decoded.LastModified)
+	assert.Equal(t, legacy.Size, decoded.Size)
+}
+
+// TestPreExistingObjectReportsZeroLastModifiedUntilRewritten asserts the
+// chosen backward-compatibility policy: an object whose metadata predates
+// the LastModified field reports the zero time on every read path until it
+// is next written (PutObject/PutObjectFromPath/CompleteMultipartUpload all
+// stamp LastModified on every call, including overwrites). No QUIC nodes
+// are needed since HeadObject/ListObjects never read shard data.
+func TestPreExistingObjectReportsZeroLastModifiedUntilRewritten(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &Config{
+		BadgerDir:      tmpDir,
+		PartitionCount: 5,
+		Buckets: []BucketConfig{
+			{Name: "test-bucket", Region: "us-east-1"},
+		},
+	}
+	b, err := New(cfg)
+	require.NoError(t, err)
+	defer b.Close()
+
+	be, ok := b.(*Backend)
+	require.True(t, ok)
+
+	ctx := context.Background()
+	const key = "legacy.txt"
+
+	objectHash := s3db.GenObjectHash("test-bucket", key)
+	hashRingShards, err := be.HashRing().GetClosestN(objectHash[:], be.RsDataShard()+be.RsParityShard())
+	require.NoError(t, err)
+
+	legacy := legacyObjectToShardNodes{
+		Object:           objectHash,
+		Size:             777,
+		DataShardNodes:   make([]uint32, be.RsDataShard()),
+		ParityShardNodes: make([]uint32, be.RsParityShard()),
+	}
+	for i := 0; i < be.RsDataShard(); i++ {
+		legacy.DataShardNodes[i], err = NodeToUint32(hashRingShards[i].String())
+		require.NoError(t, err)
+	}
+	for i := 0; i < be.RsParityShard(); i++ {
+		legacy.ParityShardNodes[i], err = NodeToUint32(hashRingShards[be.RsDataShard()+i].String())
+		require.NoError(t, err)
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&buf).Encode(legacy))
+	require.NoError(t, be.GlobalState().Set(TableObjects, objectHash[:], buf.Bytes()))
+
+	arnKey := []byte(arnObjectPrefix + "test-bucket/" + key)
+	require.NoError(t, be.GlobalState().Set(TableObjects, arnKey, objectHash[:]))
+
+	head, err := be.HeadObject(ctx, "test-bucket", key)
+	require.NoError(t, err)
+	assert.True(t, head.LastModified.IsZero(),
+		"pre-existing object without a stored timestamp must report the zero time, got %v", head.LastModified)
+
+	listResp, err := be.ListObjects(ctx, &backend.ListObjectsRequest{Bucket: "test-bucket", Prefix: key})
+	require.NoError(t, err)
+	require.Len(t, listResp.Contents, 1)
+	assert.True(t, listResp.Contents[0].LastModified.IsZero(),
+		"ListObjects for a pre-existing object must report the zero time, not a fabricated one, got %v",
+		listResp.Contents[0].LastModified)
+}

--- a/backend/distributed/list.go
+++ b/backend/distributed/list.go
@@ -126,8 +126,11 @@ func (b *Backend) ListObjects(ctx context.Context, req *backend.ListObjectsReque
 			}
 		}
 
-		// Look up object metadata using the objectHash (value) to get size
+		// Look up object metadata using the objectHash (value) to get size and
+		// LastModified. Entries that fail to resolve (corrupt/missing metadata)
+		// report a zero LastModified rather than a fabricated one.
 		var objectSize int64
+		var lastModified time.Time
 
 		if len(value) == 32 {
 			// value is the objectHash, look up the full metadata
@@ -138,6 +141,7 @@ func (b *Backend) ListObjects(ctx context.Context, req *backend.ListObjectsReque
 				dec := gob.NewDecoder(r)
 				if err := dec.Decode(&objMeta); err == nil {
 					objectSize = objMeta.Size
+					lastModified = objMeta.LastModified
 				}
 			}
 		}
@@ -145,7 +149,7 @@ func (b *Backend) ListObjects(ctx context.Context, req *backend.ListObjectsReque
 		// Add as content
 		contents = append(contents, backend.ObjectInfo{
 			Key:          objectKey,
-			LastModified: time.Now(), // TODO: Store actual modification time
+			LastModified: lastModified,
 			Size:         objectSize,
 			StorageClass: "STANDARD",
 		})

--- a/backend/distributed/multipart.go
+++ b/backend/distributed/multipart.go
@@ -396,8 +396,9 @@ func (b *Backend) CompleteMultipartUpload(ctx context.Context, req *backend.Comp
 
 	// Store object metadata (same as regular PutObject)
 	objectToShardNodes := ObjectToShardNodes{
-		Object: objectHash,
-		Size:   finalInfo.Size(),
+		Object:       objectHash,
+		Size:         finalInfo.Size(),
+		LastModified: b.now(),
 	}
 
 	// Use objectHash for hash ring placement - must match what putObjectViaQUIC uses

--- a/backend/distributed/put.go
+++ b/backend/distributed/put.go
@@ -83,6 +83,7 @@ func (b *Backend) PutObject(ctx context.Context, req *backend.PutObjectRequest) 
 	}
 
 	objectToShardNodes.Size = size
+	objectToShardNodes.LastModified = b.now()
 
 	// Get hash ring placement using objectHash for consistency with storage and retrieval
 	hashRingShards, err := b.hashRing.GetClosestN(objectHash[:], b.rsDataShard+b.rsParityShard)
@@ -164,6 +165,7 @@ func (b *Backend) PutObjectFromPath(ctx context.Context, bucket, objectPath stri
 	}
 
 	objectToShardNodes.Size = size
+	objectToShardNodes.LastModified = b.now()
 
 	// Get hash ring placement using objectHash for consistency with putObjectViaQUIC
 	hashRingShards, err := b.hashRing.GetClosestN(objectHash[:], b.rsDataShard+b.rsParityShard)


### PR DESCRIPTION
Closes **mulga-whi92**.

## Root cause

`ObjectToShardNodes` (`backend/distributed/distributed.go`) had no timestamp field at all. Three symptoms, one gap:

- `HeadObject` and all three `GetObject` return paths left `LastModified` as Go's zero `time.Time`, which `s3/httpserver.go:562` formats as `Mon, 01 Jan 0001 00:00:00 GMT`. The reported `2001-01-01` is botocore/dateutil's century-fixup rendering of a year-1 time, not a stored placeholder — there is no `2001` literal anywhere in predastore.
- `ListObjects` papered over it with `time.Now()`, so listings showed a plausible-looking timestamp that changed on every call. Arguably worse than an obviously-wrong one, because it looks real.

Audited for a fourth occurrence and found none — `bucket.go:54` `CreationDate`, `delete.go:74` `DeletedAt`, `multipart.go:67` upload `CreatedAt` and `multipart.go:192` part `LastModified` all correctly stamp at the moment of the write they describe.

## Changes

- `distributed.go` — `LastModified time.Time` on `ObjectToShardNodes`; injectable `clock` with `now()`/`SetClock()`, defaulting to `time.Now`, so tests never depend on wall clock.
- `put.go:86,168` and `multipart.go:401` — stamp on every write path.
- `get.go:285,97,231,271` — `HeadObject` and all three `GetObject` paths return the stored value.
- `list.go:129-147` — uses the stored value instead of fabricating one.

## Gob compatibility

Pre-existing objects decode with `LastModified` zeroed, and that is left as-is. Gob matches by field name, so old records are neither corrupted nor rejected — behaviour for untouched legacy objects is byte-identical to pre-fix — and it self-heals on next write, since every write path re-stamps including on overwrite.

Suppressing the header for zero values risked breaking clients that require it; fabricating one would repeat the exact `ListObjects` mistake being fixed.

## Metadata updates

There is no `CopyObject` or tagging operation in this backend today, so no metadata-only path exists to wire up. If one is added it should go through the same write path so it advances `LastModified`, matching S3's copy-creates-a-new-version semantics.

## Testing

5 new tests in `lastmodified_test.go`: fresh-write agreement across Head/Get/List, overwrite advancing the timestamp, List stability across calls, gob legacy decode, and the pre-existing-object policy.

Pre-fix, compile failures plus this runtime failure once the `ListObjects` line alone was reverted — proving the stability test catches the real bug and not just a missing field:

```
lastmodified_test.go:108: Error: Should be true
Messages: ListObjects LastModified changed between two calls on an unmodified object:
  2026-08-01 23:08:44.827437737 ... vs 2026-08-01 23:08:44.827489449 ...
--- FAIL: TestListObjectsStableAcrossCalls (0.52s)
```

All pass under `-race`; `go test ./backend/...` shows no regressions. `make preflight` green.

## No consumer impact

`ObjectToShardNodes` is internal to predastore's own gob state and spinifex has zero references to it or to `backend/distributed` — spinifex talks to predastore only over the S3 HTTP API. No `go.mod` pin move is needed.