### PR TITLE
fix: allow the active segment to become a compaction candidate

### DIFF
--- a/store/compaction.go
+++ b/store/compaction.go
@@ -153,8 +153,20 @@ func (store *Store) compactOnce() error {
 
 // candidateSegments scans the tombstone namespace, sums dead bytes per segment,
 // and returns segments whose live fraction is below the threshold, plus a
-// count of segments that could not be inspected. The active append segment is
-// never a candidate — it is the relocation destination.
+// count of segments that could not be inspected.
+//
+// The active append segment is never returned as a candidate in this pass —
+// it is the relocation destination, and it may still be receiving writes. But
+// if its own live fraction is below the threshold, it is sealed (the same
+// markFull a size-triggered roll uses) and store.segNum is advanced past it,
+// exactly like a normal roll. Without this, a store whose data never crosses
+// maxSegSize keeps its only segment active forever, and its dead bytes are
+// never reclaimable no matter how large. The sealed segment is left for the
+// next cycle to pick up as an ordinary, no-longer-active candidate: any
+// writer that reserved a slot in it before the roll is only guaranteed to
+// have finished by dropSegment's addRef/waitForRefs pairing, not by elapsed
+// time, but deferring candidacy by one cycle keeps its exposure no worse than
+// any size-rolled segment gets.
 //
 // A segment that fails to open or stat is skipped rather than aborting the
 // whole scan: one bad segment (e.g. dropped out from under a stale tombstone)
@@ -183,10 +195,6 @@ func (store *Store) candidateSegments() ([]uint64, int, error) {
 	var candidates []uint64
 	var failed int
 	for num, deadBytes := range dead {
-		if num == store.segNum {
-			continue
-		}
-
 		// Read path: a candidate must already exist. If it doesn't (e.g. a
 		// tombstone survived a segment already dropped), skip it and keep
 		// going rather than fabricating a stub or stalling the whole scan.
@@ -207,9 +215,27 @@ func (store *Store) candidateSegments() ([]uint64, int, error) {
 		if size <= segHeaderSize {
 			continue
 		}
-		if float64(size-deadBytes)/float64(size) < compactionLiveThreshold {
-			candidates = append(candidates, num)
+		if float64(size-deadBytes)/float64(size) >= compactionLiveThreshold {
+			continue
 		}
+
+		if num == store.segNum {
+			// Seal and roll now so next cycle sees a normal, non-active
+			// candidate; do not compact it in this same pass (see doc comment).
+			if err := seg.markFull(); err != nil {
+				slog.Error("compaction: failed to seal stale active segment, will retry next cycle", "segNum", num, "error", err)
+				failed++
+				continue
+			}
+			if _, err := store.rollSegment(); err != nil {
+				slog.Error("compaction: failed to roll past sealed active segment, will retry next cycle", "segNum", num, "error", err)
+				failed++
+				continue
+			}
+			continue
+		}
+
+		candidates = append(candidates, num)
 	}
 	return candidates, failed, nil
 }

--- a/store/compaction_test.go
+++ b/store/compaction_test.go
@@ -111,6 +111,71 @@ func TestCompactionDropsDrainedSegmentAndShrinks(t *testing.T) {
 	}
 }
 
+// A store whose data never crosses maxSegSize never rolls past segment 0, so
+// segment 0 is always both the sole segment and the active one. Before the
+// fix, candidateSegments unconditionally excluded the active segment, so a
+// store in this shape could never reclaim dead bytes no matter how much of
+// it was deleted -- compaction always reported segments:0. This asserts the
+// physical file shrinks, not just that the index entry is gone.
+func TestCompactionReclaimsSoleActiveSegment(t *testing.T) {
+	st, dir := openStore(t, store.WithMaxSegSize(1*store.MiB))
+	defer st.Close()
+
+	keep := [32]byte{0x5}
+	dead := [32]byte{0x6}
+	keepBody := bytes.Repeat([]byte{0x11}, 40*store.KiB)
+	deadBody := bytes.Repeat([]byte{0x22}, 200*store.KiB)
+	write(t, st, keep, 0, keepBody)
+	write(t, st, dead, 0, deadBody)
+
+	seg0 := filepath.Join(dir, fmt.Sprintf("%016d.seg", 0))
+	seg1 := filepath.Join(dir, fmt.Sprintf("%016d.seg", 1))
+	if _, err := os.Stat(seg0); err != nil {
+		t.Fatalf("segment 0 should exist: %v", err)
+	}
+	if _, err := os.Stat(seg1); !os.IsNotExist(err) {
+		t.Fatalf("precondition: store should still hold a single segment, stat err=%v", err)
+	}
+
+	if _, err := st.Delete(dead, 0); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	before := dirBytes(t, dir)
+
+	// Cycle 1: segment 0 is still active, so it is only sealed and rolled
+	// past, not dropped yet.
+	if err := st.CompactOnce(); err != nil {
+		t.Fatalf("compact cycle 1: %v", err)
+	}
+	if _, err := os.Stat(seg1); err != nil {
+		t.Fatalf("segment 0 should have been sealed and rolled past: %v", err)
+	}
+	if _, err := os.Stat(seg0); err != nil {
+		t.Fatalf("segment 0 should not be dropped in the same cycle it was sealed: %v", err)
+	}
+
+	// Cycle 2: segment 0 is no longer active, so it is now an ordinary
+	// drained candidate and gets compacted away.
+	if err := st.CompactOnce(); err != nil {
+		t.Fatalf("compact cycle 2: %v", err)
+	}
+	if _, err := os.Stat(seg0); !os.IsNotExist(err) {
+		t.Errorf("segment 0 should be unlinked once no longer active, stat err=%v", err)
+	}
+
+	if after := dirBytes(t, dir); after >= before {
+		t.Errorf("on-disk bytes should shrink once the sole active segment is reclaimed: before=%d after=%d", before, after)
+	}
+
+	got, err := readAll(t, st, keep, 0)
+	if err != nil {
+		t.Fatalf("read surviving shard: %v", err)
+	}
+	if !bytes.Equal(got, keepBody) {
+		t.Errorf("surviving shard corrupted")
+	}
+}
+
 // persistedSegNum reads the active segment counter back out of state.json.
 func persistedSegNum(t *testing.T, dir string) uint64 {
 	t.Helper()


### PR DESCRIPTION
Addresses **mulga-nfpk4** (P1). Two of four acceptance criteria are met here; the other two need a
live environment and are explicitly pending (see below).

## Problem

After deleting a large AMI, physical disk usage did not fall at all. Every 300 s cycle logged:

```
"compaction finished","segments":0,"extents":0,"bytes":0,"failed":0
```

`failed:0` alongside `segments:0` is the tell — nothing failed, nothing was even **considered**.

## Root cause

`candidateSegments` (`store/compaction.go:186-188`) unconditionally skipped `num == store.segNum`
before ever computing its live fraction.

Segments only roll past 0 **on size** — `DefaultMaxSegSize = 4 * GiB` (`store/segment.go:109`),
checked in `reserveExtent` (`store/store.go:366-388`) — and never on staleness. So any store whose
data stays under 4 GiB never advances `segNum`, and its sole segment is permanently excluded from
candidacy no matter how dead its contents are. That matches the reported 3.9 G `.seg` files exactly:
the store was one segment, and that one segment could never be a candidate.

## Fix

`candidateSegments` now computes the live-fraction check for every dead segment first, then
special-cases the active one: if it is below threshold, seal it with `seg.markFull()` and advance
`store.segNum` via `rollSegment()` — the same mechanism a size-triggered roll already uses.

The sealed segment is deliberately **not** added to the current cycle's candidate list. The next
`candidateSegments()` call sees it as an ordinary, no-longer-active segment and compacts it normally.

**Crash safety.** This reuses machinery already in the file, unmodified:

- `compactOnce`'s existing `saveState()` (`compaction.go:115-122`) persists the advanced `segNum`
  before any drop.
- `dropSegment`'s `addRef`/`waitForRefs` pairing (`segment.go:167-207`, `store.go:312,323`) blocks the
  unlink until every writer holding a reservation in the sealed segment has finished.

Deferring candidacy by one cycle also gives a straggling in-flight writer the same grace period a
size-rolled segment already gets, rather than compacting a segment in the very cycle it was sealed.

## Testing (acceptance criterion 3)

`TestCompactionReclaimsSoleActiveSegment` in `store/compaction_test.go` writes two shards that stay
inside a single segment (`WithMaxSegSize(1*MiB)`, ~240 KiB written), deletes the larger, then calls
`CompactOnce()` twice — asserting segment 0 survives cycle 1 (sealed and rolled only) and is unlinked
after cycle 2.

Crucially it asserts on `dirBytes(dir)`, a real `os.ReadDir` size sum, so it proves **on-disk bytes
actually shrink** rather than merely that the index entry is gone. An index assertion would have
passed against the broken code.

`make preflight` passes in full: lint 0 issues, govulncheck clean, coverage, race and integration
tests green.

## Still pending — criteria 1 and 2

Physical reclamation on a real cluster is **not verified**; no environment was available. To confirm
once one is:

```
du -sh <predastore-data-dir>                                # before
# import a large AMI, then: spx admin images remove <ami-id>
du -sh <predastore-data-dir>                                # after, over a few 300s cycles
journalctl -u predastore -f | grep "compaction finished"    # want segments>0, bytes>0
```

predastore is a separate module, so a deployed `spx` needs
`GOWORK=off go get github.com/mulgadc/predastore@<sha>` in spinifex before a live test reflects this.

## Related

Criterion 4 (`bytesFreed` wording) lives in spinifex and is a separate PR.

A latent ordering concern found by inspection while working here — `compactSegment`'s per-key
liveness check running before `dropSegment`'s `waitForRefs()` — is filed as **mulga-8vjz1**. It
predates this change and is not caused by it.
