### PR TITLE
fix: do not compact a segment holding a reserved-but-uncommitted write

### DIFF
--- a/store/compaction.go
+++ b/store/compaction.go
@@ -220,10 +220,40 @@ type segmentStats struct {
 	bytes   int64
 }
 
+// compactionAfterScan fires between a segment's liveness scan and its drop.
+// Production leaves it a no-op; tests override it to commit inside that window,
+// the way SetOpenFile overrides the segment opener.
+var compactionAfterScan = func(segNum uint64) {}
+
 // compactSegment relocates a segment's live extents into the active append
-// segment, then drops it and clears its tombstones.
+// segment, then drops it and clears its tombstones. A segment still holding an
+// uncommitted write is deferred to a later cycle instead.
 func (store *Store) compactSegment(num uint64) (segmentStats, error) {
 	var stats segmentStats
+
+	store.mutex.Lock()
+	// Read path: candidateSegments already opened this one, so a segment that
+	// has gone missing since must be reported rather than fabricated.
+	seg, err := store.getSegment(num, false)
+	var deferred bool
+	if err == nil {
+		// segNum only ever advances, so a segment already below it can never be an
+		// append target again: a zero pending count there can never rise back, which
+		// is what makes one reading here hold for the whole scan that follows.
+		deferred = num >= store.segNum || seg.pendingWrites() > 0
+	}
+	store.mutex.Unlock()
+	if err != nil {
+		return stats, fmt.Errorf("get segment %d: %w", num, err)
+	}
+
+	// A writer publishes its .idx row and reserves its extent at Append but only
+	// reaches the index at Close, so scanning now would read it as absent and take
+	// it for dead — and dropSegment's waitForRefs runs too late to undo that.
+	if deferred {
+		slog.Info("compaction deferred segment with uncommitted writes", "segNum", num, "pending", seg.pendingWrites())
+		return stats, nil
+	}
 
 	entries, err := scanIdx(store.dir, num)
 	if err != nil {
@@ -254,6 +284,8 @@ func (store *Store) compactSegment(num uint64) (segmentStats, error) {
 		stats.extents++
 		stats.bytes += cur.PSize
 	}
+
+	compactionAfterScan(num)
 
 	// The relocations above CAS-committed the repointed rows into badger, which
 	// runs with SyncWrites off, so they may still be only in the OS page cache.

--- a/store/compaction_internal_test.go
+++ b/store/compaction_internal_test.go
@@ -405,3 +405,125 @@ func TestIdxCoversEveryCommittedExtent(t *testing.T) {
 		}
 	}
 }
+
+// inFlightSegment0Store leaves segment 0 as a compaction candidate that still
+// holds one reserved-but-uncommitted extent: a deleted shard supplies the dead
+// bytes, the returned writer is open, and a third shard rolls the store off
+// segment 0 so it stops being the active segment.
+func inFlightSegment0Store(t *testing.T) (st *Store, dir string, live [32]byte, body []byte, w Writer) {
+	t.Helper()
+	st, dir = openTestStore(t, WithMaxSegSize(40*KiB))
+
+	dead := [32]byte{0x71}
+	live = [32]byte{0x72}
+	body = bytes.Repeat([]byte{0x5a}, 12*KiB)
+
+	putShard(t, st, dead, 0, body)
+
+	w, err := st.Append(live, 0, int64(len(body)))
+	if err != nil {
+		t.Fatalf("append in-flight shard: %v", err)
+	}
+	if _, err := w.Write(body); err != nil {
+		t.Fatalf("write in-flight shard: %v", err)
+	}
+	if ext := extentOf(t, st, dead, 0); ext.SegNum != 0 {
+		t.Fatalf("precondition: dead shard should be in segment 0, got %d", ext.SegNum)
+	}
+
+	if _, err := st.Delete(dead, 0); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	// Rolls onto segment 1, so segment 0 is no longer the active segment and
+	// becomes eligible for candidate selection with the writer above still open.
+	putShard(t, st, [32]byte{0x73}, 0, bytes.Repeat([]byte{0x5b}, 20*KiB))
+	if st.segNum == 0 {
+		t.Fatalf("precondition: store should have rolled off segment 0")
+	}
+
+	cands, failed, err := st.candidateSegments()
+	if err != nil {
+		t.Fatalf("candidates: %v", err)
+	}
+	if failed != 0 {
+		t.Fatalf("candidate scan reported %d failures, want 0", failed)
+	}
+	if len(cands) != 1 || cands[0] != 0 {
+		t.Fatalf("precondition: expected segment 0 as sole candidate, got %v", cands)
+	}
+
+	return st, dir, live, body, w
+}
+
+// A writer reserves its extent and publishes its .idx row at Append but only
+// reaches the index at Close, so compaction's per-key liveness check reads a
+// mid-write key as absent and takes it for dead. dropSegment's waitForRefs then
+// waits for that very writer before unlinking, which guarantees the commit lands
+// first — the segment is deleted out from under a live index entry.
+func TestCompactionDoesNotDropSegmentWithInFlightWrite(t *testing.T) {
+	st, _, live, body, w := inFlightSegment0Store(t)
+
+	// Force the losing interleave: commit the in-flight shard after the liveness
+	// scan and before the drop. Fires at most once; the deferral fix means the
+	// first cycle never reaches the seam at all.
+	closedByHook := false
+	prev := compactionAfterScan
+	compactionAfterScan = func(segNum uint64) {
+		if segNum != 0 || closedByHook {
+			return
+		}
+		closedByHook = true
+		if err := w.Close(); err != nil {
+			t.Errorf("close in-flight writer: %v", err)
+		}
+	}
+	defer func() { compactionAfterScan = prev }()
+
+	if err := st.compactOnce(); err != nil {
+		t.Fatalf("compact cycle 1: %v", err)
+	}
+
+	if !closedByHook {
+		if err := w.Close(); err != nil {
+			t.Fatalf("close in-flight writer: %v", err)
+		}
+	}
+
+	// Whichever way the cycle went, the shard that was mid-write must survive.
+	if got := readShard(t, st, live, 0); !bytes.Equal(got, body) {
+		t.Fatalf("mid-write shard body wrong after compaction")
+	}
+	if closedByHook {
+		t.Fatalf("compaction scanned segment 0 for liveness while a write to it was uncommitted")
+	}
+}
+
+// Deferring must cost nothing permanently: once the writer drains, the very next
+// cycle reclaims the segment. Otherwise the fix trades data loss for a segment
+// that is never reclaimed, which is the failure mode compaction exists to avoid.
+func TestCompactionReclaimsDeferredSegmentOnceWriteCommits(t *testing.T) {
+	st, dir, live, body, w := inFlightSegment0Store(t)
+	seg0 := filepath.Join(dir, fmt.Sprintf(segFilename, uint64(0)))
+
+	if err := st.compactOnce(); err != nil {
+		t.Fatalf("compact cycle 1: %v", err)
+	}
+	if _, err := os.Stat(seg0); err != nil {
+		t.Fatalf("segment 0 must survive a cycle that could not judge its liveness: %v", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close in-flight writer: %v", err)
+	}
+
+	if err := st.compactOnce(); err != nil {
+		t.Fatalf("compact cycle 2: %v", err)
+	}
+	if _, err := os.Stat(seg0); !os.IsNotExist(err) {
+		t.Fatalf("segment 0 stranded after its writer drained, stat gave %v", err)
+	}
+	if got := readShard(t, st, live, 0); !bytes.Equal(got, body) {
+		t.Fatalf("relocated shard body wrong after the deferred segment was reclaimed")
+	}
+}

--- a/store/segment.go
+++ b/store/segment.go
@@ -160,6 +160,11 @@ type segment struct {
 	// addRef can race a Wait.
 	refs sync.WaitGroup
 
+	// Writers that reserved an extent here but have not yet committed it to the
+	// index. Counted apart from refs because a reader pins the fd without
+	// hiding anything from a liveness lookup, whereas an uncommitted writer does.
+	pending atomic.Int64
+
 	// Caches the on-disk full flag, sparing the hot Append path a ReadAt.
 	full atomic.Bool
 }
@@ -167,6 +172,20 @@ type segment struct {
 func (seg *segment) addRef()      { seg.refs.Add(1) }
 func (seg *segment) releaseRef()  { seg.refs.Done() }
 func (seg *segment) waitForRefs() { seg.refs.Wait() }
+
+// addWriteRef pins the segment for a writer whose extent is reserved but not
+// yet in the index. releaseWriteRef must run only after that commit lands.
+func (seg *segment) addWriteRef() {
+	seg.pending.Add(1)
+	seg.refs.Add(1)
+}
+
+func (seg *segment) releaseWriteRef() {
+	seg.pending.Add(-1)
+	seg.refs.Done()
+}
+
+func (seg *segment) pendingWrites() int64 { return seg.pending.Load() }
 
 // appendIdx writes one row at the .idx append cursor and advances it. Caller
 // holds store.mutex.
@@ -182,7 +201,8 @@ func (seg *segment) syncIdx() error { return seg.idx.Sync() }
 
 // dropSegment unlinks a drained segment and its sidecar. Caller holds
 // store.mutex. Safe only once every live extent it held has been committed
-// elsewhere.
+// elsewhere. waitForRefs below guards the unlink alone: it runs after the
+// caller has already judged liveness, so it cannot make that judgement safe.
 func (store *Store) dropSegment(num uint64) error {
 	seg, ok := store.segCache[num]
 	if !ok {

--- a/store/store.go
+++ b/store/store.go
@@ -309,7 +309,9 @@ func (store *Store) Append(objectHash [32]byte, shardIndex uint32, size int64) (
 		return nil, err
 	}
 
-	seg.addRef()
+	// Marks the extent as reserved-but-uncommitted, which is what keeps
+	// compaction from judging this segment's liveness before the writer closes.
+	seg.addWriteRef()
 
 	ext := extent{
 		SegNum: store.segNum,
@@ -320,7 +322,7 @@ func (store *Store) Append(objectHash [32]byte, shardIndex uint32, size int64) (
 
 	key := MakeShardKey(objectHash, shardIndex)
 	if err := seg.appendIdx(idxEntry{Off: off, Key: [36]byte(key), PSize: ext.PSize}); err != nil {
-		seg.releaseRef()
+		seg.releaseWriteRef()
 		return nil, fmt.Errorf("append idx: %w", err)
 	}
 

--- a/store/writer.go
+++ b/store/writer.go
@@ -115,7 +115,9 @@ func (w *writer) Close() (err error) {
 	}
 
 	w.closed = true
-	defer w.seg.releaseRef()
+	// Deferred, so the segment stays marked as holding an uncommitted write
+	// until commitExtent below has either landed or failed for good.
+	defer w.seg.releaseWriteRef()
 
 	if w.cursor > w.flushedTo {
 		if err = w.flush(true); err != nil {


### PR DESCRIPTION
Closes **mulga-8vjz1** (raised to P1 on confirmation).

A live extent whose badger commit has not yet landed is classified **dead** by compaction, and the
segment holding it is then unlinked. This is data loss, not merely a dangling index entry.

## Why it is reachable — nothing serialises it

All paths on `dev` @ `608939e`:

| Step | Location | Fact |
| --- | --- | --- |
| Writer takes a segment ref and publishes its `.idx` row | `store/store.go:312`, `:322` | both under `store.mutex`, **before** `Append` returns |
| Writer's index commit lands only at `Close` | `store/writer.go:137` → `store/store.go:401` | `commitExtent` takes **no** `store.mutex`; the ref is released by the `defer` at `writer.go:118`, i.e. *after* the commit |
| Liveness scan runs lock-free | `store/compaction.go:233-256` | `index.Get(key)` → `ErrKeyNotFound` → `continue` (dead) |
| `waitForRefs` runs after that decision | `compaction.go:269-271` → `segment.go:192` | blocks on the very writer whose key was just judged dead, **then** unlinks |

`waitForRefs` guards the *unlink*, never the *decision*. So it does not prevent the loss — it
guarantees it, by ensuring the writer finishes committing an index row whose data is about to be
deleted.

The window opens as soon as a segment stops being active while a writer is still in flight. `segNum`
advances in `reserveExtent` (`store.go:366-388`), so the same `Append` that marks segment S full can
still reserve *in* S while the next `Append` rolls to S+1. From then on S is candidate-eligible
(`compaction.go:186` only excludes `num == store.segNum`) with an uncommitted extent inside it.

For an S3 PUT that window is the entire streaming body — seconds to minutes. And `kickCompaction`
(`store.go:289`) fires on the nearfull path, i.e. exactly when write traffic is heaviest.

## Deterministic reproduction

A 3-line test seam `compactionAfterScan` in `compaction.go` (same shape and precedent as the existing
`openFile` seam at `segment.go:141`) fires between the liveness scan and the drop, letting the test
force the exact interleave on a single goroutine. **No sleeps, no timeouts, no load sensitivity** — a
race test that fails "sometimes" just invites re-running until green.

Against pre-fix behaviour it fails in 0.04 s:

```
INFO compacted segment segNum=0 extents=0 bytes=0     <- live mid-write extent classified dead
compaction_internal_test.go:494: lookup (72,0): get segment 0:
  open .../0000000000000000.seg: no such file or directory
```

## The fix

A per-segment count of reserved-but-uncommitted writes (`segment.pending`, incremented in `Append`
under `store.mutex`, decremented in the `writer.Close` defer *after* `commitExtent`).
`compactSegment` reads it under `store.mutex` before scanning and defers the whole segment if
non-zero.

**Why not drain refs before the scan:** `refs` conflates readers with writers, so pre-draining would
let one long reader starve compaction — reintroducing exactly the over-retention this repo just fixed
— and waiting under `store.mutex` would stall every append and lookup behind the slowest streaming
PUT. Skipping costs nothing and blocks nobody.

**Why it cannot swing into over-retention:**

- The deferral is bounded by the writer's own lifetime, not by ambiguity. It is never "this might be
  live, so keep it".
- Tombstones are untouched — it returns before both `dropSegment` and `deleteTombstones` — so the
  segment is re-selected next cycle and reclaimed. `TestCompactionReclaimsDeferredSegmentOnceWriteCommits`
  asserts the file is actually unlinked on the following pass.
- A leaked never-closed writer would pin the segment, but it already pins `dropSegment` and
  `Store.Close` forever today. No new failure mode.

**Why one reading under the mutex is stable enough for the lock-free scan that follows:** `segNum`
only ever advances, so a segment below it can never be an append target again, and a zero pending
count there cannot rise back. The added `num >= store.segNum` guard closes the crash-recovery case
where a stale `state.json` leaves segments numbered *above* `segNum` (the hazard already noted at
`compaction.go:109-114`), where that monotonicity argument would not hold.

Crash safety is unchanged: deferring writes nothing to disk, and the existing
`index.Badger.Sync()`-before-drop ordering is untouched.

## Note for reviewers of predastore #71

That PR's doc comment currently states this exposure is acceptable, reasoning that the writer is
"only guaranteed to have finished by `dropSegment`'s `addRef`/`waitForRefs` pairing". That reasoning
is wrong for the reason above, and this PR corrects it.

The two branches are compatible — after #71's seal-and-roll, `num < segNum`, so the new guard does not
trip — but whichever lands second needs a trivial rebase in `candidateSegments`.
