### PR TITLE
fix: track the cluster topology test fixture

### DIFF
--- a/s3/testdata/cluster_topology.toml
+++ b/s3/testdata/cluster_topology.toml
@@ -1,0 +1,64 @@
+# Fixture for cluster topology parsing: three hosts, six nodes, one auth entry.
+
+version = "1.0"
+region = "ap-southeast-2"
+
+[rs]
+data = 2
+parity = 1
+
+[[host]]
+id = 1
+bind_addr = "0.0.0.0:6660"
+public_addr = "10.11.12.1:6660"
+data_dir = "/var/lib/predastore"
+
+[[host]]
+id = 2
+bind_addr = "0.0.0.0:6660"
+public_addr = "10.11.12.2:6660"
+data_dir = "/var/lib/predastore"
+
+[[host]]
+id = 3
+bind_addr = "0.0.0.0:6660"
+public_addr = "10.11.12.3:6660"
+data_dir = "/var/lib/predastore"
+
+[[node]]
+id = 1
+host_id = 1
+role = "shard-storage"
+
+[[node]]
+id = 2
+host_id = 1
+role = "state-replica"
+
+[[node]]
+id = 3
+host_id = 2
+role = "shard-storage"
+
+[[node]]
+id = 4
+host_id = 2
+role = "state-replica"
+
+[[node]]
+id = 5
+host_id = 3
+role = "shard-storage"
+
+[[node]]
+id = 6
+host_id = 3
+role = "state-replica"
+
+[[auth]]
+access_key_id = "AKIAIOSFODNN7EXAMPLE"
+secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+account_id = "123456789012"
+policy = [
+  { bucket = "*", actions = ["s3:*"] },
+]


### PR DESCRIPTION
Fixes the red `dev` build at [run 30771417093](https://github.com/mulgadc/predastore/actions/runs/30771417093) (`1b2e787`, "feat: rpc transport (#68)").

## Problem

`TestReadConfig_ClusterTopology` reads `s3/testdata/cluster_topology.toml`, but `.gitignore:25`'s blanket `*/testdata/*` rule kept the fixture untracked — it existed only on the authoring machine. On a clean CI checkout:

```
{"level":"WARN","msg":"Error reading config file","error":"Error reading testdata/cluster_topology.toml open testdata/cluster_topology.toml: no such file or directory"}
--- FAIL: TestReadConfig_ClusterTopology
    config_test.go:56: Received unexpected error: ... no such file or directory
    config_test.go:57: "[]" should have 3 item(s), but has 0
    config_test.go:58: "[]" should have 6 item(s), but has 0
panic: runtime error: index out of range [0] with length 0
```

The read failure is the root cause; the two `Len` assertions are downstream of it. Because `assert.Len` is non-fatal, execution reaches `s3.Hosts[0]` at `config_test.go:59` and panics, killing the test binary and taking the rest of the `s3` package with it. Both `Run Tests with Coverage` and `Run Tests with Race Detector` fail on this; `Lint and Security` passes.

## Change

Force-add `s3/testdata/cluster_topology.toml`, matching how `s3/testdata/invalid_cluster.toml` — added by the same commit `1191c44`, covered by the same ignore rule — is already tracked. The fixture is unmodified from what the test was written against: 3 hosts, 6 nodes, 1 auth entry.

## Testing

- `go test ./s3/ -run TestReadConfig -v` — all 5 config tests pass.
- `make preflight` passes (0 lint issues, no vulnerabilities, coverage + race + integration clean).

## Follow-ups (not in this PR)

- `.gitignore:25`'s `*/testdata/*` is redundant with lines 21-24, which already list the runtime-generated artefacts individually. Narrowing it would stop the next fixture hitting this trap.
- `config_test.go:56` should use `require` rather than `assert`, so a missing fixture fails one test instead of panicking the package binary.
