### PR TITLE
fix(s3): reconnect to NATS indefinitely so IAM auth survives a restart

### DIFF
--- a/s3/auth.go
+++ b/s3/auth.go
@@ -222,6 +222,29 @@ type NATSIAMProvider struct {
 var _ CredentialProvider = (*NATSIAMProvider)(nil)
 
 // NewNATSIAMProvider creates a provider that looks up IAM credentials from NATS KV.
+// natsIAMOptions builds the IAM connection's NATS options.
+//
+// MaxReconnects is unlimited on purpose. nats.go defaults to 60 attempts at 2s,
+// so a NATS restart lasting over ~2 minutes closes this connection for good and
+// every credential lookup fails until predastore itself is restarted.
+func natsIAMOptions(cfg *IAMConfig) []nats.Option {
+	opts := []nats.Option{
+		nats.Name("predastore-iam"),
+		nats.ReconnectWait(time.Second),
+		nats.MaxReconnects(-1),
+		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
+			slog.Warn("IAM NATS disconnected; credential lookups fail until it returns", "error", err)
+		}),
+		nats.ReconnectHandler(func(nc *nats.Conn) {
+			slog.Info("IAM NATS reconnected", "url", nc.ConnectedUrl())
+		}),
+	}
+	if cfg.NATSToken != "" {
+		opts = append(opts, nats.Token(cfg.NATSToken))
+	}
+	return opts
+}
+
 // The provider connects to NATS eagerly but opens KV buckets lazily — this allows
 // predastore to start before the spinifex daemon creates the IAM buckets during bootstrap.
 func NewNATSIAMProvider(cfg *IAMConfig) (*NATSIAMProvider, error) {
@@ -241,13 +264,7 @@ func NewNATSIAMProvider(cfg *IAMConfig) (*NATSIAMProvider, error) {
 		return nil, fmt.Errorf("load master key: %w", err)
 	}
 
-	// Connect to NATS
-	opts := []nats.Option{nats.Name("predastore-iam")}
-	if cfg.NATSToken != "" {
-		opts = append(opts, nats.Token(cfg.NATSToken))
-	}
-
-	conn, err := nats.Connect(cfg.NATSUrl, opts...)
+	conn, err := nats.Connect(cfg.NATSUrl, natsIAMOptions(cfg)...)
 	if err != nil {
 		return nil, fmt.Errorf("connect to NATS: %w", err)
 	}

--- a/s3/auth_test.go
+++ b/s3/auth_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/mulgadc/predastore/pkg/iampolicy"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -162,6 +164,40 @@ func TestNewNATSIAMProvider_MissingMasterKeyPath(t *testing.T) {
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "master_key_path is required")
+}
+
+// applyNATSOptions resolves an option slice into the nats.Options it produces,
+// so a test can assert on the settings rather than on a live connection.
+func applyNATSOptions(t *testing.T, opts []nats.Option) nats.Options {
+	t.Helper()
+	var resolved nats.Options
+	for _, opt := range opts {
+		require.NoError(t, opt(&resolved))
+	}
+	return resolved
+}
+
+// TestNATSIAMOptions_ReconnectsForever guards the defect that took every
+// authenticated S3 request out for 20 hours: with nats.go's default 60
+// attempts at 2s, a NATS restart longer than ~2 minutes closed this connection
+// permanently and no credential could be validated until predastore restarted.
+func TestNATSIAMOptions_ReconnectsForever(t *testing.T) {
+	resolved := applyNATSOptions(t, natsIAMOptions(&IAMConfig{NATSUrl: "nats://localhost:4222"}))
+
+	assert.Equal(t, -1, resolved.MaxReconnect, "a bounded retry count silently ends IAM auth")
+	assert.Equal(t, time.Second, resolved.ReconnectWait)
+	assert.NotNil(t, resolved.DisconnectedErrCB, "an outage must be visible without waiting for a request to fail")
+	assert.NotNil(t, resolved.ReconnectedCB)
+}
+
+func TestNATSIAMOptions_TokenOnlySetWhenConfigured(t *testing.T) {
+	withToken := applyNATSOptions(t, natsIAMOptions(&IAMConfig{
+		NATSUrl: "nats://localhost:4222", NATSToken: "secret",
+	}))
+	assert.Equal(t, "secret", withToken.Token)
+
+	withoutToken := applyNATSOptions(t, natsIAMOptions(&IAMConfig{NATSUrl: "nats://localhost:4222"}))
+	assert.Empty(t, withoutToken.Token)
 }
 
 // --- inline role policy resolution (resolveRolePolicies) ---


### PR DESCRIPTION
Fixes `mulga-ea0mh`. Found while staging model weights on wattle for `mulga-ic4tc`, which it was blocking.

## What broke

`NewNATSIAMProvider` called `nats.Connect` with only `Name` and `Token`, so it took nats.go's defaults: **`MaxReconnects=60`, `ReconnectWait=2s`** — it gives up permanently after ~120s. Once it gives up, every IAM credential lookup fails with `nats: connection closed`, which reaches clients as:

```
InternalError: An internal error occurred while validating credentials
```

Nothing recovers short of restarting predastore.

## Evidence from wattle

| | |
|---|---|
| predastore started | Mon 2026-08-03 21:26:36 |
| NATS down | 2026-08-06 13:57:23 → 14:01:22 (**239s**) |
| viperblock | logged `NATS disconnected EOF`, then `NATS reconnected` — recovered |
| predastore | exhausted 60 retries at ~13:59:23, two minutes before NATS returned |
| discovered | 2026-08-07 10:06, ~20h later |

Viperblock survived because it uses spinifex's shared `utils.ConnectNATS`, which sets `MaxReconnects(-1)`. predastore was the only production call site not doing so.

**The worst property of this failure is that it is silent.** All authenticated S3 was broken for twenty hours and nothing alerted, because no authenticated request was made in the interim. The config-based `ChainProvider` fallback does not cover IAM-issued keys, so for those it was a total outage.

## The fix

Match the shared helper: unlimited reconnects, 1s wait, and disconnect/reconnect handlers so an outage shows up in the log rather than only when a request happens to fail.

## Testing

The options move into `natsIAMOptions` so a test can assert on them without a live server. `TestNATSIAMOptions_ReconnectsForever` pins `MaxReconnect == -1` and the presence of both handlers; I verified it fails with `expected: -1, actual: 60` when the option is reverted.

Testing the reconnect loop end to end would mean adding `nats-server` as a dependency to verify behaviour nats.go already covers upstream. What broke here was our option set, so that is what is pinned.

`make preflight` passes. Note it needs `GOFLAGS=-p=1` on a memory-constrained host — `./store/`'s property tests want ~6 GiB under `-race` and get OOM-killed when packages run in parallel. That is pre-existing and unrelated to this change; the same test passes standalone on an unmodified tree.

## Follow-up

Worth a readiness or health signal for IAM provider connectivity so this cannot go unnoticed for twenty hours again. Noted on the bead.