### PR TITLE
fix: authorize S3 requests on the path chi dispatches on

### DIFF
--- a/s3/authmiddleware_test.go
+++ b/s3/authmiddleware_test.go
@@ -171,7 +171,7 @@ func TestSigV4AuthMiddleware(t *testing.T) {
 			})
 
 			rr := httptest.NewRecorder()
-			server.sigV4AuthMiddleware(next).ServeHTTP(rr, req)
+			server.s3TargetMiddleware(server.sigV4AuthMiddleware(next)).ServeHTTP(rr, req)
 
 			if tt.expectStatus == -1 {
 				// Sentinel: valid auth should pass through to next.
@@ -238,7 +238,7 @@ func TestSigV4AuthMiddleware_RequireSignedHeaders(t *testing.T) {
 				t.Fatal("next handler must not be invoked when SignedHeaders guard fires")
 			})
 			rr := httptest.NewRecorder()
-			server.sigV4AuthMiddleware(next).ServeHTTP(rr, req)
+			server.s3TargetMiddleware(server.sigV4AuthMiddleware(next)).ServeHTTP(rr, req)
 
 			assert.Equal(t, http.StatusBadRequest, rr.Code)
 			assert.Contains(t, rr.Body.String(), "AuthorizationHeaderMalformed")

--- a/s3/config.go
+++ b/s3/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
 
@@ -106,46 +107,18 @@ func (s3 *Config) BucketConfig(bucket string) (S3_Buckets, error) {
 
 // validatePublicBucketPermission checks if the request is allowed for a public bucket
 // Returns nil if the request is allowed, otherwise returns an error.
-func (s3 *Config) validatePublicBucketPermission(method, path string) error {
-	// Extract bucket name from path
-	parts := filepath.SplitList(path)
-	if len(parts) == 0 {
-		return errors.New("invalid path")
-	}
-
-	// Remove leading slash and get first component (bucket name)
-	cleanPath := path
-	if len(path) > 0 && path[0] == '/' {
-		cleanPath = path[1:]
-	}
-
-	pathParts := filepath.SplitList(cleanPath)
-	if len(pathParts) == 0 {
+func (s3 *Config) validatePublicBucketPermission(method, bucket string) error {
+	if bucket == "" {
 		// Root path (list buckets) - not public
 		return errors.New("listing buckets requires authentication")
 	}
 
-	// Get bucket name by splitting on /
-	bucketName := cleanPath
-	if idx := findSlash(cleanPath); idx != -1 {
-		bucketName = cleanPath[:idx]
+	cfg, err := s3.BucketConfig(bucket)
+	if err != nil {
+		return err
 	}
 
-	// Find bucket configuration
-	var bucket *S3_Buckets
-	for _, b := range s3.Buckets {
-		if b.Name == bucketName {
-			bucket = &b
-			break
-		}
-	}
-
-	if bucket == nil {
-		return errors.New("bucket not found")
-	}
-
-	// Check if bucket is public
-	if !bucket.Public {
+	if !cfg.Public {
 		return errors.New("bucket is not public")
 	}
 
@@ -154,19 +127,9 @@ func (s3 *Config) validatePublicBucketPermission(method, path string) error {
 	// - Allow HEAD operations (metadata)
 	// - Deny PUT, POST, DELETE without auth
 	switch method {
-	case "GET", "HEAD":
+	case http.MethodGet, http.MethodHead:
 		return nil // Allow public read
 	default:
 		return errors.New("public buckets only allow read operations")
 	}
-}
-
-// findSlash finds the first / in a string.
-func findSlash(s string) int {
-	for i, c := range s {
-		if c == '/' {
-			return i
-		}
-	}
-	return -1
 }

--- a/s3/httpserver.go
+++ b/s3/httpserver.go
@@ -74,7 +74,6 @@ func (s *HTTP2Server) setupRoutes() {
 
 	// Middleware
 	r.Use(otelsetup.HTTPMiddleware("predastore"))
-	r.Use(s3SpanMiddleware)
 	// chi's access log duplicates the APM transaction from HTTPMiddleware and
 	// is a synchronous per-request write on the hot path; only enable it for
 	// explicit debug sessions.
@@ -87,6 +86,10 @@ func (s *HTTP2Server) setupRoutes() {
 	// StripSlashes only rewrites chi's routing context, not r.URL.Path, so
 	// SigV4 verification still sees the exact URI the client signed.
 	r.Use(middleware.StripSlashes)
+	// Must follow StripSlashes: everything downstream authorizes, meters and
+	// dispatches on the pair resolved here, never on r.URL.Path.
+	r.Use(s.s3TargetMiddleware)
+	r.Use(s3SpanMiddleware)
 	r.Use(s.sigV4AuthMiddleware)
 
 	// API request throttling (post-auth, per-account + per-action)
@@ -101,7 +104,11 @@ func (s *HTTP2Server) setupRoutes() {
 					return acct, nil
 				},
 				func(r *http.Request) (string, error) {
-					return s3Action(r.Method, r.URL.Path), nil
+					target, ok := requestTargetFrom(r.Context())
+					if !ok {
+						return "", fmt.Errorf("request target missing from request context")
+					}
+					return s3Action(r.Method, target.bucket, target.key), nil
 				},
 			},
 			func(w http.ResponseWriter, r *http.Request) {
@@ -133,10 +140,18 @@ func (s *HTTP2Server) setupRoutes() {
 // cross-account bucket-ownership check.
 func (s *HTTP2Server) sigV4AuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		path := r.URL.Path
+		// Fail closed: an unresolved target would authorize as ListAllMyBuckets
+		// while the router still dispatched a bucket or key.
+		target, ok := requestTargetFrom(r.Context())
+		if !ok {
+			slog.ErrorContext(r.Context(), "Request target missing from context, s3TargetMiddleware did not run",
+				"method", r.Method, "path", r.URL.Path)
+			s.writeS3Error(w, r, http.StatusInternalServerError, "InternalError", "An internal error occurred")
+			return
+		}
 		method := r.Method
 
-		publicBucketAccess := s.config.validatePublicBucketPermission(method, path)
+		publicBucketAccess := s.config.validatePublicBucketPermission(method, target.bucket)
 
 		// Parse recognizes both header-authed and presigned requests; only a request with
 		// neither returns ErrMissingAuthentication.
@@ -168,7 +183,7 @@ func (s *HTTP2Server) sigV4AuthMiddleware(next http.Handler) http.Handler {
 		// ListBuckets is the only global operation served here, and clients sign it against
 		// us-east-1 whatever region they are configured for. Some SDKs sign it with the
 		// configured region instead, so accept either rather than pinning to us-east-1.
-		if bucket, _ := parseS3Path(path); bucket == "" && sig.Credential.Region == globalSigningRegion {
+		if target.bucket == "" && sig.Credential.Region == globalSigningRegion {
 			expectedRegion = globalSigningRegion
 		}
 
@@ -179,14 +194,14 @@ func (s *HTTP2Server) sigV4AuthMiddleware(next http.Handler) http.Handler {
 
 		// IAM policy evaluation (NATS-sourced credentials only).
 		if !credResult.SkipPolicyCheck {
-			action := s3Action(method, path)
+			action := s3Action(method, target.bucket, target.key)
 			if action == "" {
 				slog.WarnContext(r.Context(), "Unsupported HTTP method for S3 action mapping",
-					"method", method, "path", path, "remoteAddr", r.RemoteAddr)
+					"method", method, "path", r.URL.Path, "remoteAddr", r.RemoteAddr)
 				s.writeS3Error(w, r, http.StatusMethodNotAllowed, "MethodNotAllowed", "The specified method is not allowed")
 				return
 			}
-			resource := s3Resource(path)
+			resource := s3Resource(target.bucket, target.key)
 			if len(credResult.PolicyDocuments) == 0 {
 				slog.DebugContext(r.Context(), "No policies resolved for user, implicit deny",
 					"accessKeyID", accessKey, "accountID", credResult.AccountID)
@@ -206,8 +221,8 @@ func (s *HTTP2Server) sigV4AuthMiddleware(next http.Handler) http.Handler {
 		// and CreateBucket (no existing owner). A sub-resource query on a bare
 		// bucket (?policy, ?acl, ?versioning, ...) is NOT CreateBucket and must
 		// stay subject to the cross-account check.
-		bucket, key := parseS3Path(path)
-		isCreateBucket := method == http.MethodPut && bucket != "" && key == "" && r.URL.RawQuery == ""
+		bucket := target.bucket
+		isCreateBucket := method == http.MethodPut && bucket != "" && target.key == "" && r.URL.RawQuery == ""
 		if bucket != "" && !isCreateBucket {
 			meta, err := s.resolveBucketMetadata(bucket)
 			if err != nil {
@@ -225,8 +240,8 @@ func (s *HTTP2Server) sigV4AuthMiddleware(next http.Handler) http.Handler {
 					"callerAccountID", credResult.AccountID,
 					"bucketAccountID", meta.AccountID,
 					"bucket", bucket,
-					"action", s3Action(method, path),
-					"resource", s3Resource(path))
+					"action", s3Action(method, target.bucket, target.key),
+					"resource", s3Resource(target.bucket, target.key))
 				s.writeS3Error(w, r, http.StatusForbidden, "AccessDenied", "Access Denied")
 				return
 			}
@@ -397,7 +412,7 @@ func (s *HTTP2Server) listBuckets(w http.ResponseWriter, r *http.Request) {
 
 func (s *HTTP2Server) createBucket(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	bucket := chi.URLParam(r, "bucket")
+	bucket, _ := requestBucketKey(ctx)
 
 	// PUT /{bucket}?policy — bucket policies are not supported
 	if r.URL.Query().Has("policy") {
@@ -441,7 +456,7 @@ func (s *HTTP2Server) createBucket(w http.ResponseWriter, r *http.Request) {
 
 func (s *HTTP2Server) headBucket(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	bucket := chi.URLParam(r, "bucket")
+	bucket, _ := requestBucketKey(ctx)
 
 	resp, err := s.backend.HeadBucket(ctx, &backend.HeadBucketRequest{Bucket: bucket})
 	if err != nil {
@@ -455,7 +470,7 @@ func (s *HTTP2Server) headBucket(w http.ResponseWriter, r *http.Request) {
 
 func (s *HTTP2Server) deleteBucket(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	bucket := chi.URLParam(r, "bucket")
+	bucket, _ := requestBucketKey(ctx)
 
 	// DELETE /{bucket}?policy — no-op, bucket policies are not supported
 	if r.URL.Query().Has("policy") {
@@ -482,7 +497,7 @@ func (s *HTTP2Server) deleteBucket(w http.ResponseWriter, r *http.Request) {
 
 func (s *HTTP2Server) listObjects(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	bucket := chi.URLParam(r, "bucket")
+	bucket, _ := requestBucketKey(ctx)
 	query := r.URL.Query()
 
 	// Return proper errors for unsupported bucket sub-resource operations
@@ -545,8 +560,7 @@ func (s *HTTP2Server) listObjects(w http.ResponseWriter, r *http.Request) {
 
 func (s *HTTP2Server) headObject(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	bucket := chi.URLParam(r, "bucket")
-	key := chi.URLParam(r, "*")
+	bucket, key := requestBucketKey(ctx)
 
 	resp, err := s.backend.HeadObject(ctx, bucket, key)
 	if err != nil {
@@ -563,8 +577,7 @@ func (s *HTTP2Server) headObject(w http.ResponseWriter, r *http.Request) {
 
 func (s *HTTP2Server) getObject(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	bucket := chi.URLParam(r, "bucket")
-	key := chi.URLParam(r, "*")
+	bucket, key := requestBucketKey(ctx)
 
 	req := &backend.GetObjectRequest{
 		Bucket:     bucket,
@@ -616,8 +629,7 @@ func (s *HTTP2Server) getObject(w http.ResponseWriter, r *http.Request) {
 
 func (s *HTTP2Server) putObject(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	bucket := chi.URLParam(r, "bucket")
-	key := chi.URLParam(r, "*")
+	bucket, key := requestBucketKey(ctx)
 
 	// Check for multipart part upload
 	if partNum := r.URL.Query().Get("partNumber"); partNum != "" {
@@ -673,8 +685,7 @@ func (s *HTTP2Server) putObject(w http.ResponseWriter, r *http.Request) {
 
 func (s *HTTP2Server) postObject(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	bucket := chi.URLParam(r, "bucket")
-	key := chi.URLParam(r, "*")
+	bucket, key := requestBucketKey(ctx)
 
 	uploadID := r.URL.Query().Get("uploadId")
 	if uploadID == "" {
@@ -743,8 +754,7 @@ func (s *HTTP2Server) postObject(w http.ResponseWriter, r *http.Request) {
 
 func (s *HTTP2Server) deleteObject(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	bucket := chi.URLParam(r, "bucket")
-	key := chi.URLParam(r, "*")
+	bucket, key := requestBucketKey(ctx)
 
 	err := s.backend.DeleteObject(ctx, &backend.DeleteObjectRequest{
 		Bucket: bucket,

--- a/s3/ownership_test.go
+++ b/s3/ownership_test.go
@@ -204,7 +204,7 @@ func runMiddleware(t *testing.T, server *HTTP2Server, req *http.Request) (status
 		nextCalled = true
 		w.WriteHeader(http.StatusOK)
 	})
-	server.sigV4AuthMiddleware(next).ServeHTTP(rr, req)
+	server.s3TargetMiddleware(server.sigV4AuthMiddleware(next)).ServeHTTP(rr, req)
 	b, _ := io.ReadAll(rr.Body)
 	return rr.Code, nextCalled, string(b)
 }

--- a/s3/policy.go
+++ b/s3/policy.go
@@ -44,9 +44,8 @@ func parseS3Path(path string) (bucket, key string) {
 	return cleanPath, ""
 }
 
-// s3Action maps HTTP method + path to the corresponding IAM S3 action.
-func s3Action(method, path string) string {
-	bucket, key := parseS3Path(path)
+// s3Action maps an HTTP method and the resolved bucket/key to the IAM S3 action.
+func s3Action(method, bucket, key string) string {
 	hasKey := key != ""
 
 	switch method {
@@ -80,16 +79,15 @@ func s3Action(method, path string) string {
 	}
 }
 
-// s3Resource builds the ARN for the resource being accessed.
-func s3Resource(path string) string {
-	cleanPath := strings.TrimPrefix(path, "/")
-	if cleanPath == "" {
+// s3Resource builds the ARN for the resolved bucket/key.
+func s3Resource(bucket, key string) string {
+	if bucket == "" {
 		// ListAllMyBuckets — use ARN wildcard so policies with
 		// Resource: "arn:aws:s3:::*" match correctly.
 		return "arn:aws:s3:::*"
 	}
-
-	// For bucket-level operations: arn:aws:s3:::bucket-name
-	// For object-level operations: arn:aws:s3:::bucket-name/key
-	return "arn:aws:s3:::" + cleanPath
+	if key == "" {
+		return "arn:aws:s3:::" + bucket
+	}
+	return "arn:aws:s3:::" + bucket + "/" + key
 }

--- a/s3/policy_test.go
+++ b/s3/policy_test.go
@@ -12,25 +12,26 @@ import (
 func TestS3Action(t *testing.T) {
 	tests := []struct {
 		method string
-		path   string
+		bucket string
+		key    string
 		want   string
 	}{
-		{"GET", "/", "s3:ListAllMyBuckets"},
-		{"GET", "/my-bucket", "s3:ListBucket"},
-		{"GET", "/my-bucket/key.txt", "s3:GetObject"},
-		{"HEAD", "/my-bucket/key.txt", "s3:GetObject"},
-		{"HEAD", "/my-bucket", "s3:ListBucket"},
-		{"PUT", "/my-bucket", "s3:CreateBucket"},
-		{"PUT", "/my-bucket/key.txt", "s3:PutObject"},
-		{"POST", "/my-bucket/key.txt", "s3:PutObject"},
-		{"DELETE", "/my-bucket", "s3:DeleteBucket"},
-		{"DELETE", "/my-bucket/key.txt", "s3:DeleteObject"},
-		{"PATCH", "/my-bucket/key.txt", ""},
+		{"GET", "", "", "s3:ListAllMyBuckets"},
+		{"GET", "my-bucket", "", "s3:ListBucket"},
+		{"GET", "my-bucket", "key.txt", "s3:GetObject"},
+		{"HEAD", "my-bucket", "key.txt", "s3:GetObject"},
+		{"HEAD", "my-bucket", "", "s3:ListBucket"},
+		{"PUT", "my-bucket", "", "s3:CreateBucket"},
+		{"PUT", "my-bucket", "key.txt", "s3:PutObject"},
+		{"POST", "my-bucket", "key.txt", "s3:PutObject"},
+		{"DELETE", "my-bucket", "", "s3:DeleteBucket"},
+		{"DELETE", "my-bucket", "key.txt", "s3:DeleteObject"},
+		{"PATCH", "my-bucket", "key.txt", ""},
 	}
 
 	for _, tt := range tests {
-		got := s3Action(tt.method, tt.path)
-		assert.Equal(t, tt.want, got, "s3Action(%q, %q)", tt.method, tt.path)
+		got := s3Action(tt.method, tt.bucket, tt.key)
+		assert.Equal(t, tt.want, got, "s3Action(%q, %q, %q)", tt.method, tt.bucket, tt.key)
 	}
 }
 
@@ -38,18 +39,19 @@ func TestS3Action(t *testing.T) {
 
 func TestS3Resource(t *testing.T) {
 	tests := []struct {
-		path string
-		want string
+		bucket string
+		key    string
+		want   string
 	}{
-		{"/", "arn:aws:s3:::*"},
-		{"/my-bucket", "arn:aws:s3:::my-bucket"},
-		{"/my-bucket/key.txt", "arn:aws:s3:::my-bucket/key.txt"},
-		{"/my-bucket/path/to/key.txt", "arn:aws:s3:::my-bucket/path/to/key.txt"},
+		{"", "", "arn:aws:s3:::*"},
+		{"my-bucket", "", "arn:aws:s3:::my-bucket"},
+		{"my-bucket", "key.txt", "arn:aws:s3:::my-bucket/key.txt"},
+		{"my-bucket", "path/to/key.txt", "arn:aws:s3:::my-bucket/path/to/key.txt"},
 	}
 
 	for _, tt := range tests {
-		got := s3Resource(tt.path)
-		assert.Equal(t, tt.want, got, "s3Resource(%q)", tt.path)
+		got := s3Resource(tt.bucket, tt.key)
+		assert.Equal(t, tt.want, got, "s3Resource(%q, %q)", tt.bucket, tt.key)
 	}
 }
 

--- a/s3/requestpath.go
+++ b/s3/requestpath.go
@@ -28,10 +28,13 @@ var (
 // the ownership check, throttling and the route handlers all read one pair.
 func (s *HTTP2Server) s3TargetMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// InvalidURI, not AccessDenied: this fires before authentication, so
+		// reporting it as a policy outcome sends operators to audit IAM.
 		if err := validateRequestPath(r); err != nil {
-			slog.DebugContext(r.Context(), "Rejected malformed S3 request path",
+			slog.WarnContext(r.Context(), "Rejected malformed S3 request path",
 				"path", r.URL.Path, "rawPath", r.URL.RawPath, "error", err, "remoteAddr", r.RemoteAddr)
-			s.writeS3Error(w, r, http.StatusForbidden, "AccessDenied", "Access Denied")
+			s.writeS3Error(w, r, http.StatusBadRequest, "InvalidURI",
+				"Couldn't parse the specified URI: "+err.Error())
 			return
 		}
 

--- a/s3/requestpath.go
+++ b/s3/requestpath.go
@@ -1,0 +1,92 @@
+package s3
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// requestTarget is the bucket and object key a request resolves to, computed
+// from the same string chi dispatches on so the authorization subject and the
+// value the handlers act on cannot diverge.
+type requestTarget struct {
+	bucket string
+	key    string
+}
+
+var (
+	errDotSegment       = errors.New("path contains a . or .. segment")
+	errKeyTrailingSlash = errors.New("object key has a trailing slash")
+)
+
+// s3TargetMiddleware resolves the request's bucket and key onto the context.
+// It runs after StripSlashes and before authorization, so policy evaluation,
+// the ownership check, throttling and the route handlers all read one pair.
+func (s *HTTP2Server) s3TargetMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := validateRequestPath(r); err != nil {
+			slog.DebugContext(r.Context(), "Rejected malformed S3 request path",
+				"path", r.URL.Path, "rawPath", r.URL.RawPath, "error", err, "remoteAddr", r.RemoteAddr)
+			s.writeS3Error(w, r, http.StatusForbidden, "AccessDenied", "Access Denied")
+			return
+		}
+
+		bucket, key := parseS3Path(resolveRoutePath(r))
+		ctx := context.WithValue(r.Context(), contextKeyTarget, requestTarget{bucket: bucket, key: key})
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// resolveRoutePath mirrors chi's own routing-path resolution: the StripSlashes
+// rewrite wins, then the raw (still percent-encoded) path, then the decoded
+// path. Anything else would authorize a different string than chi routes on.
+func resolveRoutePath(r *http.Request) string {
+	if rctx := chi.RouteContext(r.Context()); rctx != nil && rctx.RoutePath != "" {
+		return rctx.RoutePath
+	}
+	if r.URL.RawPath != "" {
+		return r.URL.RawPath
+	}
+	return r.URL.Path
+}
+
+// validateRequestPath rejects paths that only normalise into their dispatched
+// form, which is what let an exact-ARN Deny be sidestepped. Both the raw and
+// the decoded path are checked, since either can be the routing subject. A
+// trailing slash directly after the bucket stays legal — AWS accepts
+// `PUT /bucket/` as CreateBucket, and StripSlashes exists to normalise it.
+func validateRequestPath(r *http.Request) error {
+	for _, path := range [2]string{r.URL.RawPath, r.URL.Path} {
+		trimmed := strings.TrimPrefix(path, "/")
+		if trimmed == "" {
+			continue
+		}
+		for segment := range strings.SplitSeq(trimmed, "/") {
+			if segment == "." || segment == ".." {
+				return errDotSegment
+			}
+		}
+		if strings.HasSuffix(trimmed, "/") && strings.Contains(strings.TrimSuffix(trimmed, "/"), "/") {
+			return errKeyTrailingSlash
+		}
+	}
+	return nil
+}
+
+// requestTargetFrom returns the pair resolved by s3TargetMiddleware. A false
+// second result means the middleware did not run and must be treated as a
+// failure — an empty target would authorize as ListAllMyBuckets.
+func requestTargetFrom(ctx context.Context) (requestTarget, bool) {
+	target, ok := ctx.Value(contextKeyTarget).(requestTarget)
+	return target, ok
+}
+
+// requestBucketKey returns the resolved bucket and key for a routed request.
+func requestBucketKey(ctx context.Context) (bucket, key string) {
+	target, _ := requestTargetFrom(ctx)
+	return target.bucket, target.key
+}

--- a/s3/requestpath_test.go
+++ b/s3/requestpath_test.go
@@ -5,10 +5,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/mulgadc/predastore/backend"
 	"github.com/mulgadc/predastore/pkg/iampolicy"
 	"github.com/stretchr/testify/assert"
@@ -100,14 +102,17 @@ var guardrailPolicy = iampolicy.PolicyDocument{
 	},
 }
 
-// exactGrantPolicy grants one object by exact ARN and nothing else.
-var exactGrantPolicy = iampolicy.PolicyDocument{
-	Version: "2012-10-17",
-	Statement: []iampolicy.Statement{{
-		Effect:   "Allow",
-		Action:   iampolicy.StringOrArr{"s3:GetObject"},
-		Resource: iampolicy.StringOrArr{"arn:aws:s3:::owner-bucket/secret/data"},
-	}},
+// exactObjectGrant grants one object by exact ARN and nothing else, so a
+// request that succeeds under it can only have been authorized on that ARN.
+func exactObjectGrant(key string) iampolicy.PolicyDocument {
+	return iampolicy.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []iampolicy.Statement{{
+			Effect:   "Allow",
+			Action:   iampolicy.StringOrArr{"s3:GetObject"},
+			Resource: iampolicy.StringOrArr{"arn:aws:s3:::owner-bucket/" + key},
+		}},
+	}
 }
 
 func parityServer(t *testing.T, policy iampolicy.PolicyDocument) (*HTTP2Server, *recordingBackend) {
@@ -129,15 +134,15 @@ func serveSigned(t *testing.T, server *HTTP2Server, method, target string) *http
 	return rr
 }
 
-// An exact-ARN Deny must survive every spelling of the path it protects: the
-// decision and the dispatch now come from one resolved pair.
-func TestPathParity_ExplicitDenyNotBypassable(t *testing.T) {
+// Paths that only normalise into their dispatched form never reach the
+// authorization decision. They are a client error, not a policy outcome, so
+// they must not be reported as AccessDenied.
+func TestRequestPath_MalformedRejected(t *testing.T) {
 	tests := []struct {
 		name   string
 		method string
 		target string
 	}{
-		{"canonical path", http.MethodGet, "/owner-bucket/secret/data"},
 		{"trailing slash GET", http.MethodGet, "/owner-bucket/secret/data/"},
 		{"trailing slash DELETE", http.MethodDelete, "/owner-bucket/secret/data/"},
 		{"encoded trailing slash", http.MethodGet, "/owner-bucket/secret/data%2F"},
@@ -150,6 +155,21 @@ func TestPathParity_ExplicitDenyNotBypassable(t *testing.T) {
 			server, be := parityServer(t, guardrailPolicy)
 			rr := serveSigned(t, server, tt.method, tt.target)
 
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.Contains(t, rr.Body.String(), "InvalidURI")
+			assert.NotContains(t, rr.Body.String(), "AccessDenied")
+			assert.Empty(t, be.calls, "backend must not be reached for a rejected path")
+		})
+	}
+}
+
+// An exact-ARN Deny must survive the spellings that do reach the decision.
+func TestPathParity_ExplicitDenyNotBypassable(t *testing.T) {
+	for _, method := range []string{http.MethodGet, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			server, be := parityServer(t, guardrailPolicy)
+			rr := serveSigned(t, server, method, "/owner-bucket/secret/data")
+
 			assert.Equal(t, http.StatusForbidden, rr.Code)
 			assert.Contains(t, rr.Body.String(), "AccessDenied")
 			assert.Empty(t, be.calls, "backend must not be reached for a denied request")
@@ -157,23 +177,67 @@ func TestPathParity_ExplicitDenyNotBypassable(t *testing.T) {
 	}
 }
 
+// The invariant itself: for every spelling that survives validation, the ARN
+// the policy was evaluated against is the bucket/key the backend receives. An
+// exact-ARN grant makes a 200 proof that the two agree, since nothing else
+// could have authorized it.
+func TestPathParity_AuthorizedARNMatchesDispatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  string
+		wantKey string
+	}{
+		{"canonical", "/owner-bucket/secret/data", "secret/data"},
+		{"over-encoded segment", "/owner-bucket/%73ecret/data", "%73ecret/data"},
+		{"encoded separator", "/owner-bucket/secret%2Fdata", "secret%2Fdata"},
+		{"encoded reserved char", "/owner-bucket/a%3Ab", "a%3Ab"},
+		{"canonically escaped utf-8", "/owner-bucket/reports/r%C3%A9union.txt", "reports/réunion.txt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, be := parityServer(t, exactObjectGrant(tt.wantKey))
+			rr := serveSigned(t, server, http.MethodGet, tt.target)
+
+			require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+			assert.Equal(t, []string{"GetObject owner-bucket/" + tt.wantKey}, be.calls)
+		})
+	}
+}
+
+// The routing subject must be the StripSlashes rewrite, so the middleware that
+// resolves it has to be registered after StripSlashes. Nothing observable in a
+// response distinguishes the two orderings, so assert the registration itself.
+func TestPathParity_TargetResolvedAfterStripSlashes(t *testing.T) {
+	server, _ := parityServer(t, guardrailPolicy)
+
+	stripIdx, targetIdx := -1, -1
+	wantStrip := reflect.ValueOf(middleware.StripSlashes).Pointer()
+	wantTarget := reflect.ValueOf(server.s3TargetMiddleware).Pointer()
+	for i, mw := range server.router.Middlewares() {
+		switch reflect.ValueOf(mw).Pointer() {
+		case wantStrip:
+			stripIdx = i
+		case wantTarget:
+			targetIdx = i
+		}
+	}
+
+	require.NotEqual(t, -1, stripIdx, "StripSlashes is not registered")
+	require.NotEqual(t, -1, targetIdx, "s3TargetMiddleware is not registered")
+	assert.Less(t, stripIdx, targetIdx,
+		"s3TargetMiddleware must run after StripSlashes or it resolves a different path than chi routes on")
+}
+
 // The percent-encoding variant of the split: the grant covers secret/data, and
 // the router dispatches %73ecret/data, so the grant must not authorize it.
 func TestPathParity_EncodedKeyDoesNotSatisfyExactGrant(t *testing.T) {
-	server, be := parityServer(t, exactGrantPolicy)
+	server, be := parityServer(t, exactObjectGrant("secret/data"))
 	rr := serveSigned(t, server, http.MethodGet, "/owner-bucket/%73ecret/data")
 
 	assert.Equal(t, http.StatusForbidden, rr.Code)
 	assert.Contains(t, rr.Body.String(), "AccessDenied")
 	assert.Empty(t, be.calls, "backend must not be reached for a denied request")
-}
-
-func TestPathParity_GrantedObjectStillServed(t *testing.T) {
-	server, be := parityServer(t, exactGrantPolicy)
-	rr := serveSigned(t, server, http.MethodGet, "/owner-bucket/secret/data")
-
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Equal(t, []string{"GetObject owner-bucket/secret/data"}, be.calls)
 }
 
 // The Deny covers one object, not the prefix: everything else in the bucket

--- a/s3/requestpath_test.go
+++ b/s3/requestpath_test.go
@@ -1,0 +1,212 @@
+package s3
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore/backend"
+	"github.com/mulgadc/predastore/pkg/iampolicy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- validateRequestPath unit tests ---
+
+func TestValidateRequestPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  string
+		wantErr error
+	}{
+		{"root", "/", nil},
+		{"bucket", "/owner-bucket", nil},
+		{"bucket trailing slash is CreateBucket", "/owner-bucket/", nil},
+		{"object key", "/owner-bucket/secret/data", nil},
+		{"key containing a dot", "/owner-bucket/file.txt", nil},
+		{"key segment named dotdotdot", "/owner-bucket/.../data", nil},
+		{"object key trailing slash", "/owner-bucket/secret/data/", errKeyTrailingSlash},
+		{"encoded key trailing slash", "/owner-bucket/secret/data%2F", errKeyTrailingSlash},
+		{"parent segment", "/owner-bucket/secret/../data", errDotSegment},
+		{"encoded parent segment", "/owner-bucket/%2e%2e/data", errDotSegment},
+		{"current segment", "/owner-bucket/./data", errDotSegment},
+		{"parent segment as bucket", "/../etc", errDotSegment},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRequestPath(httptest.NewRequest(http.MethodGet, tt.target, nil))
+			assert.Equal(t, tt.wantErr, err)
+		})
+	}
+}
+
+// --- authorization/dispatch parity integration tests ---
+
+// recordingBackend reports the bucket and key each object route was dispatched
+// with, so a test can prove the backend was never reached — or was reached with
+// exactly the value that was authorized.
+type recordingBackend struct {
+	*stubBackend
+
+	calls []string
+}
+
+func (b *recordingBackend) record(op, bucket, key string) {
+	b.calls = append(b.calls, op+" "+bucket+"/"+key)
+}
+
+func (b *recordingBackend) GetObject(_ context.Context, req *backend.GetObjectRequest) (*backend.GetObjectResponse, error) {
+	b.record("GetObject", req.Bucket, req.Key)
+	return &backend.GetObjectResponse{
+		Body:         io.NopCloser(strings.NewReader("payload")),
+		ContentType:  "application/octet-stream",
+		Size:         int64(len("payload")),
+		ETag:         "\"etag\"",
+		LastModified: time.Unix(0, 0).UTC(),
+		StatusCode:   http.StatusOK,
+	}, nil
+}
+
+func (b *recordingBackend) DeleteObject(_ context.Context, req *backend.DeleteObjectRequest) error {
+	b.record("DeleteObject", req.Bucket, req.Key)
+	return nil
+}
+
+func (b *recordingBackend) CreateBucket(_ context.Context, req *backend.CreateBucketRequest) (*backend.CreateBucketResponse, error) {
+	b.record("CreateBucket", req.Bucket, "")
+	return &backend.CreateBucketResponse{Location: "/" + req.Bucket}, nil
+}
+
+// guardrailPolicy is the idiomatic shape this defect defeated: a broad Allow
+// over the bucket with an exact-ARN Deny carving out one object.
+var guardrailPolicy = iampolicy.PolicyDocument{
+	Version: "2012-10-17",
+	Statement: []iampolicy.Statement{
+		{
+			Effect:   "Allow",
+			Action:   iampolicy.StringOrArr{"s3:*"},
+			Resource: iampolicy.StringOrArr{"arn:aws:s3:::owner-bucket", "arn:aws:s3:::owner-bucket/*", "arn:aws:s3:::new-bucket"},
+		},
+		{
+			Effect:   "Deny",
+			Action:   iampolicy.StringOrArr{"s3:GetObject", "s3:DeleteObject"},
+			Resource: iampolicy.StringOrArr{"arn:aws:s3:::owner-bucket/secret/data"},
+		},
+	},
+}
+
+// exactGrantPolicy grants one object by exact ARN and nothing else.
+var exactGrantPolicy = iampolicy.PolicyDocument{
+	Version: "2012-10-17",
+	Statement: []iampolicy.Statement{{
+		Effect:   "Allow",
+		Action:   iampolicy.StringOrArr{"s3:GetObject"},
+		Resource: iampolicy.StringOrArr{"arn:aws:s3:::owner-bucket/secret/data"},
+	}},
+}
+
+func parityServer(t *testing.T, policy iampolicy.PolicyDocument) (*HTTP2Server, *recordingBackend) {
+	t.Helper()
+	be := &recordingBackend{stubBackend: &stubBackend{buckets: map[string]*backend.BucketMetadata{
+		"owner-bucket": {Name: "owner-bucket", Region: "ap-southeast-2", AccountID: acctOwner},
+	}}}
+	credProv := &stubCredProvider{creds: map[string]*CredentialResult{
+		keyOwner: {SecretAccessKey: secret, AccountID: acctOwner, PolicyDocuments: []iampolicy.PolicyDocument{policy}},
+	}}
+	cfg := &Config{Region: "ap-southeast-2"}
+	return NewHTTP2ServerWithBackend(cfg, be, credProv), be
+}
+
+func serveSigned(t *testing.T, server *HTTP2Server, method, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	server.GetHandler().ServeHTTP(rr, signedReq(t, method, target, keyOwner))
+	return rr
+}
+
+// An exact-ARN Deny must survive every spelling of the path it protects: the
+// decision and the dispatch now come from one resolved pair.
+func TestPathParity_ExplicitDenyNotBypassable(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		target string
+	}{
+		{"canonical path", http.MethodGet, "/owner-bucket/secret/data"},
+		{"trailing slash GET", http.MethodGet, "/owner-bucket/secret/data/"},
+		{"trailing slash DELETE", http.MethodDelete, "/owner-bucket/secret/data/"},
+		{"encoded trailing slash", http.MethodGet, "/owner-bucket/secret/data%2F"},
+		{"parent segment", http.MethodGet, "/owner-bucket/public/../secret/data"},
+		{"encoded parent segment", http.MethodGet, "/owner-bucket/public/%2e%2e/secret/data"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, be := parityServer(t, guardrailPolicy)
+			rr := serveSigned(t, server, tt.method, tt.target)
+
+			assert.Equal(t, http.StatusForbidden, rr.Code)
+			assert.Contains(t, rr.Body.String(), "AccessDenied")
+			assert.Empty(t, be.calls, "backend must not be reached for a denied request")
+		})
+	}
+}
+
+// The percent-encoding variant of the split: the grant covers secret/data, and
+// the router dispatches %73ecret/data, so the grant must not authorize it.
+func TestPathParity_EncodedKeyDoesNotSatisfyExactGrant(t *testing.T) {
+	server, be := parityServer(t, exactGrantPolicy)
+	rr := serveSigned(t, server, http.MethodGet, "/owner-bucket/%73ecret/data")
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Contains(t, rr.Body.String(), "AccessDenied")
+	assert.Empty(t, be.calls, "backend must not be reached for a denied request")
+}
+
+func TestPathParity_GrantedObjectStillServed(t *testing.T) {
+	server, be := parityServer(t, exactGrantPolicy)
+	rr := serveSigned(t, server, http.MethodGet, "/owner-bucket/secret/data")
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, []string{"GetObject owner-bucket/secret/data"}, be.calls)
+}
+
+// The Deny covers one object, not the prefix: everything else in the bucket
+// still resolves, and the key the backend sees is the key that was authorized.
+func TestPathParity_UnrelatedObjectAllowed(t *testing.T) {
+	server, be := parityServer(t, guardrailPolicy)
+	rr := serveSigned(t, server, http.MethodGet, "/owner-bucket/public/data")
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, []string{"GetObject owner-bucket/public/data"}, be.calls)
+}
+
+// What StripSlashes is there for: PUT /bucket/ is CreateBucket, not a rejected
+// object write.
+func TestPathParity_TrailingSlashCreateBucket(t *testing.T) {
+	server, be := parityServer(t, guardrailPolicy)
+	rr := serveSigned(t, server, http.MethodPut, "/new-bucket/")
+
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	assert.Equal(t, []string{"CreateBucket new-bucket/"}, be.calls)
+}
+
+// Without the resolving middleware the auth middleware has no subject to
+// authorize, and must fail closed rather than fall through as ListAllMyBuckets.
+func TestPathParity_MissingTargetFailsClosed(t *testing.T) {
+	server, _ := parityServer(t, guardrailPolicy)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler must not run without a resolved request target")
+	})
+	rr := httptest.NewRecorder()
+	server.sigV4AuthMiddleware(next).ServeHTTP(rr, signedReq(t, http.MethodGet, "/owner-bucket/secret/data", keyOwner))
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "InternalError")
+}

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -53,9 +53,7 @@ type Config struct {
 	Buckets []S3_Buckets `toml:"buckets"`
 
 	// TODO: Move to IAM
-	Auth                  []AuthEntry `toml:"auth"`
-	AllowAnonymousListing bool        `toml:"allow_anonymous_listing"`
-	AllowAnonymousAccess  bool        `toml:"allow_anonymous_access"`
+	Auth []AuthEntry `toml:"auth"`
 
 	// IAM authentication via NATS KV (optional, enables multi-account S3 access)
 	IAM *IAMConfig `toml:"iam"`
@@ -210,6 +208,8 @@ const (
 	ContextKeyAccessKeyID contextKey = "accessKeyID"
 	// ContextKeyAccountID is the context key for the authenticated user's account ID.
 	ContextKeyAccountID contextKey = "accountID"
+	// contextKeyTarget is the context key for the resolved bucket/key pair.
+	contextKeyTarget contextKey = "requestTarget"
 )
 
 // IAMConfig configures IAM authentication via NATS KV.

--- a/s3/telemetry.go
+++ b/s3/telemetry.go
@@ -13,7 +13,8 @@ import (
 // for metrics. Span work is a no-op when tracing is not exporting.
 func s3SpanMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		action := s3Action(r.Method, r.URL.Path)
+		bucket, key := requestBucketKey(r.Context())
+		action := s3Action(r.Method, bucket, key)
 		if action != "" {
 			otelsetup.SetRequestAction(r.Context(), action)
 		}
@@ -22,7 +23,6 @@ func s3SpanMiddleware(next http.Handler) http.Handler {
 			if action != "" {
 				span.SetName(action)
 			}
-			bucket, key := parseS3Path(r.URL.Path)
 			if bucket != "" {
 				span.SetAttributes(attribute.String("s3.bucket", bucket))
 			}

--- a/s3/telemetry_test.go
+++ b/s3/telemetry_test.go
@@ -30,9 +30,13 @@ func TestS3SpanMiddlewareRenamesSpan(t *testing.T) {
 		{http.MethodDelete, "/my-bucket/obj", "s3:DeleteObject", "my-bucket", "obj"},
 	}
 
+	// The span attributes come from the resolved target, so the middleware
+	// that resolves it has to be in the chain.
+	server := NewHTTP2ServerWithBackend(&Config{}, nil, nil)
+
 	for _, tt := range tests {
 		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
-			handler := s3SpanMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+			handler := server.s3TargetMiddleware(s3SpanMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})))
 			req := httptest.NewRequest(tt.method, tt.path, nil)
 			ctx, span := tp.Tracer("test").Start(req.Context(), "HTTP")
 			handler.ServeHTTP(httptest.NewRecorder(), req.WithContext(ctx))


### PR DESCRIPTION
## Summary

Fixes a high-severity explicit-Deny bypass: any exact-ARN Deny was defeated by appending one character to the request path.

The authorization decision was computed from `r.URL.Path`, but chi routes on `rctx.RoutePath`, which `middleware.StripSlashes` rewrites before the auth middleware runs. Given the idiomatic guardrail shape — `Allow s3:* on arn:aws:s3:::b/*` plus `Deny s3:GetObject on arn:aws:s3:::b/secret/data` — a request for `GET /b/secret/data/` authorized as `b/secret/data/`, which the Deny does not match and the wildcard Allow does, and was then dispatched to the handler with key `secret/data`. The same split let `/b/%73ecret/data` satisfy an exact-ARN grant for `b/secret/data` while touching a different object.

The escalation stays within an account — `parseS3Path` extracts the same bucket either way, so the cross-account ownership check still holds.

## Changes

- New `s3TargetMiddleware` (`s3/requestpath.go`) resolves the bucket/key pair once, immediately after `StripSlashes`, using chi's own three-way resolution (`rctx.RoutePath` → `r.URL.RawPath` → `r.URL.Path`), and stashes it on the request context.
- `s3Action` and `s3Resource` take `(bucket, key)` instead of re-parsing a path. IAM policy evaluation, the bucket-ownership check, the throttler key function, the public-bucket check, span attributes and all nine route handlers read the resolved pair; `chi.URLParam` is gone from the handlers.
- `validateRequestPath` rejects any `.` or `..` segment, and a trailing slash on an object key, before the authorization decision. Both the raw and the decoded path are checked, since either can be the routing subject. A trailing slash directly after the bucket stays legal, so `PUT /bucket/` is still CreateBucket.
- The auth middleware fails closed with `InternalError` when the resolved pair is absent, so a future middleware reordering cannot silently authorize every request as `ListAllMyBuckets`.
- SigV4 input is untouched: `sigv4.Parse` still verifies against the literal URI the client signed.
- Drops the unused `AllowAnonymousListing` and `AllowAnonymousAccess` config fields, which had no runtime readers.

## Testing

`s3/requestpath_test.go` was run against a `dev` worktree first: every bypass shape fails there and passes here.

- Trailing-slash `GET` and `DELETE`, `%2F`, and `..` / `%2e%2e` segments against the guardrail policy all return `AccessDenied` with the backend never reached.
- `/owner-bucket/%73ecret/data` no longer satisfies an exact-ARN grant for `owner-bucket/secret/data`.
- Positive controls assert the granted object and an unrelated object are still served, with the dispatched key asserted to equal the authorized key.
- `PUT /new-bucket/` still reaches CreateBucket, and the fail-closed branch is covered.
- `validateRequestPath` is table-tested over the allowed and rejected shapes.

## Note

This also repairs `PUT /bucket/` under a bucket-scoped policy, which previously authorized against `arn:aws:s3:::bucket/` and was denied.
