### PR TITLE
feat: split the bind planes and stream the multipart write path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,38 @@ fix:
 govulncheck:
 	go tool govulncheck ./...
 
+# Warp is pinned so a before/after comparison is not measuring a client change.
+TOOLS_DIR    := $(CURDIR)/bin/tools
+WARP_VERSION ?= v1.1.4
+WARP         ?= $(TOOLS_DIR)/warp
+
+warp-install:
+	@if [ ! -x "$(WARP)" ]; then \
+		echo -e "\n....Installing warp $(WARP_VERSION)"; \
+		mkdir -p "$(TOOLS_DIR)"; \
+		GOBIN="$(TOOLS_DIR)" go install github.com/minio/warp@$(WARP_VERSION); \
+	fi
+
+# Local, self-contained correctness and performance run. The default smoke
+# preset records every request for 30 seconds per workload; PERF_PRESET=compare
+# uses two-minute samples for before/after decisions.
+PERF_PRESET  ?= smoke
+PERF_CONFIGS ?= 1host 3host
+e2e-performance: build certs warp-install
+	@PERF_PRESET="$(PERF_PRESET)" PERF_CONFIGS="$(PERF_CONFIGS)" WARP="$(WARP)" \
+		WARP_VERSION="$(WARP_VERSION)" \
+		./scripts/bench/e2e-performance.sh
+
+# Usage: make e2e-performance-compare PERF_BEFORE=/path/to/before PERF_AFTER=/path/to/after
+e2e-performance-compare: warp-install
+	@test -n "$(PERF_BEFORE)" || { echo "PERF_BEFORE is required" >&2; exit 2; }
+	@test -n "$(PERF_AFTER)" || { echo "PERF_AFTER is required" >&2; exit 2; }
+	@WARP="$(WARP)" ./scripts/bench/compare-performance.sh "$(PERF_BEFORE)" "$(PERF_AFTER)"
+
 # NilAway — advisory nil-panic analysis. Not in preflight: it has a known
 # false-positive rate, so findings are triaged by hand rather than gating commits.
 nilaway:
 	go tool nilaway -include-pkgs=github.com/mulgadc/predastore -exclude-test-files ./...
 
 .PHONY: certs build go_build preflight test test-cover test-race test-integration diff-coverage \
-	clean lint fix govulncheck nilaway
+	clean lint fix govulncheck nilaway warp-install e2e-performance e2e-performance-compare

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Stop, reset or benchmark the cluster with:
 | `-data-dir` | On-disk root for this host's nodes; overrides `data_dir` |
 | `-encryption-key` | Path to the 32-byte AES-256 key protecting data at rest; overrides `encryption_key` |
 | `-tls-cert`, `-tls-key` | This host's TLS identity; overrides `tls_cert` / `tls_key` |
-| `-bind-addr` | Local listen address, without a port; overrides `bind_addr` |
+| `-bind-addr` | Listen address for this host's cluster traffic, without a port; overrides `bind_addr` |
+| `-gate-bind-addr` | Listen address for the S3 API, without a port; overrides the gate node's `bind_addr` |
 | `-log-level` | `debug`, `info`, `warn` or `error` |
 
 Each of these host-local settings may come from either the file or a flag, so the same configuration file can be deployed unchanged to every machine and the paths supplied per process. The S3 port is not a flag: it is the gate node's `port`.
@@ -170,7 +171,7 @@ parity = 1    # parity shards; data + parity must not exceed the blob node count
 [[host]]
 id   = 1
 addr = "10.11.12.1"        # what other hosts dial; no port — nodes carry those
-# bind_addr = "0.0.0.0"    # optional local listen address, split from addr for NAT
+# bind_addr = "10.11.12.1" # where raft and blob listen; defaults to addr
 # data_dir  = "/var/lib/predastore"   # absolute; -data-dir supplies it otherwise
 
   # A role this host runs. One of "gate", "blob" or "meta".
@@ -178,6 +179,7 @@ addr = "10.11.12.1"        # what other hosts dial; no port — nodes carry thos
   id   = 1
   role = "gate"            # the S3 endpoint; port is the S3 port
   port = 8443
+  # bind_addr = "0.0.0.0"  # where S3 listens; gate only, defaults to the host's
 
   [[host.node]]
   id   = 2
@@ -191,6 +193,8 @@ addr = "10.11.12.1"        # what other hosts dial; no port — nodes carry thos
 ```
 
 Node ids are unique across the whole file; ports are unique within a host. A blob or meta node without its own `data_dir` derives one from the host's root and its node id, so separate disks are a per-node setting rather than a deployment layout.
+
+S3 is a public service and replication is not, so the two bind separately on a multi-homed machine: the host's `bind_addr` is where raft and blob traffic listens, and the gate's own `bind_addr` is where S3 does. Set the first to a private address and the second to `0.0.0.0` and the S3 endpoint answers on every interface while nothing reaches consensus or shard traffic from outside. Neither is required — a host that names only `addr` binds that one address for both, which is what a single-homed machine wants.
 
 Write every node under one `[[host]]` and the cluster runs in one process over the in-process pipe. Spread them across hosts and each process is launched separately with its own `-host` id. Nothing else changes.
 

--- a/cmd/s3d/main.go
+++ b/cmd/s3d/main.go
@@ -32,7 +32,8 @@ func main() {
 func run() error {
 	configPath := flag.String("config", "", "S3 server configuration file (required)")
 	hostID := flag.Int("host", 0, "ID of the [[host]] this process runs (required)")
-	bindAddr := flag.String("bind-addr", "", "Local listen address, without a port (overrides bind_addr)")
+	bindAddr := flag.String("bind-addr", "", "Listen address for this host's cluster traffic, without a port (overrides bind_addr)")
+	gateBindAddr := flag.String("gate-bind-addr", "", "Listen address for the S3 API, without a port (overrides the gate's bind_addr)")
 	dataDir := flag.String("data-dir", "", "On-disk root for this host's nodes (overrides data_dir)")
 	encryptionKey := flag.String("encryption-key", "", "Path to the 32-byte AES-256 key protecting data at rest (overrides encryption_key)")
 	tlsCert := flag.String("tls-cert", "", "Path to this host's TLS certificate (overrides tls_cert)")
@@ -85,6 +86,13 @@ func run() error {
 		return fmt.Errorf("host %d is not in %s", *hostID, *configPath)
 	}
 	host.BindAddr = cmp.Or(*bindAddr, host.BindAddr, host.Addr)
+	if *gateBindAddr != "" {
+		gate := gateEntry(host)
+		if gate == nil {
+			return fmt.Errorf("-gate-bind-addr given but host %d runs no gate", *hostID)
+		}
+		gate.BindAddr = *gateBindAddr
+	}
 	host.DataDir = cmp.Or(*dataDir, host.DataDir)
 	host.EncryptionKey = cmp.Or(*encryptionKey, host.EncryptionKey)
 	host.TLSCert = cmp.Or(*tlsCert, host.TLSCert)
@@ -117,6 +125,18 @@ func hostEntry(cfg *predastore.Config, id predastore.HostID) *predastore.HostCon
 	for i := range cfg.Hosts {
 		if cfg.Hosts[i].ID == id {
 			return &cfg.Hosts[i]
+		}
+	}
+	return nil
+}
+
+// gateEntry is the gate of this host, addressable for the same reason: the S3
+// listen address is a flag as well as a config field. A host declares at most
+// one, so the first is the only one.
+func gateEntry(h *predastore.HostConfig) *predastore.NodeConfig {
+	for i := range h.Nodes {
+		if h.Nodes[i].Role == predastore.RoleGate {
+			return &h.Nodes[i]
 		}
 	}
 	return nil

--- a/config.go
+++ b/config.go
@@ -62,6 +62,16 @@ func LoadConfig(path string) (*Config, error) {
 	return config.Load(path)
 }
 
+// HostBindAddr is where a host's cluster traffic listens, and NodeBindAddr
+// where a gate serves S3. Both are re-exported because an embedder settling
+// host-local fields has to know which plane it is settling: the S3 address
+// belongs to the gate, and putting it on the host would move raft and blob
+// traffic onto the public interface with it.
+func HostBindAddr(h HostConfig) string { return config.HostBindAddr(h) }
+
+// NodeBindAddr resolves a gate's S3 listen address against its host.
+func NodeBindAddr(h HostConfig, n NodeConfig) string { return config.NodeBindAddr(h, n) }
+
 // The queries below answer what the cluster is made of. They live here rather
 // than in the config package because they are inventory questions about a
 // parsed file, not part of parsing it.
@@ -172,7 +182,7 @@ func gateConfig(
 		RateLimit:   c.RateLimit,
 		BlobNodeIDs: nodeIDs(nodesByRole(c, RoleBlob)),
 
-		Addr:    host.BindAddr,
+		Addr:    config.NodeBindAddr(host, n),
 		Port:    n.Port,
 		TLSCert: host.TLSCert,
 		TLSKey:  host.TLSKey,

--- a/config/3host.toml
+++ b/config/3host.toml
@@ -8,6 +8,10 @@
 #
 # The hosts share one machine over loopback aliases, so each binds its own
 # address: three processes cannot share a port on one.
+#
+# Neither plane is split here, because there is one interface to split over. On
+# a multi-homed machine the host's bind_addr keeps raft and blob traffic on the
+# private interface, and the gate takes bind_addr = "0.0.0.0" for public S3.
 
 version = 1
 region = "ap-southeast-2"

--- a/config/5host.toml
+++ b/config/5host.toml
@@ -8,6 +8,10 @@
 #
 # The hosts share one machine over loopback aliases, so each binds its own
 # address: five processes cannot share a port on one.
+#
+# Neither plane is split here, because there is one interface to split over. On
+# a multi-homed machine the host's bind_addr keeps raft and blob traffic on the
+# private interface, and the gate takes bind_addr = "0.0.0.0" for public S3.
 
 version = 1
 region = "ap-southeast-2"

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,1310 +1,717 @@
-# Predastore Distributed Object Storage Architecture
+# Predastore Design
 
-Predastore is a distributed, S3-compatible, erasure-coded object store designed for high throughput, strong consistency, and fault tolerance. This document serves as the authoritative implementation guide for developers.
+Predastore is a distributed, S3-compatible object store. It combines Reed–Solomon erasure coding, a Raft-replicated metadata plane, QUIC transport between hosts, and append-only segment storage sealed with AES-256-GCM.
 
----
+This document is the implementation guide: it describes what the code does today, not what it might do. Where the implementation falls short of the intent, §15 says so explicitly. For the operator-facing view — installing, running, configuring — start with the [README](../README.md).
 
-## Table of Contents
+## Contents
 
-1. [Core Goals](#1-core-goals)
-2. [Quick Start](#2-quick-start)
-3. [System Architecture](#3-system-architecture)
-4. [Logical Data Model](#4-logical-data-model)
-5. [Global Metadata (s3db)](#5-global-metadata-s3db)
-6. [Local Shard Storage](#6-local-blob)
-7. [Reed-Solomon Encoding](#7-reed-solomon-encoding)
-8. [Hash Ring Placement](#8-hash-ring-placement)
-9. [QUIC Protocol](#9-quic-protocol)
-10. [S3 Operations](#10-s3-operations)
-11. [Failure Handling & Repair](#11-failure-handling--repair)
-12. [Cluster Evolution](#12-cluster-evolution)
-13. [Security](#13-security)
-14. [Deployment Modes](#14-deployment-modes)
-15. [Configuration Reference](#15-configuration-reference)
-16. [Developer Reference](#16-developer-reference)
-17. [Tunable Parameters](#17-tunable-parameters)
+1. [Reading order](#1-reading-order)
+2. [Cluster model](#2-cluster-model)
+3. [Process lifecycle](#3-process-lifecycle)
+4. [Transports and rpc](#4-transports-and-rpc)
+5. [The gate](#5-the-gate)
+6. [The meta plane](#6-the-meta-plane)
+7. [The blob plane](#7-the-blob-plane)
+8. [Object lifecycle](#8-object-lifecycle)
+9. [Erasure coding and placement](#9-erasure-coding-and-placement)
+10. [Encryption at rest](#10-encryption-at-rest)
+11. [Security](#11-security)
+12. [Configuration](#12-configuration)
+13. [Failure handling](#13-failure-handling)
+14. [Developer reference](#14-developer-reference)
+15. [Known gaps](#15-known-gaps)
 
 ---
 
-# 1. Core Goals
+# 1. Reading order
 
-- High throughput read/write performance
-- Strong consistency for metadata via Raft consensus
-- Efficient disk layout for large objects
-- Ability to scale from 3 nodes (RS(2,1)) to 32+ nodes (RS(3,2))
-- Node-to-node QUIC streaming for partial reads and reconstruction
-- Local rebuildability if Badger DBs are lost
-- Smooth cluster evolution as nodes are added or RS scheme changes
+The tree has four layers, and each one only knows about the layer below it:
+
+| Layer | Package | What it owns |
+|---|---|---|
+| Process | `predastore` (root), `cmd/s3d` | Flags, the config file, and building one host's nodes |
+| Roles | `internal/gate`, `internal/meta`, `internal/blob` | The three things a node can be |
+| Plumbing | `internal/rpc`, `internal/transport` | Node-addressed streams over a pipe or QUIC |
+| Storage | `internal/blob/engine` | Segments, fragments, extents, encryption at rest |
+
+`internal/config` sits underneath all of it. It parses the TOML file and validates it, and answers nothing else: placement, addressing and the conversion into each subsystem's own settings all live above it.
+
+Design goals, in the order they win arguments:
+
+- Strong consistency for metadata. Every object's placement is a Raft commit.
+- Durability through erasure coding, not replication. `K` of `K+M` shards rebuild an object.
+- No plaintext on disk, ever. There is no unencrypted code path.
+- One binary, one config file, one flag to say which machine you are.
+- Scale down as well as up: RS(1,0) on one host is the same code as RS(3,2) on five.
 
 ---
 
-# 2. Quick Start
+# 2. Cluster model
 
-### Starting a Cluster
+A cluster is two levels. A **host** is one machine running one `s3d` process, owning an address, a data directory and a TLS identity. A **node** is a role pinned to a host, running inside that process as a goroutine on its own port.
 
-One process runs one host, and every node the config pins to that host runs inside it. Start one process per `[[host]]`, each naming its own id:
+<p align="center">
+  <img src="assets/cluster-topology.svg" alt="Predastore cluster topology: S3 clients reach a gate node over HTTPS with Signature V4; each host is one s3d process running gate, meta and blob nodes that talk over an in-process pipe, while nodes on different hosts talk over QUIC" width="900">
+</p>
+
+## Roles
+
+| Role | Purpose | Listens | Dials |
+|---|---|---|---|
+| `gate` | Serves the S3 API: SigV4, IAM, erasure coding, placement | HTTPS on its `port` | meta and blob nodes |
+| `meta` | Raft replica over global state | rpc on its `port` | its meta peers |
+| `blob` | Stores erasure-coded shards | rpc on its `port` | nothing |
+
+A gate is a node with a role, not a per-host special case. A host may declare at most one — two would be two S3 endpoints answering for one machine — and a host declaring none simply serves no S3 API. Because nothing dials a gate, its rpc transports bind ephemerally and it registers no listener; its `port` is the S3 port and nothing else.
+
+Node ids are unique across the whole file, because the rpc resolver keys one flat table by id. Ports are unique within a host, because each node binds its own socket rather than sharing the host's.
+
+## Deployment shapes
+
+There are no modes. Which transport a pair of nodes uses follows from where the config pins them: same host is an in-process pipe, different hosts is QUIC. A cluster whose nodes all sit under one `[[host]]` therefore runs entirely in one process and opens no rpc socket at all — that is a property of the config, not a launch flag. The three profiles in `config/` (`1host`, `3host`, `5host`) differ only in how the nodes are spread.
+
+---
+
+# 3. Process lifecycle
+
+`cmd/s3d` is a thin entrypoint: parse flags, resolve the host-local settings, load the master key, call `predastore.Run`.
 
 ```bash
-# Host 1, and every node pinned to it — gate included.
-./bin/s3d -config cluster.toml -host 1 -encryption-key-file /etc/predastore/master.key
-
-# Host 2, on another machine, reading the same config.
-./bin/s3d -config cluster.toml -host 2 -encryption-key-file /etc/predastore/master.key
+./bin/s3d -config cluster.toml -host 1 \
+  -data-dir /var/lib/predastore \
+  -tls-cert /etc/predastore/server.pem -tls-key /etc/predastore/server.key \
+  -encryption-key /etc/predastore/master.key
 ```
 
-A config whose hosts are all one host is a single-process cluster. That is not a mode — it is the same command with fewer `[[host]]` entries.
+| Flag | Overrides | Notes |
+|---|---|---|
+| `-config` | — | Required |
+| `-host` | — | Required; selects the `[[host]]` this process is |
+| `-bind-addr` | `bind_addr` | Cluster-plane listen address, no port; defaults to `addr` |
+| `-gate-bind-addr` | the gate's `bind_addr` | S3 listen address, no port; defaults to the host's |
+| `-data-dir` | `data_dir` | On-disk root for this host's nodes |
+| `-encryption-key` | `encryption_key` | 32 raw bytes, mode `0600` |
+| `-tls-cert`, `-tls-key` | `tls_cert`, `tls_key` | This host's TLS identity |
+| `-log-level` | — | `debug`, `info`, `warn`, `error` |
 
-### CLI Flags
+There are no environment variables. The host-local fields resolve flag first, then file, then default, and are written back into the parsed config so the rest of the tree reads one settled value. The file's own validation then runs a second time over the merged tree, because `-data-dir` can supply a root the file never had and a node's derived directory only collides with an explicit one once that root is known.
 
-| Flag | Environment | Description |
-|------|-------------|-------------|
-| `-config` | `CONFIG` | Path to the configuration file (required) |
-| `-host` | `HOST` | ID of the `[[host]]` this process runs (required) |
-| `-encryption-key-file` | `ENCRYPTION_KEY_FILE` | Path to 32-byte AES-256 master key (required, mode `0600`) |
-| `-base-path` | - | Fallback for `base_path` when the config file does not set it |
-| `-debug` | - | Verbose debug logs regardless of the config file |
+`predastore.Run` builds every node of the host before starting any of them — a node that dialed a colocated peer first would otherwise find no listener registered for it — then runs them under one errgroup sharing one context. A single signal stops the lot; there is nothing else to stop it with. `buildNode` creates each node's transports, its resolver, its listeners and its service; whatever it acquired before a failure is released by the cleanup it returns.
 
-The S3 port and the TLS keypair are configuration, not flags: the port is the gate node's `port` and the keypair is its host's `tls_cert` / `tls_key`. See §15 for the `[[host]]` and `[[node]]` tables the config is built from.
+## The leader barrier
 
-`quicd` (the standalone shard-node binary) accepts the same `-encryption-key-file` / `ENCRYPTION_KEY_FILE` and refuses to start without it. Every node in a cluster MUST be given the same master key file — fragments sealed under one master cannot be opened under another.
+A gate that started serving before local consensus settled would fail writes that would have succeeded a moment later. So a host running a meta replica holds its gate off until a leader is observed, or until `LeaderTimeout` (30s) expires without one — a slow election still releases the gate rather than never serving. A host with no replica of its own has no local consensus to wait on and starts open.
 
 ---
 
-# 3. System Architecture
+# 4. Transports and rpc
 
-## Overall Architecture
+## Two transports, chosen by the config
 
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                            S3 Client (AWS CLI/SDK)                      │
-└─────────────────────────────────────────────────────────────────────────┘
-                                      │
-                                      ▼
-┌─────────────────────────────────────────────────────────────────────────┐
-│                     Predastore S3D (HTTP/Fiber)                         │
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌───────────────┐   │
-│  │ Auth/SigV4  │  │  Routing    │  │  Backend    │  │ GlobalState   │   │
-│  └─────────────┘  └─────────────┘  └─────────────┘  └───────────────┘   │
-└─────────────────────────────────────────────────────────────────────────┘
-        │                                                    │
-        │                                                    ▼
-        │                               ┌─────────────────────────────────┐
-        │                               │   Distributed s3db Cluster      │
-        │                               │  ┌─────────┐  ┌─────────┐       │
-        │                               │  │ Leader  │  │Follower │  ...  │
-        │                               │  │         │  │         │       │
-        │                               │  │ BoltDB  │  │ BoltDB  │       │
-        │                               │  │(Raft)   │  │(Raft)   │       │
-        │                               │  │         │  │         │       │
-        │                               │  │ Badger  │  │ Badger  │       │
-        │                               │  │(FSM)    │  │(FSM)    │       │
-        │                               │  └─────────┘  └─────────┘       │
-        │                               │        Raft Consensus           │
-        │                               └─────────────────────────────────┘
-        │
-        │  ┌─────────────────┼─────────────────┐
-        ▼  ▼                 ▼                 ▼
-    ┌─────────────┐   ┌─────────────┐   ┌─────────────┐
-    │  QUIC Node  │   │  QUIC Node  │   │  QUIC Node  │
-    │  (Shard 0)  │   │  (Shard 1)  │   │  (Shard 2)  │
-    ├─────────────┤   ├─────────────┤   ├─────────────┤
-    │ Store       │   │ Store       │   │ Store       │
-    │ (segments + │   │ (segments + │   │ (segments + │
-    │  index)     │   │  index)     │   │  index)     │
-    └─────────────┘   └─────────────┘   └─────────────┘
-```
+`internal/transport` provides `Transport`, `Listener`, `Conn` and `Stream`, implemented twice:
 
-## Component Overview
+- **pipe** (`NetworkPipe`) — in-process, for nodes sharing a host. No sockets, no handshake, no TLS.
+- **quic** (`NetworkQUIC`) — one bound UDP socket per node, TLS 1.3, ALPN pinned to `mulga-repl-v1`.
 
-| Component | Purpose |
-|-----------|---------|
-| **S3D (HTTP Server)** | Handles S3 API requests, authentication, routing |
-| **s3db Cluster** | Distributed Raft-based metadata store |
-| **QUIC Shard Nodes** | Store erasure-coded object shards in append-only segment files |
-| **GlobalState** | Abstraction layer for metadata access (local or distributed) |
+Every node owns its own UDP socket, bound from its host's `bind_addr` and its own port. Colocated nodes do not share a socket, so a QUIC address is a plain `host:port` and the listener a node accepts on is its own. A node only builds a pipe transport when its host runs more than one node, and only builds a QUIC transport when the cluster has nodes on other hosts.
+
+## Addressing
+
+Callers name peers by node id and never handle an address. `rpc.Resolver` is the flat route table — `NodeID → Route{Transport, Addr}` — built once from the configuration. It fails at construction if a route it must serve has no matching transport, rather than at the dial it would have served. Gates are left out of the table entirely, since nothing dials one. `Resolver.NodeAt` reverses the table, naming the node behind an inbound address.
+
+## Connection pooling
+
+`rpc.ConnPool` keys connections by node id, so a connection dialed to a peer and one accepted from it are the same entry on either transport, and a replica pair reuses one connection in both directions. An accepted connection is offered to the pool by `Donate`, which reverses the route table to name the peer behind it; a peer dialing from an ephemeral socket resolves to no node and is simply not pooled. When both ends open at once, both keep the connection the lower of the two node ids dialed and close the other, which each side computes from the same two ids.
+
+The pool runs no idle sweeper. A connection leaves through `Evict`, called by whichever side observes it die, or through `Close` when the node shuts down. Concurrent dials to one peer collapse onto a single connection via singleflight.
+
+| Layer | Lifetime | Cost |
+|---|---|---|
+| Connection | Long-lived, pooled | TLS handshake, once per peer pair |
+| Stream | Per request | A stream id |
+
+## Stream framing
+
+Every request is one stream. The stream opens with an 8-byte prefix — big-endian `uint32` opcode, then big-endian `uint32` header length — followed by the encoded header, followed by whatever body the operation carries. Headers are JSON and capped at 1 MiB. Opcodes are allocated per service in non-overlapping ranges, so a stream's opcode identifies the service that answers it:
+
+| Opcode | Service | Operation |
+|---|---|---|
+| `0x0001` | meta | Raft dial; the stream carries the raft wire protocol for its lifetime |
+| `0x1001`–`0x1004` | meta | get, put, delete, scan |
+| `0x2001`–`0x2003` | blob | get, put, delete |
+
+Both halves of a stream must be closed. Both the dial and the listen side cap a connection at 1000 concurrent incoming streams; unclosed streams block `OpenStream` once that cap is reached. The caps match deliberately — a reused connection is dialed by one side and accepted by the other, so a lower dial-side cap would silently throttle it.
+
+QUIC tuning lives in `internal/transport/quic.go`: 15s keepalive, 60s max idle, 5s handshake idle, 2 MiB initial and 8 MiB max stream receive windows, 16 MiB initial and 128 MiB max connection receive windows.
 
 ---
 
-# 4. Logical Data Model
+# 5. The gate
 
-## Objects → Shards → Fragments
+`internal/gate` is the S3 frontend: an HTTPS listener, a middleware chain, and a chi route table. The operations themselves are in `internal/gate/handlers`, credential resolution in `internal/gate/auth`, placement in `internal/gate/placement`, and the S3 vocabulary — error taxonomy, name validation, stored record shapes — in `internal/gate/model`.
 
-```
-Object (arbitrary size, RS-encoded as a whole)
- └── Shards (K data + M parity slices, one per node)
-      └── Fragments (fixed 8 KB payload + 32 B header, stored in segment files)
-```
+The gate is the S3 implementation, not a front end onto one. It erasure codes, places and records its own operations; meta and blob are storage it drives, not services it forwards to.
 
-An object is Reed-Solomon encoded end-to-end into `K` data shards and `M` parity shards without any intermediate chunking. Each shard is streamed to one node, where it is stored as a contiguous **extent** of fixed-size fragments inside an append-only segment file.
+## Request path
 
-### Size Reference
+1. **Global middleware**, registered before chi has matched, so none of it may read a bucket or key: OTel HTTP instrumentation, panic recovery, and `StripSlashes` (S3 accepts `PUT /bucket/` as `PUT /bucket`; only chi's routing context is rewritten, so SigV4 still sees the URI the client signed).
+2. **Route match**, into one of three groups — no resource, a bucket, or an object.
+3. **Resource resolution**, as inline middleware inside each group: the bucket or object is validated and put on the context. Everything downstream authorizes and acts on that one resolved resource, so the subject checked and the subject acted on cannot diverge. A malformed name answers `InvalidBucketName` or `InvalidKey`, never `AccessDenied`, since this runs before authentication.
+4. **Auth**: public-bucket short-circuit for GET and HEAD, then SigV4 verification, then IAM policy evaluation, then the cross-account bucket-ownership check.
+5. **Throttling**, keyed by account and action — after auth, so the limit counts against the authenticated account.
 
-| Unit | Size | Description |
-|------|------|-------------|
-| Fragment body | 8 KiB | AES-256-GCM ciphertext, zero-padded when logical length is shorter |
-| Fragment header | 32 B | `fragNum`, `shardNum`, `size`, `flags`, two reserved slots |
-| Fragment tag | 16 B | GCM authentication tag; binds ciphertext + AAD |
-| Fragment total | 8240 B | header + body + tag, fixed on-disk unit |
-| Shard | `⌈object_size / K⌉` | Per-node RS slice, variable size; occupies a contiguous extent |
-| Segment file | up to 4 GiB | Append-only container; rolls when full. Holds extents from multiple shards |
+## Serving
 
-Each shard is allocated a contiguous extent of fragments within a single segment. Multiple shards may share a segment but their extents are disjoint and never interleave. When a segment fills, its `flagFull` bit is set in the header and the store rolls forward to the next segment number.
+TLS 1.3 minimum, HTTP/2 advertised over ALPN with HTTP/1.1 as fallback. Read and write timeouts 60s, idle 120s, header read 10s, max header 1 MiB. `Run` serves until the context is cancelled, then drains in-flight requests within a 10s grace period. A gate that cannot bind takes the process down rather than leave the cluster running headless.
+
+## S3 surface
+
+| Area | Operations |
+|---|---|
+| Service | `ListBuckets` |
+| Buckets | `CreateBucket`, `DeleteBucket`, `HeadBucket`, `ListObjects` / `ListObjectsV2` |
+| Objects | `PutObject`, `GetObject` (incl. `Range`), `HeadObject`, `DeleteObject` |
+| Multipart | `CreateMultipartUpload`, `UploadPart`, `CompleteMultipartUpload`, `AbortMultipartUpload` |
+
+S3 overloads one method and path across several operations and distinguishes them by query string, which chi cannot match on, so the split is explicit in `routes.go`: `?partNumber` selects `UploadPart` over `PutObject`, and `?uploadId` selects the multipart completion and abort handlers.
+
+## How the gate names things in global state
+
+The meta replicas are a plain key-value store. The table taxonomy is the gate's alone: it composes `<table>/` onto the front of every key it stores and strips it back off every key it scans.
+
+| Key | Value | Purpose |
+|---|---|---|
+| `objects/<32-byte object hash>` | gob `ObjectToShardNodes` | Placement and object size, for retrieval |
+| `objects/arn:aws:s3:::<bucket>/<key>` | the 32-byte object hash | Listing, as one prefix scan per bucket |
+| `objects/deleted:<bucket>/<key>` | gob `DeletedObjectInfo` | Delete record for a future compaction coordinator |
+| `objects/part:<uploadID>:<part>` | gob `ObjectToShardNodes` | Placement of an in-flight multipart part |
+| `buckets/<name>` | gob `BucketMetadata` | Ownership, region, public flag |
+| `multipart/<uploadID>` | gob `UploadMetadata` | The upload itself |
+| `parts/<uploadID>:<part>` | gob `PartMetadata` | One uploaded part, zero-padded to 5 digits so scans sort |
+
+The object hash is `sha256("<bucket>/<key>")` and is not valid UTF-8, which is why keys travel the wire as `[]byte` and why snapshots are written as length-prefixed frames rather than JSON.
 
 ---
 
-# 5. Global Metadata (s3db)
+# 6. The meta plane
 
-Predastore uses a distributed Raft-based database (s3db) to store global state including bucket ownership, object metadata, and shard location mappings.
+`internal/meta` is one Raft replica plus the client that reaches replicas wherever they run. A process running several replicas builds one `Server` per node, each with its own rpc server and connection pool, so a replica never learns that it has siblings.
 
-## s3db Architecture
+<p align="center">
+  <img src="assets/meta-replica.svg" alt="Predastore meta replica: the client prefers the cached Raft leader and follows not-leader redirects; the replica answers key-value opcodes over rpc streams and carries Raft's own traffic over the same streams, applying committed commands into a badger FSM while bolt holds the Raft log and a file store holds snapshots" width="900">
+</p>
 
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                         Predastore S3D Binary                            │
-│  ┌───────────────────────────────┐   ┌───────────────────────────────┐  │
-│  │      S3 API Server            │   │     s3db Server(s)            │  │
-│  │   (Fiber HTTP/HTTPS)          │   │   (Fiber HTTPS + Raft)        │  │
-│  │                               │   │                               │  │
-│  │  ┌──────────┐ ┌──────────┐    │   │  ┌────────┐  ┌────────────┐   │  │
-│  │  │ Handlers │ │ Backend  │────┼───┼─▶│ Client │  │ Raft Node  │   │  │
-│  │  └──────────┘ └──────────┘    │   │  └────────┘  └────────────┘   │  │
-│  └───────────────────────────────┘   └───────────────────────────────┘  │
-└─────────────────────────────────────────────────────────────────────────┘
-```
+## Raft over rpc streams
 
-## Storage Architecture: BoltDB vs BadgerDB
+Raft has no port of its own. `RPCStreamLayer` implements `raft.StreamLayer` over the same rpc plumbing everything else uses: an outbound raft connection is a stream opened with `OpRaftDial`, and an inbound one is a stream the handler hands to the layer via `Deliver`, which then holds it open for the connection's lifetime. Raft advertise addresses are node-identifying strings — `node-5` — which the dial function parses back into a node id and routes through the resolver. There is no `raft_port`, no separate TLS setup for consensus, and no second socket to firewall.
 
-The s3db cluster uses **two different databases** for distinct purposes:
+One pool serves both directions: the client dials peers from it and the rpc server donates the connections it accepts back to it, so a connection carries raft traffic whichever end opened it.
 
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                        s3db Node Storage                                │
-│                                                                         │
-│  ┌─────────────────────────────┐    ┌─────────────────────────────┐    │
-│  │         BoltDB              │    │         BadgerDB            │    │
-│  │     (raft.db file)          │    │     (badger/ directory)     │    │
-│  │                             │    │                             │    │
-│  │  ┌───────────────────────┐  │    │  ┌───────────────────────┐  │    │
-│  │  │ Raft Log Store        │  │    │  │ Application Data      │  │    │
-│  │  │ - Committed log       │  │    │  │ - Object metadata     │  │    │
-│  │  │   entries             │  │    │  │ - Bucket info         │  │    │
-│  │  │ - Term/vote state     │  │    │  │ - ARN mappings        │  │    │
-│  │  └───────────────────────┘  │    │  └───────────────────────┘  │    │
-│  │                             │    │                             │    │
-│  │  ┌───────────────────────┐  │    │  FSM (Finite State         │    │
-│  │  │ Stable Store          │  │    │  Machine) applies          │    │
-│  │  │ - Current term        │  │    │  committed commands        │    │
-│  │  │ - Voted for           │  │    │  here                      │    │
-│  │  │ - Cluster config      │  │    │                             │    │
-│  │  └───────────────────────┘  │    └─────────────────────────────┘    │
-│  └─────────────────────────────┘                                        │
-│                                                                         │
-│  ┌─────────────────────────────┐                                        │
-│  │      Snapshot Store         │                                        │
-│  │    (snapshots/ directory)   │                                        │
-│  │  - Point-in-time FSM state  │                                        │
-│  │  - Used for log compaction  │                                        │
-│  │  - New node catch-up        │                                        │
-│  └─────────────────────────────┘                                        │
-└─────────────────────────────────────────────────────────────────────────┘
-```
+## Two databases
 
-### Why Two Databases?
+| Store | Backend | Holds |
+|---|---|---|
+| Raft log + stable store | bolt, `raft.db` | The ordered command log, current term, vote, cluster configuration |
+| FSM | badger, `badger/` | The actual key-value state, written with `SyncWrites` on |
+| Snapshots | files, `snapshots/` | Point-in-time FSM state for log compaction and replica catch-up |
 
-| Component | Database | Purpose |
-|-----------|----------|---------|
-| **Raft Log Store** | BoltDB | Stores the ordered sequence of commands (log entries) that Raft replicates. Required by HashiCorp Raft library. |
-| **Stable Store** | BoltDB | Stores Raft metadata: current term, voted-for candidate, cluster configuration. |
-| **FSM State** | BadgerDB | Stores actual application data (objects, buckets). Commands from the log are applied here. |
-| **Snapshots** | File-based | Periodic snapshots of BadgerDB state for log compaction and new node bootstrap. |
+Bolt stores *how to build the state*; badger stores *the state*. That split is what the Raft protocol requires.
 
-**Key Insight**: BoltDB stores *how to build state* (the Raft log), while BadgerDB stores *the actual state* (application data). This separation is required by the Raft consensus protocol.
+Snapshots are a stream of length-prefixed frames: big-endian `uint32` key length, key, big-endian `uint32` value length, value. Text encodings are unusable here, because object rows are keyed by a raw sha256 and JSON rewrites every byte that is not valid UTF-8 to U+FFFD, silently losing the row on restore. The legacy JSON map format is still read on restore (the first byte disambiguates) so a node upgraded on top of an old store still starts; new snapshots are always written as frames. Restore drops the FSM with badger's own bulk clear and rewrites through a `WriteBatch`, because a single transaction is capped and a metadata set that outgrew that cap used to make every snapshot permanently unrestorable — on every replica at once.
 
-### Directory Structure
+Commands are JSON: a type (put or delete), a key and a value, all binary-safe.
 
-Each database node creates the following directory structure:
+## Client behaviour
 
-```
-<path>/node-<id>/
-├── raft.db           # BoltDB: Raft log + stable store
-├── badger/           # BadgerDB: Application data (FSM state)
-│   ├── 000001.vlog
-│   ├── 000001.sst
-│   └── MANIFEST
-└── snapshots/        # Raft snapshots for recovery
-    └── <snapshot-id>/
-```
+Reads try the cached leader first, then every replica, and only report not-found once every replica has answered not-found — a replica that has not applied the key yet must not be mistaken for absence. A follower read may be stale.
 
-## Raft Consensus
+Writes go through the leader. A replica that cannot commit answers `not-leader` with the leader's advertise address when it knows one, and the client goes straight there; otherwise it rotates to the next replica after a short pause while an election settles. Attempts are bounded at `MaxRetries × len(replicas)` (default 3 per replica). A 10s per-attempt timeout is layered on the caller's context as a fallback; the caller's own cancellation still wins.
 
-Leveraging the HashiCorp Raft library: https://github.com/hashicorp/raft
+## Tuning
 
-### Leader Election Process
-
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                     Raft Leader Election                                │
-│                                                                         │
-│  1. Nodes start as Followers                                            │
-│     - Wait for heartbeats from leader                                   │
-│     - Timeout: ElectionTimeout (default: 1000ms)                        │
-│                                                                         │
-│  2. On heartbeat timeout, node becomes Candidate                        │
-│     - Increments term                                                   │
-│     - Votes for itself                                                  │
-│     - Requests votes from other nodes                                   │
-│                                                                         │
-│  3. Node becomes Leader if it receives majority votes                   │
-│     - For 3 nodes: needs 2 votes (including self)                       │
-│     - For 5 nodes: needs 3 votes                                        │
-│                                                                         │
-│  4. Leader sends heartbeats to maintain authority                       │
-│     - Interval: HeartbeatTimeout (default: 1000ms)                      │
-│     - Followers reset election timer on each heartbeat                  │
-│                                                                         │
-│  5. If leader fails, followers timeout and new election begins          │
-└─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Write Path (Requires Leader)
-
-```
-Client ──▶ Any Node ──▶ Redirect to Leader ──▶ Leader
-                                                  │
-                                                  ▼
-                                          ┌───────────────┐
-                                          │ 1. Create     │
-                                          │    Command    │
-                                          └───────┬───────┘
-                                                  │
-                                          ┌───────▼───────┐
-                                          │ 2. Append to  │
-                                          │    Raft Log   │
-                                          └───────┬───────┘
-                                                  │
-                                          ┌───────▼───────┐
-                                          │ 3. Replicate  │
-                                          │    to Followers│
-                                          └───────┬───────┘
-                                                  │
-                                          ┌───────▼───────┐
-                                          │ 4. Wait for   │
-                                          │    Majority   │
-                                          └───────┬───────┘
-                                                  │
-                                          ┌───────▼───────┐
-                                          │ 5. Apply to   │
-                                          │    FSM/Badger │
-                                          └───────┬───────┘
-                                                  │
-                                          ┌───────▼───────┐
-                                          │ 6. Return     │
-                                          │    Success    │
-                                          └───────────────┘
-```
-
-### Read Path (Any Node)
-
-Reads can go to any node but may return stale data on followers:
-
-```
-Client ──▶ Any Node ──▶ Read from local BadgerDB ──▶ Return
-```
-
-## Command Structure
-
-Commands are serialized as JSON and replicated through Raft:
+Defaults applied in `meta.New`, over hashicorp/raft's own:
 
 ```go
-type Command struct {
-    Type  CommandType `json:"type"`   // CommandPut or CommandDelete
-    Table string      `json:"table"`  // e.g., "objects", "buckets"
-    Key   []byte      `json:"key"`    // Binary key (base64 encoded in JSON)
-    Value []byte      `json:"value"`  // Binary value (base64 encoded in JSON)
-}
+HeartbeatTimeout:   1000 * time.Millisecond
+ElectionTimeout:    1000 * time.Millisecond
+CommitTimeout:      50 * time.Millisecond
+SnapshotInterval:   120 * time.Second
+SnapshotThreshold:  8192
+TrailingLogs:       10240
+LeaderLeaseTimeout: 500 * time.Millisecond
+LeaderTimeout:      30 * time.Second   // how long the gate barrier waits
 ```
 
-**Important**: The `Key` field uses `[]byte` instead of `string` to safely handle binary keys containing arbitrary bytes. JSON automatically base64-encodes `[]byte` fields, preventing corruption of binary data during serialization.
+Bootstrap is attempted by every replica. The peer set is identical across them, so the attempt is idempotent and an already-bootstrapped cluster reports `ErrCantBootstrap`, which is ignored.
 
-## GlobalState Interface
-
-The distributed backend uses a `GlobalState` interface to abstract storage operations:
-
-```go
-type GlobalState interface {
-    Get(table string, key []byte) ([]byte, error)
-    Set(table string, key []byte, value []byte) error
-    Delete(table string, key []byte) error
-    Exists(table string, key []byte) (bool, error)
-    ListKeys(table string, prefix []byte) ([][]byte, error)
-    Scan(table string, prefix []byte, fn func(key, value []byte) error) error
-    Close() error
-}
-```
-
-Two implementations:
-- **LocalState**: Wraps a local Badger DB (for single-node or testing)
-- **DistributedState**: Wraps an s3db.Client (for production clusters)
-
-## Global State Data Model
-
-| Table | Key Pattern | Value | Purpose |
-|-------|-------------|-------|---------|
-| objects | `arn:aws:s3:::<bucket>/<key>` | object hash (32 bytes) | Object listing |
-| objects | `<object-hash>` | ObjectToShardNodes (gob) | Shard location map |
-| objects | `deleted:<bucket>/<key>` | DeletedObjectInfo (gob) | Compaction tracking |
-| buckets | `<bucket-name>` | bucket metadata | Bucket ownership |
-
-## ChunkLayout Metadata
-
-```go
-type RSConfig struct {
-    DataShards   uint8
-    ParityShards uint8
-}
-
-type ChunkLayout struct {
-    ObjectID   [32]byte
-    ChunkIndex uint32
-    Size       uint64
-    RS         RSConfig
-    RingEpoch  uint32
-}
-```
-
-Key format: `[ 32 byte objectID | 4 byte chunk index ]`
-
-## s3db REST API
-
-The s3db service provides a REST API with AWS Signature V4 authentication:
-
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/v1/put/{table}/{hex-key}` | Store a key-value pair |
-| GET | `/v1/get/{table}/{hex-key}` | Retrieve a value |
-| DELETE | `/v1/delete/{table}/{hex-key}` | Delete a key |
-| GET | `/v1/scan/{table}?prefix=X&limit=N` | Scan keys with prefix |
-| GET | `/v1/leader` | Get current leader info |
-| POST | `/v1/join` | Join a new node to cluster |
-| GET | `/status` | Node status and Raft state |
-| GET | `/health` | Health check |
-
-**Note**: Keys in the URL path are hex-encoded to safely transport binary data.
+Shutdown closes the transport first — a replica that has lost quorum then fails fast rather than blocking on elections — then raft (bounded at 5s, so an unreachable quorum cannot hold the stores open), then bolt, badger and the pool.
 
 ---
 
-# 6. Local Shard Storage
+# 7. The blob plane
 
-Each QUIC shard node stores data locally in append-only segment files and maintains its own Badger index mapping shard identifiers to the on-disk extent that holds the shard's fragments. The implementation lives in the `store/` package.
+`internal/blob` is the shard service: a thin rpc server over `internal/blob/engine`, plus the client the gate uses to reach blob nodes by node id.
 
-## Local Badger (Per-QUIC-Node)
+A blob node knows nothing about S3. Its vocabulary is a **key** (32 opaque bytes) and an **index** (`uint32`), naming one **value** it stores. That the key is an object hash and the index a shard number is the gate's business.
 
-| Key Pattern | Value | Purpose |
-|-------------|-------|---------|
-| `<32 B object hash \|\| 4 B shard index>` | encoded extent record | Locate a shard's fragments on disk |
+## Wire protocol
 
-The extent record is:
+`Request` is the JSON header: key, index, size for puts, and `RangeStart`/`RangeEnd` for gets where `-1` means unset. `Response` is a newline-terminated JSON envelope; a get streams `BodyLen` body bytes after it. Two error codes carry protocol meaning — `not-found` and `store-full` — and anything else in `Err` is an opaque message. `store-full` is translated back into the engine's own `ErrStoreFull` on the client side, so capacity backoff upstream matches the same error either side of the wire.
 
-| Field | Size | Purpose |
-|-------|------|---------|
-| `SegNum` | 8 B | Segment file number containing the shard |
-| `Off` | 8 B | Byte offset of the shard's first fragment within the segment |
-| `PSize` | 8 B | Physical size on disk (fragment-aligned, includes per-fragment headers) |
-| `LSize` | 8 B | Logical (user) size of the shard |
+A put also reports `PoolNearFull` on success, so callers can back off before a write is ever outright rejected.
 
-**Commit rule**: a Badger entry for a shard exists if and only if all of that shard's fragments are fsync-durable on disk. The absence of a Badger entry means the shard is unreadable, regardless of what bytes happen to be on disk.
+## The engine
 
-## Segment File On-Disk Layout
+<p align="center">
+  <img src="assets/blob-ondisk.svg" alt="Predastore blob node on-disk format: a data directory of state.json, a badger index, append-only .seg segment files and their .idx sidecars; each segment is a 14-byte header followed by fixed 8240-byte fragments; each fragment is a 32-byte plaintext header, an 8192-byte AES-256-GCM ciphertext body and a 16-byte tag bound to the value's position" width="900">
+</p>
 
-Segments are append-only files containing a 14 B header followed by a sequence of fixed-size fragments:
+### Data directory
 
 ```
-┌──────────────────────────────────────────────────────────────┐
-│ Segment Header (14 B)                                        │
-│ ┌──────────┬─────────┬───────────┬──────────────┐            │
-│ │ Magic(4) │ Ver(2)  │ Flags(4)  │ Reserved(4)  │            │
-│ │ "S3SE"   │   1     │ flagFull  │              │            │
-│ └──────────┴─────────┴───────────┴──────────────┘            │
-├──────────────────────────────────────────────────────────────┤
-│ Fragment 0 (8240 B = 32 B header + 8192 B body + 16 B tag)   │
-├──────────────────────────────────────────────────────────────┤
-│ Fragment 1 (8240 B)                                          │
-├──────────────────────────────────────────────────────────────┤
-│ ... fragments belonging to one or more shards ...            │
-├──────────────────────────────────────────────────────────────┤
-│ Fragment N (8240 B)                                          │
-└──────────────────────────────────────────────────────────────┘
+<data dir>/
+├── state.json                 # monotonic counters + the data dir's crypto identity
+├── db/                        # badger: key‖index → extent, plus tombstones
+├── 0000000000000000.seg       # append-only fragments
+├── 0000000000000000.idx       # reverse sidecar: what was ever allocated in that segment
+└── ...
 ```
 
-Every fragment on disk is exactly `fragHeaderSize + fragBodySize + fragTagSize = 32 + 8192 + 16 = 8240` bytes. Bodies are zero-padded to `fragBodySize` before encryption; GCM is a stream cipher so the ciphertext is the same length as the plaintext (8192 B), and the authentication tag follows.
+### Segments
 
-The magic `'S','3','S','E'` (segment version `1`) identifies the encryption-at-rest format. The previous pre-encryption magic (`'S','3','S','F'`) is rejected outright by `openSegment` — there is no in-place migration, the operator must start with a fresh data dir.
+A segment is a 14-byte header — magic `S3SE`, version 1, a 32-bit flags word, 4 reserved bytes — followed by a sequence of fixed 8240-byte fragments. The previous pre-encryption magic is rejected outright by `openSegment`: there is no in-place migration, and an operator upgrading must start with a fresh data dir.
 
-A segment grows up to `maxSegSize` (4 GiB). When full, `flagFull` is set in the header and the store rolls forward to a new segment number. Within a segment, each shard occupies a contiguous extent of fragments; extents from different shards are disjoint.
+A segment grows to `maxSegSize` (4 GiB), at which point `flagFull` is set in its header and the store rolls to the next segment number. The flag is cached in memory so the hot append path does not pay a `ReadAt` for it. One oversized value is let through on a fresh segment, so a pathological size still makes progress rather than looping.
 
-### Fragment Header (32 B)
+### Fragments
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                         FragNum (8)                             │
-├─────────────────────────────────────────────────────────────────┤
-│                        ShardNum (8)                             │
-├───────────────────────────┬─────────────────────────────────────┤
-│       Reserved (4)        │          Size (4)                   │
-├───────────────────────────┼─────────────────────────────────────┤
-│         Flags (4)         │         Reserved (4)                │
-└───────────────────────────┴─────────────────────────────────────┘
-```
+| Part | Size | Contents |
+|---|---|---|
+| Header | 32 B | `fragNum`(8) ‖ `valueNum`(8) ‖ reserved(4) ‖ `size`(4) ‖ `flags`(4) ‖ reserved(4) |
+| Body | 8192 B | AES-256-GCM ciphertext; GCM is length-preserving, so the ciphertext is exactly the plaintext length |
+| Tag | 16 B | GCM authentication tag over ciphertext and AAD |
 
-| Field | Size | Purpose |
-|-------|------|---------|
-| `FragNum` | 8 B | Global monotonic fragment counter (across segments). Feeds the GCM nonce, so it must be unique for the lifetime of the master key (see Persistent State below). |
-| `ShardNum` | 8 B | Identifier of the shard this fragment belongs to. Bound into AAD. |
-| `Reserved` | 4 B | Reserved for future use |
-| `Size` | 4 B | Logical payload length (≤ 8192); the body bytes past `Size` are zero-padding inside the ciphertext |
-| `Flags` | 4 B | Bit flags; `flagEndOfShard` marks the final fragment of a shard |
-| `Reserved` | 4 B | Formerly CRC32 — see "Encryption-at-Rest" below; not reclaimed for a different field while the current segment magic is in use |
+`size` is the logical payload length in this fragment; bytes past it are zero-padding inside the ciphertext. `flags` carries `flagEndOfValue` on a value's last fragment. The header is plaintext because a reader needs `fragNum` and `valueNum` *before* decryption to rebuild the nonce and AAD — but both feed the AAD, so tampering with them fails the tag.
 
-The fragment header is plaintext on disk — readers need `FragNum` and `ShardNum` *before* decryption to reconstruct the AAD and nonce. The header fields are protected by GCM authentication, not by encryption: any tamper that changes `FragNum`, `ShardNum`, or `Size` makes the reconstructed AAD differ from what was bound at seal time and the tag check fails.
+### Extents and the index
 
-### Encryption-at-Rest
+A value of logical size `S` occupies `⌈S / 8192⌉` fragments in a contiguous extent within one segment. The index maps a 36-byte key (`key`(32) ‖ big-endian `index`(4)) to a 32-byte extent record:
 
-Every fragment is sealed independently under AES-256-GCM. The 12-byte GCM nonce and 52-byte AAD are deterministic and reconstructable at read time from the on-disk header + per-data-dir state:
+| Field | Meaning |
+|---|---|
+| `SegNum` | Which segment holds it |
+| `Off` | Byte offset of its first fragment within that segment |
+| `PSize` | Physical size on disk, `fragCount × 8240` |
+| `LSize` | Logical size the caller sees |
 
-```
-nonce[0:8]   = BE(fragNum)    // from fragment header
-nonce[8:12]  = BE(storeID)    // from state.json (4 random bytes, per data dir)
+**The index row is the only authority on what is readable.** Bytes on disk with no index row pointing at them are invisible and reclaimable. This is the linearisation point for readers, and it is what makes an overwrite safe: `Append` reserves and writes into a new extent while the old one keeps serving, and the swap happens in the single index transaction `Close` performs.
 
-aad[0:32]    = objectHash     // SHA-256, already part of the shard index key
-aad[32:36]   = BE(shardIndex) // already part of the shard index key
-aad[36:44]   = BE(shardNum)   // from fragment header
-aad[44:52]   = BE(fragNum)    // from fragment header
-```
+### The .idx sidecar
 
-Properties:
+Every reservation also appends a 52-byte row — `Off`(8) ‖ `Key`(36) ‖ `PSize`(8) — to the segment's `.idx` file. It is what compaction enumerates, so it can list a segment's extents without scanning the whole index. The rows are hints: each must be back-checked against the index, which is the authority on what is live. The sidecar is fsynced *before* the index commit, so every index-committed extent is already findable in `.idx` and a segment drop cannot lose live data. A torn trailing row is a crash mid-append, and that extent never went live.
 
-- **Confidentiality.** Disk-level access yields only ciphertext + tag; plaintext is never written to disk.
-- **Authenticated integrity.** GCM is the sole integrity authority — there is no separate CRC. A failed tag check returns `ErrIntegrity`; "disk corruption", "tamper", and "wrong master key" all surface as one error.
-- **Position binding.** AAD binds each fragment to its `(objectHash, shardIndex, shardNum, fragNum)` slot, so swapping fragments between shards or rewriting the on-disk header to claim a different slot fails the tag.
-- **Cross-data-dir defence.** `storeID` enters the nonce, not the AAD — splicing a fragment from data dir A into data dir B's segment yields a different nonce at read time and the tag fails.
-- **Mandatory.** `store.Open` errors without `WithAEAD`; the operator-layer daemons (`s3d`, `quicd`) refuse to start without `-encryption-key-file`. There is no unencrypted code path.
+### Write path
 
-The master key is loaded once at daemon startup by the `internal/keyfile` package (raw 32 bytes, mode `0600` — group/other-readable rejected outright), turned into a `cipher.AEAD`, and handed to `store.Open` via `WithAEAD`. The store never sees the raw key bytes.
+`Append` runs one short critical section under `store.mutex`, then does no data I/O under a lock at all:
 
-## Extent Reservation
+1. Check the free-space watermark. Below `full` (5%) reject with `ErrStoreFull`; below `nearfull` (15%) kick an immediate compaction pass but accept the write. A `statfs` error is treated as permissive — a monitoring hiccup must not take writes down.
+2. Compute the fragment count.
+3. If the allocation would cross the durably-reserved `fragNum` high-water, advance it and fsync `state.json`.
+4. Find or roll to a segment with room, and `Truncate` it to pre-allocate the extent.
+5. Append the `.idx` row, take a segment reference, and hand out the extent, `valueNum` and `fragNum` range.
 
-A shard of logical size `S` requires `⌈S / fragBodySize⌉` fragments occupying a contiguous extent of `n × totalFragSize` bytes within a segment.
+The writer then owns a disjoint byte range. It assembles fragments into an in-memory window (32 fragments, ≈ 256 KiB per active stream), seals each body in place under the shared AEAD, and issues one `WriteAt` per window. Concurrent writers may write the same segment file because their extents are disjoint: POSIX `pwrite` is atomic for non-overlapping regions, Go's `WriteAt` is safe for concurrent use, and the stdlib's GCM is safe for concurrent `Seal`/`Open`.
 
-**Reservation protocol** (executed under a short `store.mutex` critical section):
+`Close` then flushes, fsyncs the `.seg`, fsyncs the `.idx`, and commits the index row — in that order. A failure before the last step leaves the previous value intact and the new bytes as dead space. There is no distinct "failed" state on disk: the absence of an index row is the authoritative signal, and readers treat it identically to "never written".
 
-1. Compute the fragment count from the body length on the QUIC request header.
-2. Get the current segment. If full, mark it via `markFull()` and roll to the next segment number (up to 100 attempts).
-3. `Truncate(off + extentSize)` the segment file to reserve the extent up front. Pre-allocating ensures every subsequent `WriteAt` lands within file bounds without extending the file concurrently.
-4. Increment the segment's atomic `refs` counter.
-5. Allocate monotonic `fragNum`/`shardNum` values for the writer.
-6. Build and return a `shardWriter` bound to the reserved extent. Release the lock.
+`statfs` is throttled to at most once a second, and forced regardless once 64 MiB of extents have been reserved since the last measurement, because free space tracks write volume rather than wall-clock time.
 
-The reservation is the only shared-state critical section on the write path. No data I/O happens while holding `store.mutex` — only the `Truncate` syscall, which extends the file's size metadata without writing any blocks.
+### Read path
 
-## Lock-Free Fragment Writes
+`Lookup` reads the index row, opens the segment, takes a reference, and returns a reader over the extent. Reads are batched into the same 32-fragment window, opened in place, and a failed tag returns `ErrIntegrity`. The reader satisfies `io.ReaderAt`, so a ranged get is served by reading only the fragments the range touches. The caller must close the reader to release the segment reference.
 
-Once a reservation is issued, the writer goroutine owns a disjoint byte range within the segment file. Fragment offsets are deterministic:
+### Delete and tombstones
 
-```
-fileOffset(extent, frag) = extent.Off + frag * totalFragSize
-```
+`Delete` removes the index row and writes a tombstone in one transaction, so the dead-space hint can neither precede nor outlive the deletion. A missing key is not an error, which keeps deletes idempotent. An overwrite tombstones the extent it supersedes inside the same commit transaction.
 
-The writer assembles fragments (header + zero-padded body + GCM tag) into an in-memory window buffer, seals each body in place under the shared `cipher.AEAD`, and issues `(*os.File).WriteAt(buf, fileOffset)` for the whole window in one syscall. Multiple writer goroutines may issue concurrent `WriteAt` calls against the same segment file because their reserved extents are disjoint. POSIX `pwrite` guarantees atomicity for non-overlapping regions, and Go's `WriteAt` is explicitly safe for concurrent use. The AEAD itself is constructed once at `Store.Open` and shared — the stdlib's GCM is safe for concurrent `Seal` / `Open`.
+Tombstones are keyed by physical slot — `'d'` ‖ big-endian `segNum` ‖ big-endian `off`, 17 bytes — with the dead byte count as the value. Keying by slot rather than by object key is what lets one key die repeatedly: on delete, on overwrite, and on a relocation that lost its race. They only accelerate compaction's candidate selection and are never consulted for correctness.
 
-## Commit Sequence
+### Compaction
 
-`shardWriter.Close()` performs the following steps in order:
+Compaction is always on. Without it, overwrite and delete churn frees nothing and the store fills. The interval comes from `[compaction] interval_seconds`, defaulting to 5 minutes, and a nearfull `Append` kicks an out-of-cycle pass.
 
-1. **Final flush** of any remaining buffered fragments via `WriteAt`.
-2. **Fsync** the segment file.
-3. **Commit** by writing the Badger index entry: `<object hash || shard index>` → encoded extent.
-4. **Decrement** the segment's `refs` counter atomically.
+One cycle:
 
-Step 3 is the linearisation point for readers: a shard is readable if and only if its Badger entry is present. Steps 1-2 may produce fragments on disk that are never followed by a commit (aborted writes, crashes); those fragments are dead space reclaimable by the compactor.
+1. Scan the tombstone namespace and sum dead bytes per segment. Keys carry no namespace prefix, so roughly one hash in 256 starts with `'d'` — the fixed tombstone width is matched before the key is trusted.
+2. Select segments whose live fraction is below 70%. The active append segment is never a candidate: it is the relocation destination.
+3. Persist `segNum` before dropping anything, so a restart cannot recreate an empty segment at a number this cycle is about to drop.
+4. For each candidate, walk its `.idx`, back-check each row against the index, and relocate the rows that are still live.
+5. Fsync the index, drop the segment and its sidecar, and clear its tombstones.
 
-## Reference Counting & Segment Lifetime
+Relocation copies extent bytes **verbatim** — `fragNum` rides inside the copied bytes, so the nonce moves with them and is never reissued — then commits the repoint only if the key still points at the extent it copied from. Losing that race strands the copy for good, since only that swap could ever have referenced it, so the loser tombstones its own copy rather than let it pad the destination segment's live count. The copy itself runs without `store.mutex`, so compaction never stalls the write path.
 
-Each cached segment carries an atomic `refs` counter tracking the number of in-flight readers and writers that hold the segment open. The counter is:
+The index runs with badger's sync writes off, so relocations may still be in the page cache; the explicit index fsync before a drop is what stops a power loss from reverting the index to a segment that is already gone.
 
-- Incremented under `store.mutex` when a reservation succeeds (writers) or when `Lookup` returns a reader.
-- Decremented when the writer closes (after step 3 above) or the reader closes.
+### Persistent state
 
-`Store.Close()` waits for all `refs` to drain (spinning with `runtime.Gosched`) before closing segment file descriptors and the index.
+`state.json` holds `segNum`, `valueNum`, `fragNum`, `fragNumHighWater` and `storeID`. It is written atomically and durably: write `state.json.tmp`, fsync it, rename, fsync the parent directory.
 
-## Abort Semantics
+`fragNum` uniqueness across crashes is preserved by batched high-water reservation. On `Open` the store advances `fragNumHighWater` by 1 048 576 and fsyncs; `Append` then hands out values freely below the high-water without touching disk, and only an allocation that would cross it costs another fsync. On recovery, `Open` resumes at `fragNumHighWater`: the unflushed window from before the crash is sacrificed, because a rewound `fragNum` would reissue a nonce under the same key, which breaks GCM catastrophically. At most a million values of nonce space are wasted per crash, against a 2⁶⁴ budget.
 
-A reservation is aborted when the server-side writer fails mid-shard (network error, client disconnect, disk error). On abort:
+The first save also locks in a freshly generated `storeID` before any fragment can be sealed under it — a crash first would generate a different one and orphan everything written under the old.
 
-- The writer skips step 3 (Badger commit). The shard becomes unreadable.
-- The writer still performs step 4 (`refs` decrement) so the segment ref count drains correctly.
-- Any fragments already written to disk sit as dead space until the compactor reclaims them.
+### Shutdown
 
-There is no distinct on-disk or in-Badger `failed` state. The absence of a Badger entry is the authoritative signal that a shard is unreadable; the read path treats "Badger miss" identically to "shard never existed" and falls back to parity.
-
-## Persistent State
-
-The Store persists monotonic counters and the per-data-dir crypto identity in `state.json`:
-
-| Field | Purpose |
-|-------|---------|
-| `segNum` | Current segment number (advances when a segment is marked full) |
-| `shardNum` | Next shard identifier to assign |
-| `fragNum` | Next global fragment counter to assign (bound into the GCM nonce) |
-| `fragNumHighWater` | Durably-reserved upper bound on `fragNum`; `Append` extends it (and fsyncs) only when an allocation would cross it |
-| `storeID` | 4 random bytes generated on first `Open` and held for the lifetime of the data dir; bound into the GCM nonce |
-
-`state.json` is written atomically and durably: write `state.json.tmp`, fsync the file, rename to `state.json`, fsync the parent directory. The first save (after `storeID` generation, before any fragment can be sealed) MUST complete before `Open` returns — otherwise a crash + restart could generate a different `storeID` and orphan data written under the old one.
-
-`fragNum` uniqueness across crashes is preserved by **batched high-water reservation**, the standard pattern for crash-safe monotonic-counter allocators. On `Open`, the store advances `fragNumHighWater` by `fragNumReservation` (= 1 048 576) and fsyncs `state.json`. `Append` then hands out `fragNum` values freely below the high-water without touching disk; only an allocation that would cross the high-water triggers another fsync. On crash recovery, `Open` resumes `fragNum = fragNumHighWater` — the unflushed reservation window from before the crash is sacrificed to guarantee nonce uniqueness. At most `fragNumReservation` fragNums are "wasted" per crash; against the 2⁶⁴ budget this is negligible.
-
-## Background Compaction & Cold Storage
-
-Closed, fully-written segments are candidates for background compaction. The compactor:
-
-- Scans full segments for extents not referenced by any live Badger entry (dead extents from aborted reservations or deleted shards).
-- Rewrites live extents into a new compacted segment, updates Badger entries to point at the new location, and removes the old segment.
-- Optionally migrates aged, rarely-accessed shards to long-term cold storage. On a subsequent GET, the shard is rehydrated from cold storage into a local segment and served; rehydration may complete asynchronously with the GET response.
-
-Compaction is not on the critical write path and is not required for correctness of PUT or GET operations.
-
-## Local KV Rebuild
-
-If the local Badger index is lost, fragments alone are **not** sufficient to rebuild it. The AAD that authenticates each fragment is keyed on `(objectHash, shardIndex)` — both of which live only in the lost Badger key, not on disk. A scan-and-decrypt rebuild would need an exhaustive search over every known shard-key candidate per fragment, which is intractable.
-
-The supported recovery path for a lost local index is **read-repair from peers**: the hash ring identifies which shards this node should hold; missing shards are reconstructed by fetching `K` valid shards from peers and RS-decoding (see §11). The on-disk fragments from the lost index become dead space reclaimable by compaction.
-
-This is a deliberate trade-off introduced with the encryption-at-rest format: the per-fragment AAD binding that defends against fragment shuffling also makes "rebuild from segments alone" infeasible without storing the shard key in plaintext on disk, which would weaken the position-binding guarantee.
+`Store.Close` marks the store closed under the mutex, joins the compactor without holding it (an in-flight cycle takes the same mutex), saves state, waits for every segment's references to drain, then closes the segment file descriptors and the index.
 
 ---
 
-# 7. Reed-Solomon Encoding
+# 8. Object lifecycle
 
-Supports RS(2,1) as the default, RS(3,2) and user configurable.
+## PUT
 
-### Configuration
+<p align="center">
+  <img src="assets/put-path.svg" alt="Predastore PUT object path: the gate authenticates the request, hashes the object name, places it on the ring, Reed-Solomon encodes the body into data and parity shards, streams each shard to its blob node where it is sealed and committed, then records the placement in the Raft metadata plane" width="900">
+</p>
+
+The gate authenticates, resolves the bucket, unwraps `aws-chunked` framing if the client used it, and takes the object size from `Content-Length` or `X-Amz-Decoded-Content-Length`. A request that declares no length is rejected with `MissingContentLength`: the splitter needs the size up front, and it is what placement records.
+
+The body is split into `K` data shard buffers in memory and each is streamed to its node in parallel. Parity is encoded from those same buffers and streamed through pipes to the parity nodes. Zero parity stops after the data shards, since the encoder would otherwise read every data shard back to produce nothing.
+
+Once every shard has committed, two keys go to the meta plane — placement under the object hash, then the object hash under the listing ARN — and the client gets a 200 with an ETag. If any node reported nearfull pressure, the response also carries `X-Predastore-Pool-Pressure: nearfull`; a node that rejected outright surfaces as 507 `InsufficientStorage`.
+
+**Ordering matters.** Shards land before metadata. A crash between the two leaves shards nothing points at (reclaimed by compaction only once something tombstones them — see §15); a crash the other way round would leave metadata pointing at data that was never written.
+
+## GET
+
+<p align="center">
+  <img src="assets/get-path.svg" alt="Predastore GET object path: the gate reads the recorded placement from the Raft metadata plane, fetches the data shards from their blob nodes in parallel, joins them, and falls back to fetching parity and Reed-Solomon reconstruction when a shard is missing or fails its integrity check" width="900">
+</p>
+
+The gate reads the recorded placement — which carries the object size the join needs — fetches the data shards, and joins them. Only if the join fails does it refetch including parity and reconstruct. Parity is never touched on the happy path.
+
+A `Range` request takes a fast path when the whole range lands inside one data shard, since Reed–Solomon splits data sequentially: that is a single ranged shard read. Anything wider falls back to reconstructing the object and slicing it.
+
+## DELETE
+
+The gate loads the placement, fires shard deletes at every node in parallel, writes a `deleted:` record, then removes both metadata keys. A node that refuses its shard delete leaves garbage for the compactor; the object must still disappear from global state, so shard-delete failure is logged rather than propagated.
+
+## Multipart
+
+`CreateMultipartUpload` records upload metadata. Each `UploadPart` is stored exactly as an object would be — erasure coded and placed — but under a hidden object name, `.multipart/<uploadID>/<key>/<part>`, so an in-flight upload never shows up in a listing. `CompleteMultipartUpload` validates the claimed parts against what was stored, reads the parts back (fan-out bounded at 10 concurrent fetches), concatenates them into a temp file, and writes the result exactly as a single-shot `PutObject` would. Cleanup then drops the part shards and their metadata; it is best-effort throughout, since a cleanup failure must not fail the completion.
+
+`AbortMultipartUpload` runs the same cleanup without writing the object.
+
+---
+
+# 9. Erasure coding and placement
+
+The erasure code is cluster configuration, not a per-request choice, and it has no default: a substituted one would place objects at a width the cluster was never checked against.
 
 ```toml
 [rs]
-data = 3
-parity = 2
+data   = 2   # K
+parity = 1   # M
 ```
 
-Defines RS(3,2): 3 data shards, 2 parity shards. Can tolerate loss of any 2 nodes.
+Validation enforces two rules. `data + parity` must not exceed the number of blob nodes, because placement spreads a stripe over distinct nodes and a narrower cluster fails every write. And `parity = 0` is only legal at `data = 1`: zero parity delegates redundancy to whatever sits under the blob node, which only holds while the object is one shard on one node — striping it wider without parity makes losing any node lose every object.
 
-### Encoding Workflow
+An object is encoded end to end into `K` data and `M` parity shards with no intermediate chunking. Each shard is roughly `⌈size / K⌉` bytes. Any `K` of the `K+M` shards rebuild the object.
 
-1. Read the complete object body into memory on the S3D process.
-2. RS encode the object as a whole into `K` data shards + `M` parity shards using `reedsolomon.NewStream(K, M)` followed by `enc.Split(body, dataWriters, fileSize)`. Each shard is approximately `⌈object_size / K⌉` bytes.
-3. Ship each shard to its assigned node over QUIC (see §9). The node stores the shard as a contiguous extent of 8 KiB fragments inside a segment file, sealing each fragment under AES-256-GCM (see §6).
+## The ring
 
-No intermediate chunking or segmentation occurs. Compression is not performed on the write path; it is optionally applied to closed segments by the background compactor.
+`internal/gate/placement` wraps `buraksezer/consistent` with xxhash. Members are named `node-<id>`, so placement resolves straight to the id the blob client addresses. `Nodes(objectHash, K+M)` returns the placement in shard order: shard `i` goes to `Nodes()[i]`.
 
-### Decoding
+The ring is a concrete implementation, not a pluggable strategy. Every gate in a cluster must derive the same placement from the same object hash, so there is nothing to swap at runtime.
 
-- Request data shards in parallel from their assigned nodes.
-- If a data shard is missing (Badger miss) or any fragment fails GCM authentication (`ErrIntegrity`), fetch a parity shard instead.
-- Once `K` valid shards have been collected, RS decode to reconstruct the object.
-- Fewer than `K` valid shards → GET fails.
+| Parameter | Value |
+|---|---|
+| Partition count | 5 |
+| Replication factor | 100 |
+| Load factor | 1.25 |
+
+The gate records the resolved placement rather than relying on the ring alone at read time, so a ring that has since changed shape does not lose objects placed under the old one. It does check that the recorded shard count still matches the ring's width.
 
 ---
 
-# 8. Hash Ring Placement
+# 10. Encryption at rest
 
-Predastore uses a consistent hash ring with virtual nodes.
+Every fragment is sealed independently under AES-256-GCM. The 12-byte nonce and 52-byte AAD are deterministic and fully reconstructable at read time from the on-disk header plus per-data-dir state:
 
-### Placement Algorithm
+```
+nonce[0:8]   = BE(fragNum)     // from the fragment header
+nonce[8:12]  = BE(storeID)     // from state.json, 4 random bytes per data dir
 
-1. Compute `hash64 = first8(SHA256(bucket/path:chunkIndex))`
-2. Locate ring position ≥ hash64
-3. Select next K+M distinct nodes based on RSConfig
+aad[0:32]    = key             // sha256, already part of the index key
+aad[32:36]   = BE(index)       // already part of the index key
+aad[36:44]   = BE(valueNum)    // from the fragment header
+aad[44:52]   = BE(fragNum)     // from the fragment header
+```
+
+What this buys:
+
+- **Confidentiality.** Disk-level access yields ciphertext and tags. Plaintext is never written.
+- **Authenticated integrity.** GCM is the sole integrity authority; there is no separate checksum. Disk corruption, tampering and a wrong master key all surface as one `ErrIntegrity`.
+- **Position binding.** The AAD binds each fragment to its `(key, index, valueNum, fragNum)` slot, so swapping fragments between values — or rewriting the header to claim a different slot — fails the tag.
+- **Cross-data-dir defence.** `storeID` enters the nonce, not the AAD, so splicing a fragment from one data dir into another yields a different nonce at read time and the tag fails.
+- **Mandatory.** `engine.Open` errors without `WithAEAD`, `blob.New` errors without an AEAD, and `s3d` refuses to start without `-encryption-key`. There is no unencrypted code path.
+
+The master key is one 32-byte AES-256 key per cluster, loaded once at startup by `pkg/masterkey`. The loader is fail-closed on permissions: any group- or other-readable mode is rejected outright with no override, because the master key gates plaintext access to every object cluster-wide and warn-and-allow would put the cluster one ignored log line from a permanent breach. The raw bytes are not retained past `Load` — only the `cipher.AEAD` and a short log-safe fingerprint, `hex(sha256(key)[:8])`.
+
+Every node in a cluster must be given the same key file. Fragments sealed under one master cannot be opened under another. Rotation is out of scope for the current implementation (see §15).
+
+Binaries are built with `GOFIPS140=v1.0.0`, and `internal/fipsboot` panics at startup if FIPS mode was turned off at runtime via `GODEBUG`.
 
 ---
 
-# 9. QUIC Protocol
+# 11. Security
 
-Node-to-node communication uses QUIC for shard storage and retrieval. QUIC was chosen specifically to avoid TLS handshakes on every request while maintaining encryption.
+## TLS
 
-Every node owns one UDP socket, bound at construction from its host's `bind_addr` and its own `port`. Colocated nodes do not share a socket, so there is no ALPN accept router demultiplexing one and no two-part address naming a node within it: a QUIC address is a plain `host:port`, and the listener a node accepts on is its own. Nodes sharing a host bypass QUIC entirely and reach each other over the in-process pipe transport.
+- The S3 API serves TLS 1.3 minimum with a restricted curve preference, from the host's `tls_cert` / `tls_key`.
+- QUIC between hosts uses the same keypair, TLS 1.3, and pins the cluster ALPN `mulga-repl-v1`, so a handshake against anything but a cluster peer fails outright. Dialers verify the server certificate against the OS trust store, with no `InsecureSkipVerify` anywhere.
+- Raft rides those same connections and needs no TLS setup of its own.
 
-Callers name peers by node id and never handle an address themselves. `rpc.Resolver` is the flat route table — `NodeID → Route{Transport, Addr}` — built once from the configuration, and it fails at construction if a route it must serve has no matching transport rather than at the dial it would have served. `rpc.ConnPool` keys connections by the same node id, so a connection dialed to a peer and one accepted from it are the same entry on either transport and a replica pair reuses one connection in both directions. An accepted connection is offered to the pool by `Donate`, which reverses the route table to name the peer behind it; a peer dialing from an ephemeral socket resolves to no node and is simply not pooled. When both ends open at once, both keep the connection the lower of the two node ids dialed and close the other, which each side computes from the same two ids.
+Certificates belong to the host, not the node. That is what TLS can express: SANs carry no port, so two nodes on one machine are indistinguishable to TLS regardless. One keypair therefore serves both the public and the cluster plane; a separate certificate per plane is not implemented, and neither are per-node client certificates (mTLS).
 
-## Architecture Overview
+Keeping the cluster plane off the public interface is a bind-address question rather than a TLS one — see [Two planes](#two-planes).
 
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                           CLIENT SIDE                                    │
-│                                                                          │
-│  storage.Client / state.Client                                           │
-│       │                                                                  │
-│       ▼                                                                  │
-│  pool.Dial(ctx, NodeID(3))                                              │
-│       │                                                                  │
-│       ▼                                                                  │
-│  ┌─────────────────────────────────────────────────────────────────┐    │
-│  │  rpc.ConnPool (one per dialing node)                             │    │
-│  │  ┌─────────────────────────────────────────────────────────┐    │    │
-│  │  │  map[NodeID]pooled + Resolver route table               │    │    │
-│  │  │                                                          │    │    │
-│  │  │  NodeID(2) → pipe conn (colocated peer)  ─┐             │    │    │
-│  │  │  NodeID(3) → quic conn, dialed by us      │ REUSED!     │    │    │
-│  │  │  NodeID(4) → quic conn, accepted          │ (no TLS)    │    │    │
-│  │  └──────────────────────────────────────────┼──────────────┘    │    │
-│  └─────────────────────────────────────────────┼───────────────────┘    │
-│                                                │                         │
-│       ▼                                        │                         │
-│  rpc.OpenStream(ctx, cli, node, op, hdr)       │                         │
-│       │                                        │                         │
-│       ▼                                        │                         │
-│  conn.OpenStreamSync() ←───────────────────────┘                        │
-│       │         ▲                                                        │
-│       │         │ Multiplexed streams on SINGLE connection              │
-│       │         │ (stream IDs: 0, 4, 8, 12, ...)                        │
-│       ▼         │                                                        │
-│  ┌──────────────┴──────────────────────────────────────────────┐        │
-│  │  Stream (per request - lightweight!)                         │        │
-│  │  - Write: header + request JSON + shard data                │        │
-│  │  - Read: response header + response JSON                    │        │
-│  │  - Close: CancelRead(0) + Close() → releases stream ID      │        │
-│  └──────────────────────────────────────────────────────────────┘        │
-└─────────────────────────────────────────────────────────────────────────┘
+Standalone operators must install the cluster CA into the host trust store before launching `s3d`, or nodes cannot dial each other. Under Spinifex this happens automatically during node bootstrap.
 
-                              │ QUIC/UDP │
-                              │ (single  │
-                              │  socket) │
-                              ▼          ▼
+## Authentication and authorization
 
-┌─────────────────────────────────────────────────────────────────────────┐
-│                           SERVER SIDE                                    │
-│                                                                          │
-│  listener.Accept() → quic.Conn (TLS handshake HERE, ONCE per client)   │
-│       │                                                                  │
-│       ▼                                                                  │
-│  pool.Donate(conn) → the peer is named, so the connection is reused     │
-│       │              for outbound streams too; Evict releases it        │
-│       ▼                                                                  │
-│  serveConn(conn) - runs forever for this connection                     │
-│       │                                                                  │
-│       ▼ (loop)                                                          │
-│  conn.AcceptStream() → gets next stream from client                     │
-│       │                                                                  │
-│       ▼                                                                  │
-│  go handleStream(stream)                                                │
-│       │                                                                  │
-│       ├─→ Read request header + body                                    │
-│       ├─→ Process (store write, read, etc.)                            │
-│       ├─→ Write response                                                │
-│       └─→ Close stream (CancelRead + Close)                             │
-│                                                                          │
-│  [Loop back to AcceptStream for next request on same connection]        │
-└─────────────────────────────────────────────────────────────────────────┘
-```
+- **SigV4** on every S3 request, against the URI the client actually signed. Presigned URLs are supported. Global operations are signed against `us-east-1` regardless of the cluster region.
+- **Config-defined accounts** in `[[auth]]` are trusted service accounts: the policy table is only consulted for IAM accounts. Each must carry an `account_id`, so buckets it creates land with a real owner.
+- **IAM via NATS JetStream KV**, when `[iam]` is configured: access keys, users, roles and policies are read from KV buckets and layered over the config accounts through a chain provider. Predastore serves S3 over HTTP and does not subscribe to any NATS request topic; KV is the only thing NATS is used for.
+- **Bucket ownership** is checked cross-account after policy evaluation.
+- **Public buckets** short-circuit authentication for GET and HEAD only; everything else still requires a signature, and listing buckets is never public.
 
-## Connection vs Stream Lifecycle
+## Rate limiting
 
-| Layer | Lifecycle | Cost | When Created |
-|-------|-----------|------|--------------|
-| **Connection** | Long-lived, pooled | TLS handshake (~50-100ms) | First request to node |
-| **Stream** | Per-request | ~0 (stream ID allocation) | Every PUT/GET/DELETE |
-
-### What Happens Per Shard Write
-
-| Step | Operation | Cost |
-|------|-----------|------|
-| 1 | `pool.Dial(ctx, nodeID)` | **O(1) map lookup** - no TLS! |
-| 2 | Check connection alive | `conn.Context().Err() == nil` |
-| 3 | `conn.OpenStreamSync()` | **Very fast** - just assigns stream ID |
-| 4 | Write request + data | Network I/O |
-| 5 | Read response | Network I/O |
-| 6 | Close stream | Releases stream ID |
-
-**Connection stays in pool, NOT closed!**
-
-### TLS Handshake Occurs Only When
-
-1. **First connection to a node** - unavoidable
-2. **Connection died** (idle timeout, network error) - re-establishes
-3. **Connection evicted** by either side's close path
-
-A colocated peer costs no handshake at all: its route names the pipe transport.
-
-## Connection Pool Configuration
-
-```go
-// internal/transport/quic.go — dialQUICConfig()
-&quic.Config{
-    HandshakeIdleTimeout:  5 * time.Second,
-    KeepAlivePeriod:       15 * time.Second,
-    MaxIdleTimeout:        60 * time.Second,   // Connection stays alive
-    MaxIncomingStreams:    1000,               // Matches the listen side
-    MaxIncomingUniStreams: 1000,
-}
-```
-
-The pool runs no idle sweeper. A connection leaves through `Evict`, called by whichever side observes it die, or through `Close` when the node shuts down.
-
-## Stream Closing (Critical for Connection Reuse)
-
-QUIC streams have two independent half-connections. Both must be closed:
-
-```go
-// After reading all response data:
-s.CancelRead(0)  // Close read side (tells peer we're done reading)
-s.Close()        // Close write side (sends FIN)
-```
-
-**Warning**: Failing to close streams causes stream exhaustion. Both the dial and the listen side cap a connection at 1000 concurrent incoming streams; unclosed streams will block `OpenStreamSync()` once that cap is reached. The caps match deliberately — a reused connection is dialed by one side and accepted by the other, so a lower dial-side cap would silently throttle it.
-
-## Protocol Format
-
-### Request Header (32 bytes)
-
-```
-┌────────────────────────────────────────────────────────────────┐
-│ Version (1) │ Method (1) │ Status (1) │ Reserved (1)          │
-├────────────────────────────────────────────────────────────────┤
-│                         ReqID (8)                              │
-├────────────────────────────────────────────────────────────────┤
-│         KeyLen (4)        │        MetaLen (4)                 │
-├────────────────────────────────────────────────────────────────┤
-│                        BodyLen (8)                             │
-└────────────────────────────────────────────────────────────────┘
-```
-
-### Methods
-
-| Method | Value | Description |
-|--------|-------|-------------|
-| GET | 1 | Retrieve shard data |
-| PUT | 2 | Store shard data |
-| DELETE | 3 | Delete shard metadata |
-
-### Request/Response Flow
-
-**PUT Request:**
-```
-[Header 32B] [PutRequest JSON] [Shard Data...]
-```
-
-**PUT Response:**
-```
-[Header 32B] [PutResponse JSON]
-```
-
-**GET Request:**
-```
-[Header 32B] [ObjectRequest JSON]
-```
-
-**GET Response:**
-```
-[Header 32B] [Shard Data...]
-```
-
-## Key Files
-
-| File | Purpose |
-|------|---------|
-| `internal/transport/transport.go` | `Transport`, `Listener`, `Conn`, `Stream`, the shared `Addr` |
-| `internal/transport/quic.go` | One bound UDP socket per node: dial, listen, close |
-| `internal/transport/pipe.go` | In-process transport for colocated nodes |
-| `internal/rpc/resolver.go` | `NodeID → Route{Transport, Addr}`, and `NodeAt` reversing it |
-| `internal/rpc/pool.go` | `ConnPool`: one connection per peer node, donation, tiebreak |
-| `internal/rpc/client.go` | Stream opening and the per-stream header framing |
-| `internal/rpc/server.go` | `Mux`, accept loop, connection donation, stream dispatch |
-| `internal/rpc/rpc.go` | `Opcode` and the `Header` codec contract |
+Optional, keyed by `(account, action)` with per-action overrides, answering `SlowDown` with 503 when a bucket is exhausted.
 
 ---
 
-# 10. S3 Operations
+# 12. Configuration
 
-## List Buckets
-
-```
-┌──────────────┐     ┌─────────────┐     ┌─────────────────┐
-│  S3 Client   │────▶│    S3D      │────▶│  s3db Cluster   │
-│  aws s3 ls   │     │  (HTTP)     │     │   (via Client)  │
-└──────────────┘     └─────────────┘     └─────────────────┘
-                            │                    │
-                            │  1. Extract account ID from auth
-                            │                    │
-                            │  2. Query buckets table
-                            │                    │
-                            ▼                    ▼
-                     ┌─────────────────────────────┐
-                     │  Return XML bucket list     │
-                     └─────────────────────────────┘
-```
-
-## PUT Object
-
-```
-┌───────────────────────────┐
-│         S3 Client         │
-│ aws s3 cp file s3://b/k   │
-└─────────────┬─────────────┘
-              │
-              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                         S3D (HTTP)                          │
-│  1. Authenticate request (SigV4)                            │
-│  2. Verify bucket access                                    │
-│  3. Handle chunked transfer encoding (aws-chunked)          │
-│  4. Read body into memory                                   │
-│  5. Generate object hash from bucket + key                  │
-│  6. Determine shard nodes via consistent hash ring          │
-└─────────────┬───────────────────────────────────────────────┘
-              │
-              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                  Reed-Solomon Encoding                      │
-│  - RS encode whole object into K data + M parity shards     │
-│  - Shard size ≈ object_size / K                             │
-└─────────────┬───────────────────────────────────────────────┘
-              │
-              │  Parallel QUIC streams, one per shard
-              ▼
-┌─────────────────┐  ┌─────────────────┐       ┌─────────────────┐
-│   QUIC Node 0   │  │   QUIC Node 1   │  ...  │   QUIC Node K+M │
-│   (Data 0)      │  │   (Data 1)      │       │   (Parity M-1)  │
-│                 │  │                 │       │                 │
-│  Per-stream goroutine per shard:                              │
-│  1. Read body length from protocol header                     │
-│  2. Reserve a contiguous extent under short store.mutex lock  │
-│     - Roll to next segment if current is full                 │
-│     - Truncate segment to pre-allocate the extent             │
-│     - Increment segment refs                                  │
-│  3. Lock-free WriteAt of fragment buffers within the extent   │
-│  4. fsync the segment file                                    │
-│  5. Badger put: <object-hash || shard-index> → extent record  │
-│  6. Atomic segment refs decrement                             │
-└─────────────────┘  └─────────────────┘       └─────────────────┘
-              │
-              ▼
-┌─────────────────────────────────────────────────────────────┐
-│              s3db Cluster Update (via Client)               │
-│  1. Write to leader node                                    │
-│  2. Leader replicates to followers (Raft)                   │
-│  3. Store ARN key → object hash mapping                     │
-│  4. Store object hash → ObjectToShardNodes metadata         │
-│  5. Return ETag to client on majority commit                │
-└─────────────────────────────────────────────────────────────┘
-```
-
-### Write-Path Concurrency Invariants
-
-- `store.mutex` is held only during reservation and is released before any data I/O begins. It covers extent allocation, segment rotation, segment-file `Truncate`, `fragNum`/`shardNum` assignment, and `state.json` persistence.
-- Fragment writes to disk are lock-free. Multiple concurrent writer goroutines may issue `WriteAt` against the same segment file provided their reserved extents are disjoint.
-- A shard is observable to readers only after its Badger entry has been committed. Fragments fsynced to disk without a corresponding Badger put are invisible to GET and are reclaimable by compaction.
-- Segment file descriptors are kept open in a per-store cache and are closed only on `Store.Close()`, after waiting for all outstanding writer/reader references to drain.
-
-## GET Object
-
-```
-┌───────────────────────────┐
-│         S3 Client         │
-│ aws s3 cp s3://bucket/key │
-└─────────────┬─────────────┘
-              │
-              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                         S3D (HTTP)                          │
-│  1. Authenticate request (SigV4)                            │
-│  2. Query s3db cluster for object metadata                  │
-│  3. Get ObjectToShardNodes via object hash                  │
-│  4. Determine shard nodes via consistent hash ring          │
-└─────────────┬───────────────────────────────────────────────┘
-              │
-              │  Parallel QUIC requests to data shard nodes
-              ▼
-┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐
-│   QUIC Node 0   │  │   QUIC Node 1   │  │   QUIC Node 2   │
-│  ┌───────────┐  │  │  ┌───────────┐  │  │  ┌───────────┐  │
-│  │LocalBadger│  │  │  │LocalBadger│  │  │  │LocalBadger│  │
-│  │key→extent │  │  │  │key→extent │  │  │  │key→extent │  │
-│  └─────┬─────┘  │  │  └─────┬─────┘  │  │  └─────┬─────┘  │
-│        ▼        │  │        ▼        │  │        ▼        │
-│  ┌───────────┐  │  │  ┌───────────┐  │  │  ┌───────────┐  │
-│  │ Segment   │  │  │  │ Segment   │  │  │  │ Segment   │  │
-│  │  Shard 0  │  │  │  │  Shard 1  │  │  │  │  Shard 2  │  │
-│  └───────────┘  │  │  └───────────┘  │  │  └───────────┘  │
-└────────┬────────┘  └────────┬────────┘  └────────┬────────┘
-         │                    │                    │
-         └────────────────────┼────────────────────┘
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                    S3D Reassembly                           │
-│  - Collect data shards (minimum: rsDataShard count)         │
-│  - If shard missing/corrupt: fetch parity, reconstruct      │
-│  - Reed-Solomon decode to original object                   │
-│  - Stream response to client                                │
-└─────────────────────────────────────────────────────────────┘
-```
-
-## DELETE Object
-
-```
-┌────────────────────────────┐
-│          S3 Client         │
-│ aws s3 rm s3://bucket/key  │
-└─────────────┬──────────────┘
-              │
-              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                         S3D (HTTP)                          │
-│  1. Authenticate request (SigV4)                            │
-│  2. Query s3db for object metadata                          │
-│  3. Get ObjectToShardNodes to find all shard locations      │
-│  4. Determine nodes via consistent hash ring                │
-└─────────────┬───────────────────────────────────────────────┘
-              │
-              │  Parallel QUIC DELETE requests to all nodes
-              ▼
-┌─────────────────┐  ┌─────────────────┐       ┌─────────────────┐
-│   QUIC Node 0   │  │   QUIC Node 1   │  ...  │   QUIC Node 4   │
-│  ┌───────────┐  │  │  ┌───────────┐  │       │  ┌───────────┐  │
-│  │LocalBadger│  │  │  │LocalBadger│  │       │  │LocalBadger│  │
-│  │Deletehash │  │  │  │Deletehash │  │       │  │Deletehash │  │
-│  └───────────┘  │  │  └───────────┘  │       │  └───────────┘  │
-└─────────────────┘  └─────────────────┘       └─────────────────┘
-              │
-              ▼
-┌─────────────────────────────────────────────────────────────┐
-│              s3db Cluster Cleanup (via Client)              │
-│  1. Write DeletedObjectInfo for compaction tracking         │
-│  2. Delete ARN key → object hash mapping                    │
-│  3. Delete object hash → ObjectToShardNodes metadata        │
-│  4. Return 204 No Content on majority commit                │
-└─────────────────────────────────────────────────────────────┘
-```
-
----
-
-# 11. Failure Handling & Repair
-
-## Read-Path Failure Modes
-
-A GET fetches shards in parallel from their placement nodes. Each node either returns a valid shard or fails; failures degrade to parity fetches until `K` valid shards are collected.
-
-| Failure | Detection | Response |
-|---------|-----------|----------|
-| Badger miss | Local lookup returns not-found | Node returns "absent"; S3D fetches parity |
-| Fragment integrity failure | GCM tag check fails during read (returns `ErrIntegrity`) | Node treats the shard as unreadable; S3D fetches parity. Covers disk corruption, tamper, fragment swap, and wrong master key indistinguishably. |
-| Node timeout | QUIC request deadline exceeded | S3D fetches parity |
-| Fewer than `K` valid shards | Aggregate check after all fetches | GET returns 500/503 to the client |
-
-A shard that was written to disk but never committed to Badger is indistinguishable from one that was never attempted — both surface as "absent." The read path does not distinguish between them, and the commit invariant (§6) ensures readers cannot observe partial writes.
-
-## Background Repair
-
-A node-local healing process periodically reconciles local state against the hash ring:
-
-1. Query s3db for the set of shards the hash ring places on this node.
-2. For each expected shard, look up the local Badger index.
-3. If absent, reconstruct the shard by fetching `K` valid shards from peers and RS decoding, then write the result as a new reservation locally.
-
-The healer uses pull-based reconciliation against the metadata plane, so it repairs both shards that failed mid-write and shards that never arrived (e.g. the node was offline during the original PUT). A per-node in-memory recent-failures queue may optionally drive faster repair for known-bad shards without requiring a full ring scan.
-
----
-
-# 12. Cluster Evolution
-
-### Adding Nodes
-
-- Update hash ring → bump ringEpoch
-- New writes use new epoch
-- Old objects remain on old epoch
-- Background rebalancer optional
-
-### Changing RS Configuration
-
-- Mixed RS(2,1) and RS(3,2) allowed as per design
-- RS config encoded into Badger KV to determine configuration
-- New objects can switch RSConfig
-- Old objects can be migrated in background
-
----
-
-# 13. Security
-
-## TLS/HTTPS
-
-All communication uses TLS:
-- s3db server uses HTTPS with configurable certificates
-- The Raft transport (`raft_port`) is TLS-wrapped using the same cert/key pair; peers verify the server cert against the OS trust store
-- The QUIC RPC transport between s3d and shard nodes verifies the server cert against the OS trust store (no `InsecureSkipVerify`)
-- Certificate paths come from the `[[host]]` table (`tls_cert` / `tls_key`), shared by the S3 API and every node's QUIC socket on that host. TLS is host-scoped by design: SANs carry no port, so nodes colocated on a machine are indistinguishable to TLS. Per-node (mTLS) client auth is not implemented.
-## Authentication
-
-- S3 API uses AWS Signature V4 authentication
-- s3db uses AWS Signature V4 authentication
-- Credentials defined in `[[db]]` or `[[auth]]` sections
-- All database operations require valid signatures
-
-## Encryption at Rest
-
-Every shard fragment is sealed under AES-256-GCM before it touches disk — see §6 ("Encryption-at-Rest") for the on-disk format, AAD, and nonce construction. Operationally:
-
-- **Master key.** One 32-byte AES-256 key per cluster, loaded from a file path supplied via `-encryption-key-file` / `ENCRYPTION_KEY_FILE`. The loader is fail-closed on permissions: any group/other-readable mode (`mode & 0077 != 0`) is rejected with no override — `chmod 600` is mandatory. The same key MUST be configured on every node; rotation is out of scope for the current implementation.
-- **No plaintext on disk.** Both `s3d` and `quicd` refuse to start without a key path; `store.Open` errors without `WithAEAD`. There is no unencrypted code path to fall back to.
-- **Logging.** The raw key is never logged. Operators identify a key by its fingerprint (`hex(sha256(key)[:8])`, 16 hex chars), logged once at `Server.init` and at QUIC server startup.
-- **In scope.** Confidentiality and integrity against an attacker reading or modifying segment files; detection of fragment shuffling within or across shards / data dirs on the same master key.
-- **Out of scope.** Compromise of a node host with the live master key in memory; per-bucket / per-tenant keys; KMS integration; key rotation; migration of existing unencrypted data (clusters must start fresh against the new segment magic); encryption of the s3db (BadgerDB) index.
-
----
-
-# 14. Deployment Modes
-
-One process runs one host. `-host` selects the `[[host]]` this process is, and the process runs every `[[node]]` pinned to it — the S3 gate among them — as goroutines under a single context. There is no separate dev mode and no per-node binary: `predastore.Run(ctx, opts)` builds the nodes, serves until the context is cancelled or a node fails, then drains what it started.
-
-## Development Mode (Single Host)
-
-Put every node on one host and the whole cluster is one process. Its nodes reach each other over the in-process pipe, so it opens no network socket for rpc and needs no TLS keypair at all:
-
-```bash
-./bin/s3d -config cluster.toml -host 1 -encryption-key-file /etc/predastore/master.key
-```
-
-## Production Mode (Multi-Host)
-
-Spread the nodes across hosts and run the same command per machine, each naming its own host id. Which transport a pair uses follows from the config: same host is a pipe, different hosts is QUIC. Nothing in the deployment names a transport.
-
-```bash
-# Host 1: gate + meta replica
-./bin/s3d -config cluster.toml -host 1 -encryption-key-file /etc/predastore/master.key
-
-# Host 2: shard storage + meta replica
-./bin/s3d -config cluster.toml -host 2 -encryption-key-file /etc/predastore/master.key
-
-# Host 3: shard storage + meta replica
-./bin/s3d -config cluster.toml -host 3 -encryption-key-file /etc/predastore/master.key
-```
-
-## Default Embedded Database
-
-When no `[[db]]` configuration is provided and the distributed backend is used, s3d automatically launches a default embedded database:
-- Listens on `127.0.0.1:6660`
-- Data stored in `<base_path>/db/` or `data/db/`
-- Uses credentials from first `[[auth]]` entry or defaults to `predastore:predastore`
-
----
-
-# 15. Configuration Reference
-
-## Database Node Configuration
+One TOML file, meant to be identical on every machine. The settings only the local machine cares about — its data directory, TLS identity and encryption key — may be omitted and supplied as flags instead. Parsing is strict: an unknown key is either a typo or a setting this build dropped, and both otherwise read as configured until something misbehaves.
 
 ```toml
-# Specify distributed database nodes
-[[db]]
-id = 1
-host = "192.168.1.10"      # Bind address (can be 0.0.0.0)
-port = 6660                # HTTPS API port
-raft_port = 7660           # Optional, defaults to port + 1000
-advertise_host = ""        # Optional: address to advertise (see below)
-path = "/data/db/node-1/"
-leader = true              # Bootstrap leader hint
-access_key_id = "AKIAIOSFODNN7EXAMPLE"
-secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+version = 1                     # no migrations: a format change rewrites the file
+region  = "ap-southeast-2"      # required; the credential scope requests are compared against
 
-[[db]]
-id = 2
-host = "192.168.1.11"
-port = 6660
-path = "/data/db/node-2/"
-access_key_id = "AKIAIOSFODNN7EXAMPLE"
-secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-
-[[db]]
-id = 3
-host = "192.168.1.12"
-port = 6660
-path = "/data/db/node-3/"
-access_key_id = "AKIAIOSFODNN7EXAMPLE"
-secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-```
-
-### Port Configuration
-
-Each database node uses two ports:
-
-| Port | Purpose | Default |
-|------|---------|---------|
-| `port` | HTTPS REST API for client requests | 6660 |
-| `raft_port` | TLS-wrapped TCP for Raft consensus (leader election, log replication) | `port + 1000` (e.g., 7660) |
-
-The Raft transport is TLS-protected using the same `-tls-cert` / `-tls-key` pair as the HTTPS S3 API and s3db REST listener. Peers verify the server cert against the OS trust store (cluster CA installed via `update-ca-certificates`); s3db refuses to start without a cert/key pair — there is no plaintext fallback. Mutual TLS (peer client-cert auth) is deferred to a follow-up bead.
-
-### Bind vs Advertise Address
-
-Raft requires two addresses:
-- **Bind Address**: Where the node listens (can be `0.0.0.0` to accept connections on any interface)
-- **Advertise Address**: What the node tells other nodes to connect to (must be reachable)
-
-```toml
-[[db]]
-id = 1
-host = "0.0.0.0"              # Bind to all interfaces
-advertise_host = "10.0.1.5"   # Tell other nodes to connect here
-port = 6660
-```
-
-**Important**: If `host` is `0.0.0.0` and `advertise_host` is not set, it defaults to `127.0.0.1`. For multi-machine clusters, always set `advertise_host` to the reachable IP address.
-
-## Host and Node Configuration
-
-The cluster is two tables. `[[host]]` is a machine: one s3d process, one data directory, one TLS identity. `[[node]]` is a role pinned to a host, running inside that host's process on its own port.
-
-```toml
-[[host]]
-id = 1
-bind_addr = "0.0.0.0"          # local listen address, no port
-public_addr = "10.11.12.1"     # what peers dial, no port
-data_dir = "/data/predastore/host-1"
-tls_cert = "/etc/predastore/server.pem"
-tls_key  = "/etc/predastore/server.key"
-
-[[host]]
-id = 2
-bind_addr = "0.0.0.0"
-public_addr = "10.11.12.2"
-data_dir = "/data/predastore/host-2"
-tls_cert = "/etc/predastore/server.pem"
-tls_key  = "/etc/predastore/server.key"
-
-[[node]]
-id = 1
-host_id = 1
-role = "gate"               # S3 frontend
-port = 443                     # the S3 port
-
-[[node]]
-id = 2
-host_id = 1
-role = "meta"
-port = 6661
-
-[[node]]
-id = 3
-host_id = 2
-role = "blob"
-port = 6662
-```
-
-### Addresses
-
-Host addresses carry no port. A node's port comes from its own `[[node]]` entry and must be unique within its host, because a node binds its own socket rather than sharing the host's. `bind_addr` is where the host's sockets listen — `0.0.0.0` for every interface — and `public_addr` is the literal address a peer observes, which is also what an accepted connection is matched against when the pool decides whether to keep it. A hostname or a NAT between hosts resolves to nothing there and the connection is simply not pooled.
-
-### Roles
-
-| Role | Purpose |
-|------|---------|
-| `gate` | Serves the S3 API. Its `port` is the S3 port; its rpc transports bind ephemerally, since nothing dials a gate and it therefore listens on no rpc socket. |
-| `meta` | Participates in Raft consensus over global state. Dials its peers and is dialed by them, so one pooled connection serves both directions. |
-| `blob` | Stores erasure-coded shards. Never dials, so it holds no pool. |
-
-The gate is a node with a role, not a per-host special case. A host may declare at most one — two would be two S3 endpoints answering for one machine — and a host declaring none simply serves no S3 API.
-
-### TLS
-
-`tls_cert` / `tls_key` belong to the host, not the node, and serve both the S3 API and the QUIC rpc sockets of every node on it. Host granularity is what TLS can express — SANs carry no port, so two nodes on one machine are indistinguishable to TLS regardless. Both fields are optional: a cluster whose nodes all sit on one host opens no QUIC socket and needs no keypair.
-
-## Reed-Solomon Configuration
-
-```toml
 [rs]
-data = 3
-parity = 2
+data   = 2
+parity = 1
+
+# [compaction]
+# interval_seconds = 300        # zero uses the engine default; compaction is never off
+
+[[host]]
+id   = 1
+addr = "10.11.12.1"             # what peers dial; no port — nodes carry those
+# bind_addr      = "10.11.12.1" # where raft and blob listen; defaults to addr
+# data_dir       = "/var/lib/predastore"
+# encryption_key = "/etc/predastore/master.key"
+# tls_cert       = "/etc/predastore/server.pem"
+# tls_key        = "/etc/predastore/server.key"
+
+  [[host.node]]
+  id   = 1
+  role = "gate"                 # the S3 endpoint; port is the S3 port
+  port = 8443
+  # bind_addr = "0.0.0.0"       # where S3 listens; gate only, defaults to the host's
+
+  [[host.node]]
+  id   = 2
+  role = "meta"
+  port = 6660
+
+  [[host.node]]
+  id   = 3
+  role = "blob"
+  port = 9991
+  # data_dir = "/mnt/disk1"     # per-node, so blob nodes can sit on separate disks
+
+[[auth]]
+access_key_id     = "AKIAIOSFODNN7EXAMPLE"
+secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+account_id        = "123456789012"
+
+# [[bucket]]
+# name       = "my-bucket"
+# region     = "ap-southeast-2"
+# account_id = "123456789012"
+# public     = false
+
+# [iam]
+# nats_url          = "nats://127.0.0.1:4222"
+# master_key_path   = "/etc/spinifex/master.key"
+# access_keys_bucket = "iam_access_keys"
+
+# [ratelimit]
+# enabled = true
+# rate    = 100
+# burst   = 200
 ```
 
-Requires 5 nodes, providing 3 data, and 2 parity bits for recovery.
+## Addresses
+
+Host addresses carry no port; a node's port comes from its own entry. `addr` is the literal address a peer observes, and is also what an accepted connection is matched against when the pool decides whether to keep it — so it may not be a wildcard or a multicast address. A hostname or a NAT between hosts resolves to nothing there, and such a connection is simply not pooled.
+
+## Two planes
+
+The S3 API is a public service and replication is not, so they bind separately:
+
+| Plane | Carries | Address |
+|---|---|---|
+| Cluster | Raft and blob traffic, over QUIC | The host's `bind_addr`, defaulting to `addr` |
+| Public | The S3 API, over HTTPS | The gate's own `bind_addr`, defaulting to the host's |
+
+On a multi-homed machine the host binds a private address and the gate binds `0.0.0.0`, so S3 answers on every interface while consensus and shard traffic stay on the interface peers actually use. Both may be a wildcard; neither is required, and a host naming only `addr` binds that one address for both. Only a gate may name one — the other roles have no listener of its own to point anywhere, and `Validate` rejects it.
+
+The defaults are the safe direction: a host that says nothing puts the cluster plane on `addr`, which is by construction the address peers dial and nothing wider.
+
+## What validation rejects
+
+Version mismatch, missing region, an erasure code that is absent or invalid, `parity = 0` at any width but 1, `data + parity` exceeding the blob node count, duplicate host or node ids, an unknown role, a missing or duplicated port within a host, a port on a host or node address, a wildcard `addr`, a relative path anywhere, a `data_dir` on a gate, a `bind_addr` on anything but a gate, two gates on one host, two nodes deriving the same data directory, and two nodes at the same address. A malformed bucket name is dropped with a warning rather than being fatal, since the rest of the config is still serviceable.
+
+## Dev profiles
+
+`config/` ships three ready-made layouts driven by `scripts/start.sh`. `1host` is one process over the pipe at RS(1,0); `3host` and `5host` put every host on one machine behind loopback aliases at RS(2,1) and RS(3,2), so they need `sudo` for the aliases and the trust anchor.
 
 ---
 
-# 16. Developer Reference
+# 13. Failure handling
 
-## Key Files
+## Read path
 
-| File | Purpose |
-|------|---------|
-| `s3db/config.go` | Cluster configuration, port calculation, advertise addresses |
-| `s3db/raft.go` | RaftNode implementation, leader election, consensus |
-| `s3db/fsm.go` | Finite State Machine, applies commands to BadgerDB |
-| `s3db/server.go` | HTTPS REST API, routes, authentication middleware |
-| `s3db/client.go` | Client for connecting to s3db cluster |
-| `store/store.go` | Store: segment cache, extent reservation, fragNum high-water reservation, index commits, `WithAEAD` option |
-| `store/segment.go` | Segment file format, header (magic `S3SE`), `flagFull` rollover |
-| `store/fragment.go` | Per-fragment layout, AES-256-GCM `seal` / `open`, AAD + nonce construction |
-| `store/writer.go` | Per-shard writer: buffered fragment assembly, in-place seal, lock-free `WriteAt`, fsync, commit |
-| `store/reader.go` | Per-shard reader: extent → batched seg.ReadAt → in-place GCM Open, `ErrIntegrity` on tag failure |
-| `store/state.go` | Persistent counters + `storeID` (`state.json`, atomic + fsync'd) |
-| `store/extent.go` | Extent record + encoding for the per-node Badger index |
-| `internal/keyfile/keyfile.go` | Master-key loader (32-byte, fail-closed on loose perms) + `Fingerprint` for log-safe key identification |
-| `backend/distributed/globalstate.go` | GlobalState interface, LocalState, DistributedState |
-| `backend/distributed/put.go` | PUT object implementation |
-| `backend/distributed/get.go` | GET object implementation |
-| `backend/distributed/list.go` | LIST operations implementation |
-| `backend/distributed/delete.go` | DELETE object implementation |
-| `quic/quicserver/put.go` | QUIC handler for shard PUT (calls `store.Append` + writer) |
-| `quic/quicserver/get.go` | QUIC handler for shard GET (calls `store.Lookup` + reader) |
-| `quic/quicserver/delete.go` | QUIC handler for shard DELETE (calls `store.Delete`) |
+| Failure | Detected as | Response |
+|---|---|---|
+| No index row for the shard | `not-found` from the blob node | The join fails; the gate refetches with parity and reconstructs |
+| Fragment fails its GCM tag | `ErrIntegrity` | Same. Covers corruption, tampering, fragment swaps and a wrong master key indistinguishably |
+| Node unreachable or slow | Stream error or deadline | Same |
+| Fewer than `K` valid shards | Reconstruction fails | 500 to the client |
+| Object metadata missing | Meta read fails | 404 `NoSuchKey` |
 
-## Raft Tuning Parameters
+A shard written to disk but never committed is indistinguishable from one that was never attempted. Both are absent, and the commit invariant is what guarantees readers cannot observe a partial write.
 
-```go
-// Default configuration in s3db/config.go
-HeartbeatTimeout:   1000 * time.Millisecond  // Leader heartbeat interval
-ElectionTimeout:    1000 * time.Millisecond  // Follower timeout before election
-CommitTimeout:      50 * time.Millisecond    // Max time to wait for commit
-SnapshotInterval:   120 * time.Second        // How often to check for snapshot
-SnapshotThreshold:  8192                     // Log entries before snapshot
-TrailingLogs:       10240                    // Logs to keep after snapshot
-LeaderLeaseTimeout: 500 * time.Millisecond   // Leader step-down if no contact
-```
+## Write path
 
-## Common Patterns
+| Failure | Response |
+|---|---|
+| Any shard write fails | 500, or 507 `InsufficientStorage` when a node was full |
+| Free space below the nearfull watermark | Write succeeds, `X-Predastore-Pool-Pressure: nearfull` returned, compaction kicked |
+| Meta write cannot reach a leader | Retried across replicas, then 500 |
+| Crash between shard commit and meta commit | The object does not exist; its shards are orphaned (see §15) |
 
-```go
-// Creating a distributed state client
-state, err := distributed.NewDistributedState(&distributed.DBClientConfig{
-    Nodes:           []string{"127.0.0.1:6660", "127.0.0.1:6661"},
-    AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
-    SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-    Region:          "us-east-1",
-})
+## Cluster
 
-// Storing object metadata
-objectHash := s3db.GenObjectHash(bucket, key)
-err := state.Set("objects", objectHash[:], metadataBytes)
-
-// Listing objects by prefix
-err := state.Scan("objects", []byte("arn:aws:s3:::mybucket/"), func(key, value []byte) error {
-    // Process each object
-    return nil
-})
-```
+A meta quorum loss stops all writes and leaves reads serving whatever the surviving replicas last applied. Losing up to `M` blob nodes leaves every object readable; losing more than `M` loses the objects placed on them. Nothing currently re-replicates a shard after a node is replaced.
 
 ---
 
-# 17. Tunable Parameters
+# 14. Developer reference
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `fragBodySize` | 8 KiB | Fragment body size on disk (GCM ciphertext, same length as plaintext) |
-| `fragHeaderSize` | 32 B | Per-fragment header (`FragNum`, `ShardNum`, two reserved slots, `Size`, `Flags`) |
-| `fragTagSize` | 16 B | AES-256-GCM authentication tag per fragment |
-| `totalFragSize` | 8240 B | header + body + tag, fixed on-disk fragment unit |
-| `maxSegSize` | 4 GiB | Maximum segment file size before rollover |
-| `fragNumReservation` | 1 048 576 | fragNum batch durably reserved in `state.json` per fsync; bounds wasted nonce space per crash |
-| `bufLen` | 32 fragments | Per-shard writer/reader window: amortises `WriteAt` / `ReadAt` syscalls (≈ 256 KiB RAM per active stream) |
-| RS schemes | RS(2,1) / RS(3,2) | Erasure coding configuration |
-| Hash ring vnodes | 64–256 | Virtual nodes for distribution |
-| QUIC concurrent streams | 1000 | Per-connection incoming stream limit, identical on the dial and listen sides |
-| QUIC flow-control windows | see `internal/transport/quic.go` | Receive window sizes (stream and connection) |
+## Package map
+
+| Path | Purpose |
+|---|---|
+| `predastore.go`, `config.go` | The module's public surface: `Options`, `Run`, `Config`, `LoadConfig`, and the conversions from the file into each subsystem's settings |
+| `cmd/s3d` | Flags, telemetry, signal context |
+| `internal/config` | TOML parsing and validation; the `HostID`/`NodeID`/`Role` vocabulary |
+| `internal/gate` | HTTPS listener, middleware chain, route table, credential chain |
+| `internal/gate/handlers` | The S3 operations, one factory per operation |
+| `internal/gate/model` | Stored record shapes, error taxonomy, name validation, object hashing, table names |
+| `internal/gate/auth` | Config and NATS-KV credential providers, chained |
+| `internal/gate/placement` | The consistent hash ring |
+| `internal/gate/chunked` | `aws-chunked` transfer decoding |
+| `internal/meta` | Raft replica, FSM, snapshots, rpc handlers, client |
+| `internal/blob` | Shard rpc service and client |
+| `internal/blob/engine` | Segments, fragments, extents, index, tombstones, compaction, encryption |
+| `internal/rpc` | Resolver, connection pool, stream framing, mux and server |
+| `internal/transport` | The pipe and QUIC transports behind one interface |
+| `pkg/masterkey` | Master key loading, AEAD construction, fingerprints |
+| `pkg/sigv4`, `pkg/iampolicy`, `pkg/auth` | Signature verification, policy evaluation, ARNs |
+| `pkg/ratelimit`, `pkg/otelsetup` | Throttling and telemetry |
+
+## Key files
+
+| File | Why you would open it |
+|---|---|
+| `predastore.go` | How a host's nodes get built and started |
+| `internal/config/config.go` | Every rule the config file is held to |
+| `internal/rpc/resolver.go` | How a node id becomes an address |
+| `internal/rpc/pool.go` | Connection reuse and the simultaneous-open tiebreak |
+| `internal/gate/routes.go` | The S3 route table |
+| `internal/gate/handlers/shards.go` | Erasure coding, shard fan-out, reconstruction |
+| `internal/gate/handlers/meta.go` | The table-prefix convention over the flat key-value store |
+| `internal/meta/streamlayer.go` | Raft over rpc streams |
+| `internal/meta/fsm.go` | Command apply, snapshot format, restore |
+| `internal/blob/engine/store.go` | Reservation, commit, delete, tombstones |
+| `internal/blob/engine/fragment.go` | The on-disk fragment layout, seal and open |
+| `internal/blob/engine/compaction.go` | Candidate selection and relocation |
+| `internal/blob/engine/state.go` | The crash-safe counter and `storeID` handling |
+
+## Tunables
+
+| Constant | Value | Where |
+|---|---|---|
+| `fragBodySize` | 8 KiB | `engine/fragment.go` |
+| `totalFragSize` | 8240 B | header 32 + body 8192 + tag 16 |
+| `bufLen` | 32 fragments | Per-stream read/write window, ≈ 256 KiB |
+| `DefaultMaxSegSize` | 4 GiB | Segment roll threshold |
+| `fragNumReservation` | 1 048 576 | fragNums per durable reservation |
+| `defaultCompactionInterval` | 5 min | Overridden by `[compaction] interval_seconds` |
+| `compactionLiveThreshold` | 0.70 | Live-byte fraction below which a segment is a candidate |
+| `defaultNearfullFreeFrac` | 0.15 | Kicks compaction, flags pressure |
+| `defaultFullFreeFrac` | 0.05 | Rejects writes with `ErrStoreFull` |
+| `statfsThrottleInterval` | 1s | Free-space check throttle |
+| `statfsBytesInterval` | 64 MiB | Forces a check regardless of the throttle |
+| `maxSegmentScanAttempts` | 100 | Bound on the walk for a non-full segment |
+| `maxHeaderSize` | 1 MiB | rpc stream header cap |
+| QUIC streams | 1000 | Identical on the dial and listen sides |
+| Ring partitions / replication / load | 5 / 100 / 1.25 | `gate/placement` |
+| `maxParallelPartFetches` | 10 | Multipart completion fan-out |
+
+## Working on it
+
+```bash
+make build            # GOFIPS140=v1.0.0 go build -o ./bin/s3d ./cmd/s3d
+make certs            # dev TLS certs the integration tests serve
+make test             # unit tests
+make preflight        # what CI runs: lint, govulncheck, coverage, integration
+make fix              # auto-fix what the linter can
+./scripts/start.sh -w 1host   # a running cluster on https://127.0.0.1:8443
+./scripts/stop.sh ; ./scripts/clean.sh
+./scripts/bench.sh 3host      # or `disk` for the engine alone
+```
+
+`make preflight` must pass before committing.
 
 ---
 
-This file covers the engineering rationale and architecture of Predastore. For gaps between this design and the current codebase, and for longer-horizon work, see [TODO.md](./TODO.md).
+# 15. Known gaps
+
+Things the design implies but the code does not do. Longer-horizon items live in [TODO.md](./TODO.md).
+
+**No repair.** Nothing reconstructs a shard that a node lost or never received. A GET rebuilds the object on the fly from parity, but does not write the missing shard back, and there is no background healer reconciling a node's contents against the ring. Replacing a blob node therefore leaves every object it held permanently down one shard until it is rewritten.
+
+**No index rebuild.** If a blob node's badger index is lost, its data is unreachable through that node. The `.idx` sidecars do record the key of every extent ever allocated, so a rebuild is mechanically possible — but no such path is implemented, and the extents would still need validating against the index that decides which of several allocations for a key is live.
+
+**Orphaned shards after a crash.** Shards commit before metadata. A crash in between leaves shards that nothing references and nothing tombstones, so compaction never reclaims them. A startup scrubber reconciling a node's index against the metadata plane would close this.
+
+**No rebalancing.** Adding a blob node changes the ring for new objects only. Existing objects stay where they were placed, and nothing migrates them. Changing the erasure code likewise applies to new objects only, and old objects are read at the width recorded in their placement.
+
+**Two Raft round-trips per PUT.** The placement and the listing key are written separately. A batched apply would halve the metadata cost of a write.
+
+**ETags are derived from the name, not the content.** `ObjectETag` is the first half of `sha256("bucket/key")`, hex encoded. It identifies the object but not its version, so a client cannot use it to detect that an object changed.
+
+**Listings are not paginated.** `ListObjects` scans and returns everything under the prefix, always reporting `IsTruncated: false` and a max-keys of 1000 it does not enforce. `LastModified` is not stored and is reported as the current time.
+
+**No multi-object delete.** `POST /{bucket}?delete=` has no route and returns 405.
+
+**No key rotation.** One cluster-wide master key, no envelope layer, no per-bucket or per-tenant keys, and no migration path for data written under a different key.
+
+**Whole objects are buffered in memory.** Both the PUT and GET paths hold the full object, and multipart completion additionally stages the assembled object through a temp file.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,125 +1,151 @@
 # Predastore Roadmap
 
-Gaps between [DESIGN.md](./DESIGN.md) and the current codebase, plus longer-horizon work. DESIGN covers the intended architecture and rationale; this file tracks the distance to it.
+Work not yet done. [DESIGN.md](./DESIGN.md) describes what the code does today, and its §15 lists the gaps between that and the intended architecture; this file is the plan for closing them, plus longer-horizon work.
 
-Items become `bd` issues when claimed. Priority below is rough ordering, not a queue.
+Items become `bd` issues when claimed. The ordering below is rough priority, not a queue.
 
 ---
 
 ## Performance
 
-The lock-free segment write path is sound at 3-node, c=10, 1 MiB warp-mixed: PUT ~53 MiB/s, p50 ~83 ms. Per-PUT timing instrumentation (since reverted) showed the floor is **two synchronous Raft writes** (`globalState.Set` ×2) to the s3db cluster on the critical path of every PUT, ~40 ms median combined. The per-shard segment fsync (~9 ms) and per-node store-index Badger writes (~60 µs) are not the bottleneck. Items below are ordered by expected ROI.
+The measurements below were taken on the pre-refactor tree (3 nodes, warp mixed, c=10, 1 MiB objects): PUT ~53 MiB/s, p50 ~83 ms. Per-PUT instrumentation put the floor at **two synchronous Raft commits** on the critical path of every PUT, ~40 ms median combined. The per-shard segment fsync (~9 ms) and the per-node index writes (~60 µs) were not the bottleneck.
 
-### Raft-side BatchSet for metadata commits
+Transport and package names have changed since — the two commits are now `metaPut` calls from `internal/gate/handlers/put_object.go` — but nothing in the refactor moved the metadata commits off the critical path, so the ordering below still holds. Re-measure with `./scripts/bench.sh 3host` before claiming any of it.
 
-S3 PutObject commits two keys to the s3db cluster after shards land: `objectHash → shard metadata` and `arnKey → objectHash`. Today they go as two separate `client.Put` calls — two Raft round-trips, two majority fsyncs. Add a server-side batch endpoint and route both keys through a single Raft proposal.
+### Batch the two metadata commits
 
-- Extend `s3db.Client` with a batch Put.
-- Add the matching FSM apply (single `Update` txn writing both keys).
-- Wire `GlobalState.BatchSet` (interface already sketched and reverted) through `DistributedState`.
-- Update `PutObject` and `CompleteMultipartUpload` callers.
+`PutObject` writes two keys after the shards land: `objects/<hash> → placement` and `objects/<arn> → hash`. They go as two separate `Put` calls, which is two Raft round-trips and two majority fsyncs for one object.
 
-Expected savings: ~20 ms median per PUT (one Raft round-trip).
+- Add a batch opcode alongside `OpMetaPut`, carrying several key-value pairs in one header.
+- Add the matching FSM command type, applying all pairs in a single badger `Update` txn.
+- Extend `meta.Client` with the batch call, and route both keys through it.
+- Update `PutObject` and `CompleteMultipartUpload`.
 
-### Eliminate the per-PUT temp file in `distributed.PutObject`
+Expected saving: ~20 ms median per PUT, one Raft round-trip.
 
-The body is currently spooled to `/tmp/distributed-put-*`, then re-opened inside `putObjectViaQUIC` and read back to populate `dataShardBuffers` for RS split. On tmpfs this is invisible; on a real disk it's two unnecessary disk hops on every PUT. Stream the request body directly into the data shard buffers (the RS streaming encoder accepts an `io.Reader`).
+### Overlap the parity send with the data send
 
-- Remove `os.CreateTemp` + `io.Copy(tmpFile, reader)` from `PutObject`.
-- Pass the body reader to a new `putObjectViaQUIC` signature that takes `io.Reader` and `size int64` instead of a path.
-- Make the existing `bytesBufferWriter` path the only path.
+In `writeObject` (`internal/gate/handlers/shards.go`), the parity goroutines and `enc.Encode` only start once every data shard has finished uploading, even though the encoder reads the already-populated `dataShardBuffers` and the parity sends are independent of the data sends.
 
-### Overlap parity send with data send
+- Spawn the parity goroutines and start `enc.Encode` as soon as `enc.Split` returns, in parallel with the data-shard send loop.
+- Wait on both sets at the end, keeping the current first-error semantics.
 
-In `putObjectViaQUIC`, parity goroutines and `enc.Encode` start only after all data shards have fully uploaded, even though the encoder reads the already-populated `dataShardBuffers` and the parity sends are independent of data sends.
-
-- Spawn parity goroutines + start `enc.Encode` immediately after `enc.Split` returns, in parallel with the data-shard send loop.
-- Wait on both sets at the end.
-
-Expected savings: ~20 ms on `quic_us` median.
+Expected saving: ~20 ms median.
 
 ### Async metadata commit
 
-Largest single lever. Reply 200 OK to the client after QUIC shards commit; write `globalState` metadata in a background goroutine. Removes the full ~40 ms metadata Raft cost from the critical path.
+The largest single lever, and the one with the most surface area. Reply 200 once the shards commit and write the metadata in the background, taking the whole ~40 ms Raft cost off the critical path.
 
-- Cost: a crash window between shard commit and metadata commit leaves orphaned shards. Needs a startup scrubber that scans the per-node store index, reconciles against the metadata table, and either backfills missing metadata or garbage-collects orphans.
-- Likely the right answer long-term, but bigger surface area than the items above.
+- Requires the orphan scrubber below: the crash window between shard commit and metadata commit becomes routine rather than exceptional.
+- Worth doing after the batch commit lands, since batching halves the cost this removes.
 
-### Periodic fsync (deferred)
+### Periodic fsync
 
-Originally tracked as Stage 3 of the store rewrite. Bench data shows the per-close `seg.Sync()` costs ~9 ms median latency but is **not** the throughput cap (removing it entirely tied throughput, while p99 latency got 4× worse from kernel writeback storms). A 200 ms periodic syncer would likely be a Pareto improvement on latency without hurting p99, but the throughput payoff is small relative to the Raft items above. Reorder once those land.
+`shardWriter.Close` fsyncs the segment per value (`internal/blob/engine/writer.go`). Bench data showed this costs ~9 ms median but is **not** the throughput cap: removing it entirely tied throughput while p99 got 4× worse from kernel writeback storms. A 200 ms periodic syncer would likely be a Pareto improvement on latency without hurting p99, but the payoff is small next to the Raft items.
 
 - Add a 200 ms ticker to `Store` that fsyncs dirty segments.
-- Drop `seg.Sync()` from `shardWriter.Close()`.
-- Final sync on `store.Close()`.
+- Drop `seg.Sync()` from `shardWriter.Close()`, keeping the `.idx` fsync ordering intact — the sidecar must still be durable before the index row commits.
+- Final sync on `Store.Close()`.
 
-### Deletion tracking in Store
+### Stop buffering whole objects in memory
 
-`store.Delete` removes the index entry but leaves the on-disk extent as dead space. Compaction needs a record of freed extents to reclaim them.
+The PUT path holds every data shard in memory before sending, and the GET path assembles the whole object before responding. Multipart completion additionally stages the assembled object through a temp file. Object size is therefore bounded by gate memory, and concurrency multiplies it.
 
-- Persist a freed-extents log (segment-local or store-global).
-- Surface it to the future compactor.
+- PUT: stream `enc.Split` output straight into the per-shard `Put` bodies rather than into `[]byte` buffers.
+- GET: stream the join to the response writer; only the reconstruction path needs the shards resident.
+- Multipart: concatenate parts into the shard writers directly instead of a temp file.
 
 ---
 
-## Design–Implementation Gaps
+## Design–implementation gaps
 
-### Background Compaction & Cold-Storage Tiering
+These are the items behind [DESIGN.md §15](./DESIGN.md#15-known-gaps).
 
-DESIGN §6 treats compaction as live; not implemented.
+### Node-local healer
 
-- Scan closed segments, rewrite live extents, reclaim dead space, atomically update index entries.
-- Migrate aged segments to long-term cold storage; rehydrate on demand during GET (rehydration may complete asynchronously with the GET).
+Nothing reconstructs a shard that a blob node lost or never received. A GET rebuilds the object from parity on the fly but does not write the missing shard back, so a replaced blob node leaves every object it held permanently down one shard.
+
+- Periodically ask the meta plane for the shards the ring assigns to this node, and reconstruct any that are locally absent by fetching `K` valid peers and RS decoding.
+- Write the result as a normal reservation, so a heal is indistinguishable from a write on disk.
+- Optionally feed an in-memory recent-failures queue from failed reads for faster repair.
+
+### Startup scrubber for orphaned shards
+
+Shards commit before metadata. A crash in between leaves shards that nothing references and nothing tombstones, so compaction never reclaims them. This is also the precondition for the async metadata commit above.
+
+- Walk the node's index, reconcile each key against the metadata plane, and either backfill the missing placement or tombstone the extent.
+- Needs care against in-flight writes: a key with no placement may be a PUT still in progress, not an orphan.
+
+### Index rebuild from the .idx sidecars
+
+If a blob node's badger index is lost, its data is unreachable through that node even though the bytes are intact. The `.idx` sidecars record the 36-byte key of every extent ever allocated, so a rebuild is mechanically possible.
+
+- Walk each segment's sidecar, validate each extent by opening its first fragment (a failed GCM tag rejects a torn or superseded row), and rebuild the index rows.
+- Resolve duplicate allocations for one key: the sidecar records every allocation, including the ones an overwrite superseded, and only one is live.
+- Rebuild the tombstone namespace as dead space rather than trying to recover it.
+
+### Cold-storage tiering
+
+Compaction is implemented and always on; tiering is not.
+
+- Migrate aged segments to long-term cold storage, rehydrating on demand during a GET (rehydration may complete asynchronously with the GET).
 - Policy for "aged" and "cold" is TBD.
 
-### Node-Local Healer
+### Envelope encryption and key rotation
 
-DESIGN §11 describes pull-based repair; not implemented.
-
-- Periodically query s3db for ring-assigned shards; reconstruct any that are absent locally by fetching `K` valid peers and RS decoding, writing the result as a new reservation.
-- Optional in-memory recent-failures queue for faster repair.
-
-### Envelope Encryption (Master Key Rotation)
-
-The current encryption-at-rest implementation uses a single cluster-wide master key with no rotation. Rotating the master would require re-encrypting every fragment, which is not viable.
+One cluster-wide master key, no envelope layer. Rotating it would mean re-encrypting every fragment, which is not viable.
 
 - Introduce a per-data-dir derived key wrapped by a true cluster master held in NATS KV; rotating the master re-wraps the derived keys without re-encrypting any ciphertext.
-- Per-bucket / per-tenant keys ride the same envelope layer.
-- Collapses the cluster-wide `storeID` collision domain (each data dir gets its own per-key collision space).
+- Per-bucket and per-tenant keys ride the same envelope layer.
+- Collapses the cluster-wide `storeID` collision domain, since each data dir gets its own per-key nonce space.
 
-### Formal Verification Harness
+### Extend the property-based harness past the engine
 
-Reference model + stateful PBT against the QUIC server + Store.
+`internal/storetest` holds a reference model and `internal/blob/engine` drives it with `rapid`, including fault injection. The layers above it are not covered.
 
-- Reference model in Go (~50 lines): state is `committed: map[ShardID]ShardBytes`; ops `Append`/`Write`/`Close`/`Lookup`/`Read`.
-- Driver via `pgregory.net/rapid`.
-- Invariant: reads see a linearisation of commits, nothing else.
-- Scope: QUIC server + Store only. s3db and the S3 API layer are out of scope for this first pass.
+- Extend the model through the blob rpc server, so the protocol framing and the range paths are exercised against the same invariant.
+- A separate model for the meta FSM: apply, snapshot and restore should round-trip arbitrary binary keys and values.
+- Invariant throughout: reads see a linearisation of commits, and nothing else.
 
 ---
 
 ## S3 API
 
-- `POST /{bucket}?delete=` (S3 batch DeleteObjects). Currently returns 405 because no route exists; warp's mixed test cleanup hits it. Routing-only change.
-- Unit tests for put/get/list/delete without the correct permission set.
-- Auth header session invalidation after 15 minutes.
-- Checksum support (CRC32, crc64nvme, etc.) for `aws s3 cp` and multipart.
-- `DeleteBucket`.
+- `POST /{bucket}?delete=` (batch DeleteObjects). Returns 405 because no route exists; warp's mixed-test cleanup hits it. Routing plus a fan-out over the existing single-object delete.
+- **Pagination for `ListObjects`.** The handler scans and returns everything under the prefix, hardcodes `IsTruncated: false`, and does not enforce `max-keys`. A large bucket returns an unbounded response.
+- **`LastModified` is not stored.** Listings report the current time for every object. Needs a timestamp in the placement record, or a parallel metadata key.
+- **Content-derived ETags.** `ObjectETag` is `hex(sha256("bucket/key")[:16])`, so it identifies the object but never changes when the object does, and clients cannot use it to detect a modification. Needs the hash computed over the body during the split.
+- **Checksum support.** `internal/gate/chunked` computes CRC64NVME and can verify the trailer, but no handler calls `VerifyTrailerChecksum`, the `x-amz-checksum-*` request headers are not honoured, and `ChecksumCRC64NVME` in the multipart response is never populated.
+- **End-to-end authorization tests.** Policy evaluation is unit tested in `internal/gate/policy_test.go`, but no test drives PUT, GET, LIST or DELETE through the full handler stack with a credential that lacks the action.
 
 ---
 
-## Future Work
+## Future work
 
 Longer-horizon, not planned for this cycle.
 
-- **Process separation**: split `s3d` into independent HTTP, s3db (Raft), and QUIC storage binaries to enable independent scaling and reduce blast radius.
-- **Gossip protocol**: replace static `cluster.toml` with dynamic node discovery.
-- **Dynamic bucket operations**: create/delete buckets via s3db, not config.
-- **Cluster rebalancing**: redistribute shards on node join/leave or when the RS configuration changes.
-- **Read replicas**: serve reads from s3db followers.
+- **Cluster rebalancing**: redistribute shards on node join or leave, and when the RS configuration changes. Today the ring change applies to new objects only.
+- **Process separation**: run each node as its own process rather than as a goroutine inside one `s3d`, to reduce blast radius and let roles be scheduled independently. The rpc layer already makes this mostly a matter of how nodes are launched, since a colocated pair would simply move from the pipe transport to QUIC.
+- **Gossip protocol**: dynamic node discovery in place of a static config file on every host.
+- **mTLS between nodes**: client certificates so a peer is authenticated, not just the ALPN and the server certificate.
 - **Storage classes**: per-object redundancy selection.
 - **Object versioning**: S3-compatible versioning.
 - **Lifecycle policies**: automatic object expiration.
-- **Compression**: optional LZ4/Snappy applied by the compactor to closed WAL files.
+- **Compression**: optional LZ4/Snappy applied by the compactor to segments it rewrites.
 - **Event notifications**: S3-compatible hooks.
-- **Metrics & observability**: Prometheus, structured logging.
+- **Metrics**: `pkg/otelsetup` covers traces, metrics and structured logging; what is missing is coverage of the storage internals — segment counts, live fraction, compaction cycles, free-space watermarks.
+
+---
+
+## Recently closed
+
+Tracked here so an old reference to one of these is not mistaken for outstanding work.
+
+- **Background compaction** — `internal/blob/engine/compaction.go`. Always on, interval from `[compaction] interval_seconds`, with an out-of-cycle pass on nearfull.
+- **Deletion tracking** — tombstones keyed by physical slot, written in the same transaction as the index removal.
+- **The per-PUT temp file** — the body is split straight into the shard buffers. Only multipart completion still stages a temp file.
+- **`DeleteBucket`** — implemented, with the bucket record removed from the meta plane.
+- **Dynamic bucket operations** — `CreateBucket` and `DeleteBucket` write to the meta plane. Config-defined buckets remain as a static set known at startup.
+- **Read replicas** — `meta.Client` reads from the cached leader first and then any replica; only writes need the leader.
+- **Session expiry** — session credentials carry `ExpiresAt`, are never cached, and expiry is re-checked on every request.
+- **A reference model and property tests** — `internal/storetest` plus the `rapid` suites in `internal/blob/engine`, including fault injection.

--- a/docs/assets/blob-ondisk.svg
+++ b/docs/assets/blob-ondisk.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="662" viewBox="0 0 1000 662" role="img" aria-label="Predastore blob node on-disk format: a data directory of state.json, a badger index, append-only .seg segment files and their .idx sidecars; each segment is a 14-byte header followed by fixed 8240-byte fragments; each fragment is a 32-byte plaintext header, an 8192-byte AES-256-GCM ciphertext body and a 16-byte tag bound to the value's position.">
+<rect x="0" y="0" width="1000" height="662" rx="20" fill="#14181D" stroke="#2A2F36" stroke-width="1"/>
+
+<text x="28" y="42" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11.5" fill="#3FB950" font-weight="600" letter-spacing="2.5">BLOB NODE · ON-DISK FORMAT</text>
+<text x="972" y="42" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11.5" fill="#9AA1A8" text-anchor="end">append-only · fixed fragments · sealed at rest</text>
+<text x="28" y="72" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="21" fill="#F5F3EE" font-weight="800">A value is a contiguous extent of sealed fragments.</text>
+
+<rect x="28" y="88" width="944" height="112" rx="13" fill="#181D23" stroke="#2A2F36" stroke-width="1"/>
+<text x="48" y="112" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#9AA1A8" font-weight="700" letter-spacing="1.5">DATA DIRECTORY</text>
+<text x="952" y="112" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="end">one per blob node</text>
+<rect x="48" y="126" width="214" height="60" rx="8" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="62" y="147" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#3FB950">state.json</text>
+<text x="62" y="165" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="10.5" fill="#9AA1A8">segNum, valueNum, fragNum,</text>
+<text x="62" y="179" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="10.5" fill="#9AA1A8">fragNumHighWater, storeID</text>
+<rect x="278" y="126" width="214" height="60" rx="8" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="292" y="147" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#3FB950">db/</text>
+<text x="292" y="165" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="10.5" fill="#9AA1A8">badger index: key‖index → extent,</text>
+<text x="292" y="179" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="10.5" fill="#9AA1A8">plus the tombstone namespace</text>
+<rect x="508" y="126" width="214" height="60" rx="8" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="522" y="147" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#3FB950">0000000000000000.seg</text>
+<text x="522" y="165" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="10.5" fill="#9AA1A8">the fragments themselves,</text>
+<text x="522" y="179" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="10.5" fill="#9AA1A8">rolled at 4 GiB</text>
+<rect x="738" y="126" width="214" height="60" rx="8" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="752" y="147" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#3FB950">0000000000000000.idx</text>
+<text x="752" y="165" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="10.5" fill="#9AA1A8">52-byte rows: off ‖ key ‖ psize,</text>
+<text x="752" y="179" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="10.5" fill="#9AA1A8">what compaction enumerates</text>
+
+<rect x="28" y="216" width="944" height="124" rx="13" fill="#181D23" stroke="#2A2F36" stroke-width="1"/>
+<text x="48" y="240" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#9AA1A8" font-weight="700" letter-spacing="1.5">SEGMENT FILE</text>
+<text x="952" y="240" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="end">magic S3SE · version 1</text>
+<rect x="48" y="256" width="70" height="46" rx="6" fill="#3FB950" fill-opacity="0.14" stroke="#3FB950" stroke-width="1" stroke-opacity="0.4"/>
+<text x="83" y="275" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#3FB950" text-anchor="middle">header</text><text x="83" y="290" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#3FB950" text-anchor="middle">14 B</text>
+<rect x="118" y="256" width="154" height="46" rx="6" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="195" y="275" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#9AA1A8" text-anchor="middle">fragment 0</text><text x="195" y="290" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="middle">8240 B</text>
+<rect x="272" y="256" width="154" height="46" rx="6" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="349" y="275" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#9AA1A8" text-anchor="middle">fragment 1</text><text x="349" y="290" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="middle">8240 B</text>
+<rect x="426" y="256" width="154" height="46" rx="6" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="503" y="275" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#9AA1A8" text-anchor="middle">fragment 2</text><text x="503" y="290" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="middle">8240 B</text>
+<rect x="580" y="256" width="154" height="46" rx="6" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="657" y="275" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#9AA1A8" text-anchor="middle">fragment 3</text><text x="657" y="290" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="middle">8240 B</text>
+<rect x="734" y="256" width="218" height="46" rx="6" fill="none" stroke="#2A2F36" stroke-width="1" stroke-dasharray="3 4"/>
+<text x="843" y="275" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#9AA1A8" text-anchor="middle">… up to 4 GiB</text><text x="843" y="290" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="middle">then flagFull, roll to the next segment</text>
+<text x="48" y="324" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">One value occupies a contiguous run of fragments. Runs from different values share a segment but never interleave.</text>
+
+<rect x="28" y="356" width="944" height="150" rx="13" fill="#181D23" stroke="#3FB950" stroke-width="1" stroke-opacity="0.35"/>
+<text x="48" y="380" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#3FB950" font-weight="700" letter-spacing="1.5">FRAGMENT · 8240 B FIXED</text>
+<text x="952" y="380" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="end">32 + 8192 + 16</text>
+<rect x="48" y="396" width="180" height="46" rx="6" fill="none" stroke="#9AA1A8" stroke-width="1" stroke-opacity="0.5"/>
+<text x="138" y="415" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#9AA1A8" text-anchor="middle">header · 32 B</text><text x="138" y="431" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="9.5" fill="#5B636C" text-anchor="middle">plaintext, authenticated</text>
+<rect x="228" y="396" width="592" height="46" rx="6" fill="#3FB950" fill-opacity="0.14" stroke="#3FB950" stroke-width="1" stroke-opacity="0.4"/>
+<text x="524" y="415" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#3FB950" text-anchor="middle">body · 8192 B — AES-256-GCM ciphertext</text><text x="524" y="431" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="9.5" fill="#3FB950" text-anchor="middle">zero-padded before sealing when the payload is shorter</text>
+<rect x="820" y="396" width="132" height="46" rx="6" fill="#F5B500" fill-opacity="0.14" stroke="#F5B500" stroke-width="1" stroke-opacity="0.4"/>
+<text x="886" y="415" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#F5B500" text-anchor="middle">tag · 16 B</text><text x="886" y="431" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="9.5" fill="#F5B500" text-anchor="middle">GCM</text>
+<text x="48" y="466" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10.5" fill="#9AA1A8">header = fragNum(8) ‖ valueNum(8) ‖ reserved(4) ‖ size(4) ‖ flags(4) ‖ reserved(4)</text>
+<text x="48" y="486" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">The header must be readable before decryption, so it is plaintext — but it feeds the AAD, so tampering with it fails the tag.</text>
+
+<rect x="28" y="522" width="944" height="112" rx="13" fill="#181D23" stroke="#F5B500" stroke-width="1" stroke-opacity="0.35"/>
+<text x="48" y="546" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#F5B500" font-weight="700" letter-spacing="1.5">WHAT EACH FRAGMENT IS BOUND TO</text>
+<text x="952" y="546" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="end">reconstructed at read time</text>
+<text x="48" y="574" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#9AA1A8">nonce (12 B) = BE(fragNum) ‖ BE(storeID)</text>
+<text x="48" y="596" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#9AA1A8">aad   (52 B) = key(32) ‖ index(4) ‖ BE(valueNum) ‖ BE(fragNum)</text>
+<text x="48" y="620" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">storeID is random per data dir, so a fragment spliced between data dirs opens under the wrong nonce and fails.</text>
+</svg>

--- a/docs/assets/cluster-topology.svg
+++ b/docs/assets/cluster-topology.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="580" viewBox="0 0 1000 580" role="img" aria-label="Predastore cluster topology: S3 clients reach a gate node over HTTPS with Signature V4; each host is one s3d process running gate, meta and blob nodes that talk over an in-process pipe, while nodes on different hosts talk over QUIC.">
+<rect x="0" y="0" width="1000" height="580" rx="20" fill="#14181D" stroke="#2A2F36" stroke-width="1"/>
+
+<text x="28" y="42" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11.5" fill="#F5B500" font-weight="600" letter-spacing="2.5">PREDASTORE CLUSTER TOPOLOGY</text>
+<text x="972" y="42" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11.5" fill="#9AA1A8" text-anchor="end">one s3d process per host · roles pinned by config</text>
+<text x="28" y="72" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="21" fill="#F5F3EE" font-weight="800">A host is a process. A node is a role inside it.</text>
+
+<rect x="28" y="88" width="944" height="52" rx="13" fill="#181D23" stroke="#2A2F36" stroke-width="1"/>
+<text x="48" y="112" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#9AA1A8" font-weight="700" letter-spacing="1.5">S3 CLIENTS</text>
+<text x="48" y="130" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11.5" fill="#5B636C">Unmodified AWS tooling. No shims, no custom SDK.</text>
+<rect x="604" y="103" width="70" height="22" rx="7" fill="none" stroke="#2A2F36" stroke-width="1"/><text x="639" y="118" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#9AA1A8" text-anchor="middle">aws-cli</text>
+<rect x="684" y="103" width="84" height="22" rx="7" fill="none" stroke="#2A2F36" stroke-width="1"/><text x="726" y="118" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#9AA1A8" text-anchor="middle">AWS SDKs</text>
+<rect x="778" y="103" width="76" height="22" rx="7" fill="none" stroke="#2A2F36" stroke-width="1"/><text x="816" y="118" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#9AA1A8" text-anchor="middle">Spinifex</text>
+<rect x="864" y="103" width="88" height="22" rx="7" fill="none" stroke="#2A2F36" stroke-width="1"/><text x="908" y="118" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#9AA1A8" text-anchor="middle">Viperblock</text>
+
+<line x1="176" y1="140" x2="176" y2="172" stroke="#F5B500" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="170,170 182,170 176,179" fill="#F5B500" fill-opacity="0.6"/>
+<line x1="500" y1="140" x2="500" y2="172" stroke="#F5B500" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="494,170 506,170 500,179" fill="#F5B500" fill-opacity="0.6"/>
+<line x1="824" y1="140" x2="824" y2="172" stroke="#F5B500" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="818,170 830,170 824,179" fill="#F5B500" fill-opacity="0.6"/>
+<rect x="530" y="149" width="124" height="20" rx="10" fill="#F5B500" fill-opacity="0.14"/><text x="592" y="163" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#F5B500" text-anchor="middle">HTTPS · SigV4</text>
+
+<rect x="28" y="180" width="296" height="304" rx="13" fill="#181D23" stroke="#2A2F36" stroke-width="1"/>
+<text x="48" y="206" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12.5" fill="#F5F3EE" font-weight="700">host 1</text>
+<text x="304" y="206" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="end">addr 10.11.12.1</text>
+<line x1="48" y1="216" x2="304" y2="216" stroke="#2A2F36" stroke-width="1"/>
+<line x1="38" y1="250" x2="38" y2="416" stroke="#9AA1A8" stroke-width="1" stroke-opacity="0.35" stroke-dasharray="2 4"/>
+<line x1="38" y1="261" x2="48" y2="261" stroke="#9AA1A8" stroke-width="1" stroke-opacity="0.35"/><line x1="38" y1="333" x2="48" y2="333" stroke="#9AA1A8" stroke-width="1" stroke-opacity="0.35"/><line x1="38" y1="405" x2="48" y2="405" stroke="#9AA1A8" stroke-width="1" stroke-opacity="0.35"/>
+<rect x="48" y="230" width="256" height="62" rx="8" fill="#F5B500" fill-opacity="0.10" stroke="#F5B500" stroke-width="1.2" stroke-opacity="0.5"/>
+<text x="64" y="252" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12.5" fill="#F5B500" font-weight="700">gate</text><text x="288" y="252" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#9AA1A8" text-anchor="end">node 1 · :8443</text>
+<text x="64" y="270" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">S3 API · SigV4 · IAM · placement</text>
+<text x="64" y="284" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">erasure codes and reassembles objects</text>
+<rect x="48" y="302" width="256" height="62" rx="8" fill="#5AA9E6" fill-opacity="0.10" stroke="#5AA9E6" stroke-width="1.2" stroke-opacity="0.5"/>
+<text x="64" y="324" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12.5" fill="#5AA9E6" font-weight="700">meta</text><text x="288" y="324" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#9AA1A8" text-anchor="end">node 2 · :6660</text>
+<text x="64" y="342" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">Raft replica · bolt log · badger FSM</text>
+<text x="64" y="356" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">buckets, objects, uploads</text>
+<rect x="48" y="374" width="256" height="62" rx="8" fill="#3FB950" fill-opacity="0.10" stroke="#3FB950" stroke-width="1.2" stroke-opacity="0.5"/>
+<text x="64" y="396" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12.5" fill="#3FB950" font-weight="700">blob</text><text x="288" y="396" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#9AA1A8" text-anchor="end">node 3 · :9991</text>
+<text x="64" y="414" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">append-only segments · AES-256-GCM</text>
+<text x="64" y="428" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">one shard of each object placed here</text>
+<text x="48" y="462" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C">colocated → in-process pipe, no socket</text>
+
+<rect x="352" y="180" width="296" height="304" rx="13" fill="#181D23" stroke="#2A2F36" stroke-width="1"/>
+<text x="372" y="206" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12.5" fill="#F5F3EE" font-weight="700">host 2</text>
+<text x="628" y="206" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="end">addr 10.11.12.2</text>
+<line x1="372" y1="216" x2="628" y2="216" stroke="#2A2F36" stroke-width="1"/>
+<line x1="362" y1="250" x2="362" y2="416" stroke="#9AA1A8" stroke-width="1" stroke-opacity="0.35" stroke-dasharray="2 4"/>
+<line x1="362" y1="261" x2="372" y2="261" stroke="#9AA1A8" stroke-width="1" stroke-opacity="0.35"/><line x1="362" y1="333" x2="372" y2="333" stroke="#9AA1A8" stroke-width="1" stroke-opacity="0.35"/><line x1="362" y1="405" x2="372" y2="405" stroke="#9AA1A8" stroke-width="1" stroke-opacity="0.35"/>
+<rect x="372" y="230" width="256" height="62" rx="8" fill="#F5B500" fill-opacity="0.10" stroke="#F5B500" stroke-width="1.2" stroke-opacity="0.5"/>
+<text x="388" y="252" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12.5" fill="#F5B500" font-weight="700">gate</text><text x="612" y="252" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#9AA1A8" text-anchor="end">node 4 · :8443</text>
+<text x="388" y="270" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">every host may run at most one gate</text>
+<text x="388" y="284" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">nothing dials a gate: rpc binds ephemerally</text>
+<rect x="372" y="302" width="256" height="62" rx="8" fill="#5AA9E6" fill-opacity="0.10" stroke="#5AA9E6" stroke-width="1.2" stroke-opacity="0.5"/>
+<text x="388" y="324" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12.5" fill="#5AA9E6" font-weight="700">meta</text><text x="612" y="324" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#9AA1A8" text-anchor="end">node 5 · :6660</text>
+<text x="388" y="342" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">raft rides rpc streams, not its own port</text>
+<text x="388" y="356" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">advertise address is node-5</text>
+<rect x="372" y="374" width="256" height="62" rx="8" fill="#3FB950" fill-opacity="0.10" stroke="#3FB950" stroke-width="1.2" stroke-opacity="0.5"/>
+<text x="388" y="396" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12.5" fill="#3FB950" font-weight="700">blob</text><text x="612" y="396" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#9AA1A8" text-anchor="end">node 6 · :9991</text>
+<text x="388" y="414" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">never dials, so it holds no pool</text>
+<text x="388" y="428" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">own data_dir puts it on its own disk</text>
+<text x="372" y="462" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C">node ids unique per file, ports per host</text>
+
+<rect x="676" y="180" width="296" height="304" rx="13" fill="#181D23" stroke="#2A2F36" stroke-width="1"/>
+<text x="696" y="206" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12.5" fill="#F5F3EE" font-weight="700">host 3</text>
+<text x="952" y="206" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="end">addr 10.11.12.3</text>
+<line x1="696" y1="216" x2="952" y2="216" stroke="#2A2F36" stroke-width="1"/>
+<line x1="686" y1="250" x2="686" y2="416" stroke="#9AA1A8" stroke-width="1" stroke-opacity="0.35" stroke-dasharray="2 4"/>
+<line x1="686" y1="261" x2="696" y2="261" stroke="#9AA1A8" stroke-width="1" stroke-opacity="0.35"/><line x1="686" y1="333" x2="696" y2="333" stroke="#9AA1A8" stroke-width="1" stroke-opacity="0.35"/><line x1="686" y1="405" x2="696" y2="405" stroke="#9AA1A8" stroke-width="1" stroke-opacity="0.35"/>
+<rect x="696" y="230" width="256" height="62" rx="8" fill="#F5B500" fill-opacity="0.10" stroke="#F5B500" stroke-width="1.2" stroke-opacity="0.5"/>
+<text x="712" y="252" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12.5" fill="#F5B500" font-weight="700">gate</text><text x="936" y="252" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#9AA1A8" text-anchor="end">node 7 · :8443</text>
+<text x="712" y="270" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">a host declaring none serves no S3</text>
+<text x="712" y="284" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">gate port is the S3 port</text>
+<rect x="696" y="302" width="256" height="62" rx="8" fill="#5AA9E6" fill-opacity="0.10" stroke="#5AA9E6" stroke-width="1.2" stroke-opacity="0.5"/>
+<text x="712" y="324" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12.5" fill="#5AA9E6" font-weight="700">meta</text><text x="936" y="324" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#9AA1A8" text-anchor="end">node 8 · :6660</text>
+<text x="712" y="342" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">quorum over the meta set</text>
+<text x="712" y="356" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">3 replicas tolerate 1 loss</text>
+<rect x="696" y="374" width="256" height="62" rx="8" fill="#3FB950" fill-opacity="0.10" stroke="#3FB950" stroke-width="1.2" stroke-opacity="0.5"/>
+<text x="712" y="396" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12.5" fill="#3FB950" font-weight="700">blob</text><text x="936" y="396" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#9AA1A8" text-anchor="end">node 9 · :9991</text>
+<text x="712" y="414" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">rs data + parity ≤ blob node count</text>
+<text x="712" y="428" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">RS(2,1) here: any one node may be lost</text>
+<text x="696" y="462" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C">config/3host.toml ships this layout</text>
+
+<line x1="326" y1="333" x2="350" y2="333" stroke="#9AA1A8" stroke-width="1.2" stroke-opacity="0.6" stroke-dasharray="3 3"/><polygon points="332,329 332,337 324,333" fill="#9AA1A8" fill-opacity="0.7"/><polygon points="344,329 344,337 352,333" fill="#9AA1A8" fill-opacity="0.7"/>
+<line x1="326" y1="405" x2="350" y2="405" stroke="#9AA1A8" stroke-width="1.2" stroke-opacity="0.6" stroke-dasharray="3 3"/><polygon points="332,401 332,409 324,405" fill="#9AA1A8" fill-opacity="0.7"/><polygon points="344,401 344,409 352,405" fill="#9AA1A8" fill-opacity="0.7"/>
+<line x1="650" y1="333" x2="674" y2="333" stroke="#9AA1A8" stroke-width="1.2" stroke-opacity="0.6" stroke-dasharray="3 3"/><polygon points="656,329 656,337 648,333" fill="#9AA1A8" fill-opacity="0.7"/><polygon points="668,329 668,337 676,333" fill="#9AA1A8" fill-opacity="0.7"/>
+<line x1="650" y1="405" x2="674" y2="405" stroke="#9AA1A8" stroke-width="1.2" stroke-opacity="0.6" stroke-dasharray="3 3"/><polygon points="656,401 656,409 648,405" fill="#9AA1A8" fill-opacity="0.7"/><polygon points="668,401 668,409 676,405" fill="#9AA1A8" fill-opacity="0.7"/>
+
+<rect x="28" y="498" width="944" height="54" rx="13" fill="#181D23" stroke="#2A2F36" stroke-width="1"/>
+<text x="48" y="522" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#9AA1A8" font-weight="700" letter-spacing="1.5">TRANSPORT</text>
+<text x="48" y="540" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11.5" fill="#5B636C">Nothing in a deployment names a transport: same host is a pipe, different hosts is QUIC.</text>
+<rect x="582" y="513" width="120" height="22" rx="7" fill="none" stroke="#2A2F36" stroke-width="1"/><text x="642" y="528" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#9AA1A8" text-anchor="middle">pipe · in-process</text>
+<rect x="712" y="513" width="112" height="22" rx="7" fill="#F5B500" fill-opacity="0.14"/><text x="768" y="528" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#F5B500" text-anchor="middle">QUIC · TLS 1.3</text>
+<rect x="834" y="513" width="118" height="22" rx="7" fill="none" stroke="#2A2F36" stroke-width="1"/><text x="893" y="528" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#9AA1A8" text-anchor="middle">1 conn per peer</text>
+</svg>

--- a/docs/assets/get-path.svg
+++ b/docs/assets/get-path.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="596" viewBox="0 0 1000 596" role="img" aria-label="Predastore GET object path: the gate reads the recorded placement from the Raft metadata plane, fetches the data shards from their blob nodes in parallel, joins them, and falls back to fetching parity and Reed-Solomon reconstruction when a shard is missing or fails its integrity check.">
+<rect x="0" y="0" width="1000" height="596" rx="20" fill="#14181D" stroke="#2A2F36" stroke-width="1"/>
+
+<text x="28" y="42" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11.5" fill="#F5B500" font-weight="600" letter-spacing="2.5">GET OBJECT</text>
+<text x="972" y="42" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11.5" fill="#9AA1A8" text-anchor="end">data shards first, parity only on failure</text>
+<text x="28" y="72" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="21" fill="#F5F3EE" font-weight="800">Read K shards, join, reconstruct if you must.</text>
+
+<rect x="28" y="88" width="944" height="52" rx="13" fill="#181D23" stroke="#2A2F36" stroke-width="1"/>
+<text x="48" y="112" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#9AA1A8" font-weight="700" letter-spacing="1.5">S3 CLIENT</text>
+<text x="48" y="130" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11.5" fill="#5B636C">aws s3 cp s3://my-bucket/file.txt ./file.txt</text>
+<rect x="742" y="103" width="210" height="22" rx="7" fill="none" stroke="#2A2F36" stroke-width="1"/><text x="847" y="118" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#9AA1A8" text-anchor="middle">GET · optional Range</text>
+
+<line x1="500" y1="140" x2="500" y2="168" stroke="#F5B500" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="494,166 506,166 500,175" fill="#F5B500" fill-opacity="0.6"/>
+
+<rect x="28" y="176" width="608" height="96" rx="13" fill="#181D23" stroke="#F5B500" stroke-width="1" stroke-opacity="0.35"/>
+<text x="48" y="202" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#F5B500" font-weight="700" letter-spacing="1.5">GATE</text>
+<text x="616" y="202" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="end">internal/gate/handlers/get_object.go</text>
+<text x="48" y="226" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11.5" fill="#9AA1A8">1 · authenticate, resolve the bucket and key</text>
+<text x="48" y="246" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11.5" fill="#9AA1A8">2 · hash the name, read the recorded placement</text>
+<text x="48" y="264" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11.5" fill="#5B636C">the placement carries the object size, which the join needs</text>
+
+<rect x="664" y="176" width="308" height="96" rx="13" fill="#181D23" stroke="#5AA9E6" stroke-width="1" stroke-opacity="0.35"/>
+<text x="684" y="202" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#5AA9E6" font-weight="700" letter-spacing="1.5">META</text>
+<text x="952" y="202" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="end">any replica answers</text>
+<text x="684" y="226" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10.5" fill="#9AA1A8">objects/&lt;hash&gt; → gob placement</text>
+<text x="684" y="246" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11.5" fill="#9AA1A8">cached leader first, then every replica</text>
+<text x="684" y="264" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11.5" fill="#5B636C">a follower read may be stale</text>
+<line x1="636" y1="224" x2="662" y2="224" stroke="#5AA9E6" stroke-width="1.2" stroke-opacity="0.6" stroke-dasharray="3 3"/><polygon points="642,220 642,228 634,224" fill="#5AA9E6" fill-opacity="0.7"/><polygon points="656,220 656,228 664,224" fill="#5AA9E6" fill-opacity="0.7"/>
+
+<line x1="176" y1="272" x2="176" y2="300" stroke="#3FB950" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="170,298 182,298 176,307" fill="#3FB950" fill-opacity="0.6"/>
+<line x1="500" y1="272" x2="500" y2="300" stroke="#3FB950" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="494,298 506,298 500,307" fill="#3FB950" fill-opacity="0.6"/>
+<line x1="824" y1="272" x2="824" y2="300" stroke="#9AA1A8" stroke-width="1.2" stroke-opacity="0.4" stroke-dasharray="3 3"/><polygon points="818,298 830,298 824,307" fill="#9AA1A8" fill-opacity="0.5"/>
+
+<rect x="28" y="308" width="296" height="112" rx="13" fill="#181D23" stroke="#3FB950" stroke-width="1" stroke-opacity="0.35"/>
+<text x="48" y="332" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#3FB950" font-weight="700">blob · shard 0</text>
+<line x1="48" y1="342" x2="304" y2="342" stroke="#2A2F36" stroke-width="1"/>
+<text x="48" y="364" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">index row → extent</text>
+<text x="48" y="384" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">batched ReadAt, GCM open in place</text>
+<text x="48" y="404" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">a ranged read stops at the range</text>
+
+<rect x="352" y="308" width="296" height="112" rx="13" fill="#181D23" stroke="#3FB950" stroke-width="1" stroke-opacity="0.35"/>
+<text x="372" y="332" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#3FB950" font-weight="700">blob · shard 1</text>
+<line x1="372" y1="342" x2="628" y2="342" stroke="#2A2F36" stroke-width="1"/>
+<text x="372" y="364" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">missing row → not-found</text>
+<text x="372" y="384" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">failed tag → integrity error</text>
+<text x="372" y="404" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">either way the shard is unreadable</text>
+
+<rect x="676" y="308" width="296" height="112" rx="13" fill="#181D23" stroke="#2A2F36" stroke-width="1" stroke-dasharray="3 4"/>
+<text x="696" y="332" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#9AA1A8" font-weight="700">blob · parity</text>
+<text x="952" y="332" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="end">fallback only</text>
+<line x1="696" y1="342" x2="952" y2="342" stroke="#2A2F36" stroke-width="1"/>
+<text x="696" y="364" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">not touched while the join succeeds</text>
+<text x="696" y="384" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">fetched when a data shard is absent</text>
+<text x="696" y="404" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">any K of K+M shards rebuild the object</text>
+
+<line x1="176" y1="420" x2="176" y2="444" stroke="#3FB950" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="170,442 182,442 176,451" fill="#3FB950" fill-opacity="0.6"/>
+<line x1="500" y1="420" x2="500" y2="444" stroke="#3FB950" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="494,442 506,442 500,451" fill="#3FB950" fill-opacity="0.6"/>
+<line x1="824" y1="420" x2="824" y2="444" stroke="#9AA1A8" stroke-width="1.2" stroke-opacity="0.4" stroke-dasharray="3 3"/><polygon points="818,442 830,442 824,451" fill="#9AA1A8" fill-opacity="0.5"/>
+
+<rect x="28" y="452" width="944" height="60" rx="13" fill="#181D23" stroke="#F5B500" stroke-width="1" stroke-opacity="0.35"/>
+<text x="48" y="476" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#F5B500" font-weight="700" letter-spacing="1.5">JOIN · RECONSTRUCT</text>
+<text x="48" y="496" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">Join the data shards to the recorded size. A failed join refetches with parity and rebuilds the missing shards.</text>
+<rect x="768" y="470" width="184" height="26" rx="7" fill="#F5B500" fill-opacity="0.14"/><text x="860" y="487" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10.5" fill="#F5B500" text-anchor="middle">fewer than K valid → 500</text>
+
+<line x1="500" y1="512" x2="500" y2="536" stroke="#F5B500" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="494,534 506,534 500,543" fill="#F5B500" fill-opacity="0.6"/>
+
+<rect x="28" y="544" width="944" height="34" rx="13" fill="#181D23" stroke="#2A2F36" stroke-width="1"/>
+<text x="48" y="566" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11.5" fill="#9AA1A8">200 OK with the whole object, or 206 Partial Content with the requested range.</text>
+<text x="952" y="566" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10.5" fill="#5B636C" text-anchor="end">the response is assembled in memory</text>
+</svg>

--- a/docs/assets/meta-replica.svg
+++ b/docs/assets/meta-replica.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="506" viewBox="0 0 1000 506" role="img" aria-label="Predastore meta replica: the client prefers the cached Raft leader and follows not-leader redirects; the replica answers key-value opcodes over rpc streams and carries Raft's own traffic over the same streams, applying committed commands into a badger FSM while bolt holds the Raft log and a file store holds snapshots.">
+<rect x="0" y="0" width="1000" height="506" rx="20" fill="#14181D" stroke="#2A2F36" stroke-width="1"/>
+
+<text x="28" y="42" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11.5" fill="#5AA9E6" font-weight="600" letter-spacing="2.5">META PLANE · ONE REPLICA</text>
+<text x="972" y="42" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11.5" fill="#9AA1A8" text-anchor="end">raft rides rpc streams · no port of its own</text>
+<text x="28" y="72" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="21" fill="#F5F3EE" font-weight="800">A flat key-value store, replicated by Raft.</text>
+
+<rect x="28" y="88" width="296" height="290" rx="13" fill="#181D23" stroke="#2A2F36" stroke-width="1"/>
+<text x="48" y="112" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#9AA1A8" font-weight="700" letter-spacing="1.5">meta.Client</text>
+<text x="304" y="112" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="end">held by the gate</text>
+<line x1="48" y1="122" x2="304" y2="122" stroke="#2A2F36" stroke-width="1"/>
+<rect x="48" y="136" width="256" height="72" rx="8" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="62" y="157" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#5AA9E6">reads</text>
+<text x="62" y="175" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">cached leader first, then every</text>
+<text x="62" y="191" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">replica; a follower may be stale</text>
+<rect x="48" y="220" width="256" height="90" rx="8" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="62" y="241" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#5AA9E6">writes</text>
+<text x="62" y="259" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">follow the not-leader redirect,</text>
+<text x="62" y="275" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">otherwise rotate replicas while</text>
+<text x="62" y="291" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">an election settles</text>
+<text x="48" y="336" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">Keys are opaque strings that may hold</text>
+<text x="48" y="352" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">arbitrary bytes. Namespacing is the</text>
+<text x="48" y="368" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">caller's, not the replica's.</text>
+
+<line x1="326" y1="200" x2="350" y2="200" stroke="#5AA9E6" stroke-width="1.2" stroke-opacity="0.6" stroke-dasharray="3 3"/><polygon points="344,196 344,204 352,200" fill="#5AA9E6" fill-opacity="0.7"/>
+
+<rect x="352" y="88" width="620" height="290" rx="13" fill="#181D23" stroke="#5AA9E6" stroke-width="1" stroke-opacity="0.35"/>
+<text x="372" y="112" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#5AA9E6" font-weight="700" letter-spacing="1.5">meta replica · node 5</text>
+<text x="952" y="112" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="end">advertise address: node-5</text>
+<line x1="372" y1="122" x2="952" y2="122" stroke="#2A2F36" stroke-width="1"/>
+
+<rect x="372" y="134" width="282" height="52" rx="8" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="386" y="155" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10.5" fill="#5AA9E6">0x1001–0x1004</text>
+<text x="386" y="173" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">get · put · delete · scan</text>
+<rect x="670" y="134" width="282" height="52" rx="8" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="684" y="155" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10.5" fill="#5AA9E6">0x0001 · raft dial</text>
+<text x="684" y="173" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">the stream becomes a raft conn</text>
+
+<line x1="513" y1="186" x2="513" y2="206" stroke="#5AA9E6" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="507,204 519,204 513,212" fill="#5AA9E6" fill-opacity="0.6"/>
+<line x1="811" y1="186" x2="811" y2="206" stroke="#5AA9E6" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="805,204 817,204 811,212" fill="#5AA9E6" fill-opacity="0.6"/>
+
+<rect x="372" y="212" width="580" height="52" rx="8" fill="#5AA9E6" fill-opacity="0.10" stroke="#5AA9E6" stroke-width="1.2" stroke-opacity="0.5"/>
+<text x="386" y="233" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11.5" fill="#5AA9E6" font-weight="700">hashicorp/raft</text>
+<text x="938" y="233" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#9AA1A8" text-anchor="end">RPCStreamLayer</text>
+<text x="386" y="253" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">Only the leader may apply. Commands are JSON: put or delete, one key, one value.</text>
+
+<line x1="463" y1="264" x2="463" y2="284" stroke="#5AA9E6" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="457,282 469,282 463,290" fill="#5AA9E6" fill-opacity="0.6"/>
+<line x1="662" y1="264" x2="662" y2="284" stroke="#5AA9E6" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="656,282 668,282 662,290" fill="#5AA9E6" fill-opacity="0.6"/>
+<line x1="861" y1="264" x2="861" y2="284" stroke="#5AA9E6" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="855,282 867,282 861,290" fill="#5AA9E6" fill-opacity="0.6"/>
+
+<rect x="372" y="290" width="182" height="68" rx="8" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="386" y="311" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#F5F3EE">raft.db</text>
+<text x="386" y="329" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="10.5" fill="#9AA1A8">bolt: the log and</text>
+<text x="386" y="345" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="10.5" fill="#9AA1A8">the stable store</text>
+<rect x="571" y="290" width="182" height="68" rx="8" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="585" y="311" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#F5F3EE">badger/</text>
+<text x="585" y="329" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="10.5" fill="#9AA1A8">the FSM: the state</text>
+<text x="585" y="345" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="10.5" fill="#9AA1A8">the log builds</text>
+<rect x="770" y="290" width="182" height="68" rx="8" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="784" y="311" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#F5F3EE">snapshots/</text>
+<text x="784" y="329" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="10.5" fill="#9AA1A8">length-prefixed key</text>
+<text x="784" y="345" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="10.5" fill="#9AA1A8">and value frames</text>
+
+<rect x="28" y="396" width="944" height="82" rx="13" fill="#181D23" stroke="#2A2F36" stroke-width="1"/>
+<text x="48" y="420" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#9AA1A8" font-weight="700" letter-spacing="1.5">WHY TWO DATABASES</text>
+<text x="48" y="442" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11.5" fill="#9AA1A8">Bolt stores how to build the state — the ordered log Raft replicates. Badger stores the state itself.</text>
+<text x="48" y="462" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11.5" fill="#5B636C">Snapshots compact the log and let a new replica catch up without replaying it from the beginning.</text>
+</svg>

--- a/docs/assets/put-path.svg
+++ b/docs/assets/put-path.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="648" viewBox="0 0 1000 648" role="img" aria-label="Predastore PUT object path: the gate authenticates the request, hashes the object name, places it on the ring, Reed-Solomon encodes the body into data and parity shards, streams each shard to its blob node where it is sealed and committed, then records the placement in the Raft metadata plane.">
+<rect x="0" y="0" width="1000" height="648" rx="20" fill="#14181D" stroke="#2A2F36" stroke-width="1"/>
+
+<text x="28" y="42" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11.5" fill="#F5B500" font-weight="600" letter-spacing="2.5">PUT OBJECT</text>
+<text x="972" y="42" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11.5" fill="#9AA1A8" text-anchor="end">shards land first, metadata commits last</text>
+<text x="28" y="72" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="21" fill="#F5F3EE" font-weight="800">Erasure code, place, then record.</text>
+
+<rect x="28" y="88" width="944" height="52" rx="13" fill="#181D23" stroke="#2A2F36" stroke-width="1"/>
+<text x="48" y="112" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#9AA1A8" font-weight="700" letter-spacing="1.5">S3 CLIENT</text>
+<text x="48" y="130" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11.5" fill="#5B636C">aws s3 cp ./file.txt s3://my-bucket/file.txt</text>
+<rect x="742" y="103" width="210" height="22" rx="7" fill="none" stroke="#2A2F36" stroke-width="1"/><text x="847" y="118" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#9AA1A8" text-anchor="middle">PUT /my-bucket/file.txt</text>
+
+<line x1="500" y1="140" x2="500" y2="168" stroke="#F5B500" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="494,166 506,166 500,175" fill="#F5B500" fill-opacity="0.6"/>
+
+<rect x="28" y="176" width="944" height="100" rx="13" fill="#181D23" stroke="#F5B500" stroke-width="1" stroke-opacity="0.35"/>
+<text x="48" y="202" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#F5B500" font-weight="700" letter-spacing="1.5">GATE</text>
+<text x="952" y="202" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="end">internal/gate/handlers/put_object.go</text>
+<rect x="48" y="214" width="214" height="48" rx="8" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="62" y="234" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10.5" fill="#F5B500">1 · authenticate</text>
+<text x="62" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">SigV4, IAM policy, ownership</text>
+<rect x="278" y="214" width="214" height="48" rx="8" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="292" y="234" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10.5" fill="#F5B500">2 · decode body</text>
+<text x="292" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">unwrap aws-chunked, take size</text>
+<rect x="508" y="214" width="214" height="48" rx="8" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="522" y="234" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10.5" fill="#F5B500">3 · hash the name</text>
+<text x="522" y="250" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10.5" fill="#9AA1A8">sha256("bucket/key")</text>
+<rect x="738" y="214" width="214" height="48" rx="8" fill="none" stroke="#2A2F36" stroke-width="1"/>
+<text x="752" y="234" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10.5" fill="#F5B500">4 · place on the ring</text>
+<text x="752" y="250" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">K+M distinct blob nodes</text>
+
+<line x1="500" y1="276" x2="500" y2="300" stroke="#F5B500" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="494,298 506,298 500,307" fill="#F5B500" fill-opacity="0.6"/>
+
+<rect x="28" y="308" width="944" height="60" rx="13" fill="#181D23" stroke="#2A2F36" stroke-width="1"/>
+<text x="48" y="332" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#9AA1A8" font-weight="700" letter-spacing="1.5">REED–SOLOMON</text>
+<text x="48" y="352" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">Split the whole body into K data shards, then encode M parity from them. No chunking.</text>
+<rect x="640" y="326" width="88" height="26" rx="7" fill="#3FB950" fill-opacity="0.14"/><text x="684" y="343" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#3FB950" text-anchor="middle">data 0</text>
+<rect x="736" y="326" width="88" height="26" rx="7" fill="#3FB950" fill-opacity="0.14"/><text x="780" y="343" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#3FB950" text-anchor="middle">data 1</text>
+<rect x="832" y="326" width="120" height="26" rx="7" fill="#F5B500" fill-opacity="0.14"/><text x="892" y="343" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="11" fill="#F5B500" text-anchor="middle">parity 0</text>
+
+<line x1="176" y1="368" x2="176" y2="392" stroke="#3FB950" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="170,390 182,390 176,399" fill="#3FB950" fill-opacity="0.6"/>
+<line x1="500" y1="368" x2="500" y2="392" stroke="#3FB950" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="494,390 506,390 500,399" fill="#3FB950" fill-opacity="0.6"/>
+<line x1="824" y1="368" x2="824" y2="392" stroke="#3FB950" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="818,390 830,390 824,399" fill="#3FB950" fill-opacity="0.6"/>
+<rect x="530" y="371" width="180" height="20" rx="10" fill="#3FB950" fill-opacity="0.14"/><text x="620" y="385" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#3FB950" text-anchor="middle">one rpc stream per shard</text>
+
+<rect x="28" y="400" width="296" height="136" rx="13" fill="#181D23" stroke="#3FB950" stroke-width="1" stroke-opacity="0.35"/>
+<text x="48" y="424" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#3FB950" font-weight="700">blob · node 3</text>
+<text x="304" y="424" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="end">shard 0</text>
+<line x1="48" y1="434" x2="304" y2="434" stroke="#2A2F36" stroke-width="1"/>
+<text x="48" y="456" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">1 · reserve a contiguous extent</text>
+<text x="48" y="476" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">2 · seal each fragment, lock-free WriteAt</text>
+<text x="48" y="496" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">3 · fsync the .seg, then the .idx</text>
+<text x="48" y="516" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#F5F3EE">4 · commit the index row ← visible here</text>
+
+<rect x="352" y="400" width="296" height="136" rx="13" fill="#181D23" stroke="#3FB950" stroke-width="1" stroke-opacity="0.35"/>
+<text x="372" y="424" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#3FB950" font-weight="700">blob · node 6</text>
+<text x="628" y="424" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="end">shard 1</text>
+<line x1="372" y1="434" x2="628" y2="434" stroke="#2A2F36" stroke-width="1"/>
+<text x="372" y="456" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">key = the object hash, 32 opaque bytes</text>
+<text x="372" y="476" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">index = the shard number</text>
+<text x="372" y="496" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">an overwrite serves the old bytes</text>
+<text x="372" y="516" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">until the new extent commits</text>
+
+<rect x="676" y="400" width="296" height="136" rx="13" fill="#181D23" stroke="#3FB950" stroke-width="1" stroke-opacity="0.35"/>
+<text x="696" y="424" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#3FB950" font-weight="700">blob · node 9</text>
+<text x="952" y="424" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10" fill="#5B636C" text-anchor="end">shard 2 · parity</text>
+<line x1="696" y1="434" x2="952" y2="434" stroke="#2A2F36" stroke-width="1"/>
+<text x="696" y="456" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">free space below the full watermark</text>
+<text x="696" y="476" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">rejects the write → S3 507</text>
+<text x="696" y="496" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#9AA1A8">below nearfull it still accepts and</text>
+<text x="696" y="516" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">flags pressure back to the gate</text>
+
+<line x1="500" y1="536" x2="500" y2="560" stroke="#5AA9E6" stroke-width="1.2" stroke-opacity="0.5"/><polygon points="494,558 506,558 500,567" fill="#5AA9E6" fill-opacity="0.6"/>
+
+<rect x="28" y="568" width="944" height="60" rx="13" fill="#181D23" stroke="#5AA9E6" stroke-width="1" stroke-opacity="0.35"/>
+<text x="48" y="592" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="12" fill="#5AA9E6" font-weight="700" letter-spacing="1.5">META · RAFT COMMIT</text>
+<text x="48" y="612" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, system-ui, sans-serif" font-size="11" fill="#5B636C">Two keys, two consensus writes. The 200 OK follows the second.</text>
+<rect x="540" y="586" width="196" height="26" rx="7" fill="#5AA9E6" fill-opacity="0.14"/><text x="638" y="603" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10.5" fill="#5AA9E6" text-anchor="middle">objects/&lt;hash&gt; → placement</text>
+<rect x="744" y="586" width="208" height="26" rx="7" fill="#5AA9E6" fill-opacity="0.14"/><text x="848" y="603" font-family="ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace" font-size="10.5" fill="#5AA9E6" text-anchor="middle">objects/&lt;arn&gt; → hash</text>
+</svg>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,8 +65,10 @@ const (
 // flags. Empty means the file did not supply one.
 type Host struct {
 	ID HostID `toml:"id"`
-	// BindAddr is the local listen address, without a port; 0.0.0.0 binds all
-	// interfaces. It defaults to Addr.
+	// BindAddr is where this host's cluster traffic listens — raft and blob
+	// over QUIC — without a port; 0.0.0.0 binds all interfaces. It defaults to
+	// Addr, which keeps the cluster plane off any interface peers do not use.
+	// The S3 API is public and binds separately, per gate node.
 	BindAddr string `toml:"bind_addr"`
 	// Addr is the address other hosts dial, without a port, split from
 	// BindAddr for NAT and multi-homed machines.
@@ -93,6 +95,11 @@ type Node struct {
 	// Port is the port this node answers on, unique within its host. For a
 	// gate it is the S3 port, and its rpc sockets bind ephemerally.
 	Port int `toml:"port"`
+	// BindAddr is where a gate serves the S3 API, without a port. S3 is a
+	// public service and the cluster plane is not, so a multi-homed host puts
+	// this on the public interface and leaves the host's bind_addr on the
+	// private one. Empty follows the host. Only a gate may set it.
+	BindAddr string `toml:"bind_addr"`
 	// DataDir is an absolute directory this node owns outright, so that blob
 	// nodes on one host can sit on separate disks. Empty derives one under the
 	// host's root instead. It has no flag: it is per-node, and a flag is not.
@@ -103,6 +110,22 @@ type Node struct {
 // of its own under the data root of the host it runs on.
 func NodeDataDir(h Host, n Node) string {
 	return cmp.Or(n.DataDir, filepath.Join(h.DataDir, fmt.Sprintf("node-%d", n.ID)))
+}
+
+// HostBindAddr is where this host's cluster traffic listens: the address it
+// names, or the one its peers dial. The fallback is what keeps raft and blob
+// traffic off the interfaces nothing in the cluster uses — an empty bind
+// address is a wildcard to the network stack, so leaving it out must not mean
+// publishing consensus to every interface.
+func HostBindAddr(h Host) string {
+	return cmp.Or(h.BindAddr, h.Addr)
+}
+
+// NodeBindAddr is where a gate serves the S3 API: the address it names, or the
+// one its host binds the cluster plane to. A host that says nothing binds one
+// address for both, which is what a single-homed machine wants.
+func NodeBindAddr(h Host, n Node) string {
+	return cmp.Or(n.BindAddr, HostBindAddr(h))
 }
 
 // RS fixes the erasure code. The counts must match what the cluster was
@@ -350,6 +373,15 @@ func (c *Config) validateTopology() error {
 				return fmt.Errorf("nodes %d and %d both use port %d on host %d", other, n.ID, n.Port, h.ID)
 			}
 			ports[n.Port] = n.ID
+			// Only the S3 API is served on an address of its own; every other
+			// node reaches its peers over the host's cluster plane, so a
+			// bind_addr on one names a listener it does not have.
+			if n.Role != RoleGate && n.BindAddr != "" {
+				return fmt.Errorf("node %d has role %q and must not set bind_addr", n.ID, n.Role)
+			}
+			if hasPort(n.BindAddr) {
+				return fmt.Errorf("node %d bind_addr %q must not carry a port", n.ID, n.BindAddr)
+			}
 			if n.Role == RoleGate {
 				// A gate keeps nothing on disk, so a data_dir on one is a
 				// misunderstanding rather than something to ignore.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,3 +42,102 @@ func TestLoad_MissingFile(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "read ")
 }
+
+// TestNodeBindAddr covers the resolution a multi-homed host depends on: the
+// gate may name the public interface while the cluster plane stays on the
+// private one, and a host that names neither binds one address for both.
+func TestNodeBindAddr(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     Host
+		node     Node
+		expected string
+	}{
+		{
+			name:     "gate binds its own address",
+			host:     Host{Addr: "10.0.0.1", BindAddr: "10.0.0.1"},
+			node:     Node{Role: RoleGate, BindAddr: "0.0.0.0"},
+			expected: "0.0.0.0",
+		},
+		{
+			name:     "gate without one follows the host bind",
+			host:     Host{Addr: "10.0.0.1", BindAddr: "0.0.0.0"},
+			node:     Node{Role: RoleGate},
+			expected: "0.0.0.0",
+		},
+		{
+			name:     "a host that binds nothing falls back to its dialable address",
+			host:     Host{Addr: "10.0.0.1"},
+			node:     Node{Role: RoleGate},
+			expected: "10.0.0.1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, NodeBindAddr(tt.host, tt.node))
+		})
+	}
+}
+
+// TestHostBindAddr pins the fallback the cluster plane depends on. An empty
+// address is a wildcard once it reaches the network stack, so a host that
+// names no bind_addr must resolve to the address its peers dial rather than
+// publishing raft and blob traffic to every interface.
+func TestHostBindAddr(t *testing.T) {
+	assert.Equal(t, "10.0.0.1", HostBindAddr(Host{Addr: "10.0.0.1"}))
+	assert.Equal(t, "192.168.1.1", HostBindAddr(Host{Addr: "10.0.0.1", BindAddr: "192.168.1.1"}))
+	assert.Equal(t, "0.0.0.0", HostBindAddr(Host{Addr: "10.0.0.1", BindAddr: "0.0.0.0"}), "a wildcard is still the operator's to ask for")
+}
+
+// TestValidate_NodeBindAddr pins the two ways a bind_addr under [[host.node]]
+// is a mistake: on a role with no listener of its own, and carrying a port
+// that belongs to the node's own field.
+func TestValidate_NodeBindAddr(t *testing.T) {
+	cfg := func(n Node) *Config {
+		return &Config{
+			Version: Version,
+			Region:  "ap-southeast-2",
+			RS:      RS{Data: 1, Parity: 0},
+			Hosts: []Host{{
+				ID:   1,
+				Addr: "10.0.0.1",
+				Nodes: []Node{
+					{ID: 1, Role: RoleGate, Port: 8443},
+					{ID: 2, Role: RoleBlob, Port: 9991, DataDir: "/var/lib/predastore/blob"},
+					n,
+				},
+			}},
+		}
+	}
+
+	t.Run("rejected on a blob node", func(t *testing.T) {
+		err := cfg(Node{ID: 3, Role: RoleBlob, Port: 9992, DataDir: "/var/lib/predastore/blob2", BindAddr: "0.0.0.0"}).Validate()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must not set bind_addr")
+	})
+
+	t.Run("rejected on a meta node", func(t *testing.T) {
+		err := cfg(Node{ID: 3, Role: RoleMeta, Port: 6660, DataDir: "/var/lib/predastore/meta", BindAddr: "10.0.0.1"}).Validate()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must not set bind_addr")
+	})
+
+	t.Run("rejected when it carries a port", func(t *testing.T) {
+		c := cfg(Node{ID: 3, Role: RoleMeta, Port: 6660, DataDir: "/var/lib/predastore/meta"})
+		c.Hosts[0].Nodes[0].BindAddr = "0.0.0.0:8443"
+
+		err := c.Validate()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must not carry a port")
+	})
+
+	t.Run("accepted on a gate", func(t *testing.T) {
+		c := cfg(Node{ID: 3, Role: RoleMeta, Port: 6660, DataDir: "/var/lib/predastore/meta"})
+		c.Hosts[0].Nodes[0].BindAddr = "0.0.0.0"
+
+		require.NoError(t, c.Validate())
+	})
+}

--- a/internal/gate/handlers/complete_multipart_upload.go
+++ b/internal/gate/handlers/complete_multipart_upload.go
@@ -9,10 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
-	"sync"
 
-	"github.com/klauspost/reedsolomon"
 	"github.com/mulgadc/predastore/internal/gate/model"
 	"github.com/mulgadc/predastore/internal/gate/placement"
 )
@@ -63,7 +60,22 @@ func CompleteMultipartUpload(mc MetaClient, bc BlobClient, ring *placement.Ring,
 			HandleError(w, r, model.NewS3Error(model.ErrInternalError, "Failed to retrieve parts", 500))
 			return
 		}
+		// A completion naming no parts means "use everything uploaded". AWS
+		// rejects that, but MinIO accepts it and clients written against MinIO
+		// rely on it. Honouring it costs nothing: a client that does send a
+		// list is still held to that list exactly.
+		if len(parts) == 0 && len(storedParts) > 0 {
+			parts = make([]model.CompletedPart, len(storedParts))
+			for i, p := range storedParts {
+				parts[i] = model.CompletedPart{PartNumber: p.PartNumber, ETag: p.ETag}
+			}
+		}
+
 		if err := model.ValidatePartsForCompletion(parts, storedParts); err != nil {
+			// A rejected completion is a client-visible 400 and nothing else,
+			// so without this the upload simply disappears from the logs.
+			slog.WarnContext(ctx, "Multipart completion rejected",
+				"uploadID", uploadID, "requested", len(parts), "stored", len(storedParts), "error", err)
 			HandleError(w, r, err)
 			return
 		}
@@ -73,87 +85,28 @@ func CompleteMultipartUpload(mc MetaClient, bc BlobClient, ring *placement.Ring,
 			storedMap[p.PartNumber] = p
 		}
 
-		// Assemble the parts into a temp file, which is then written exactly as a
-		// single-shot PutObject would write it.
-		tmpFile, err := os.CreateTemp("", "multipart-complete-*")
-		if err != nil {
-			HandleError(w, r, model.NewS3Error(model.ErrInternalError, "Failed to create temp file", 500))
-			return
-		}
-		defer os.Remove(tmpFile.Name())
-		defer tmpFile.Close()
-
+		// Validation has already established that every requested part exists,
+		// so the final size is known without assembling anything to measure.
 		partETags := make([]string, len(parts))
-		partData := make([][]byte, len(parts))
-
-		type partResult struct {
-			index int
-			data  []byte
-			err   error
-		}
-		resultChan := make(chan partResult, len(parts))
-		semaphore := make(chan struct{}, maxParallelPartFetches)
-
-		var wg sync.WaitGroup
+		var finalSize int64
 		for i, part := range parts {
 			partETags[i] = model.NormalizeETag(storedMap[part.PartNumber].ETag)
-
-			wg.Add(1)
-			go func(idx int, partNum int) {
-				defer wg.Done()
-				semaphore <- struct{}{}
-				defer func() { <-semaphore }()
-
-				data, err := getPartData(ctx, mc, bc, cfg, bucket, key, uploadID, partNum)
-				resultChan <- partResult{index: idx, data: data, err: err}
-			}(i, part.PartNumber)
+			finalSize += storedMap[part.PartNumber].Size
 		}
 
-		go func() {
-			wg.Wait()
-			close(resultChan)
-		}()
-
-		for result := range resultChan {
-			if result.err != nil {
-				slog.ErrorContext(ctx, "Failed to retrieve part data", "uploadID", uploadID, "index", result.index, "error", result.err)
-				HandleError(w, r, model.NewS3Error(model.ErrInternalError, "Failed to retrieve part data", 500))
-				return
-			}
-			partData[result.index] = result.data
-		}
-
-		for _, data := range partData {
-			if _, err := tmpFile.Write(data); err != nil {
-				HandleError(w, r, model.NewS3Error(model.ErrInternalError, "Failed to write assembled data", 500))
-				return
-			}
-		}
-		if closeErr := tmpFile.Close(); closeErr != nil {
-			slog.DebugContext(ctx, "Failed to close temp file", "path", tmpFile.Name(), "error", closeErr)
-		}
-
-		finalInfo, err := os.Stat(tmpFile.Name())
-		if err != nil {
-			HandleError(w, r, model.NewS3Error(model.ErrInternalError, "Failed to get final object size", 500))
-			return
-		}
-
-		assembled, err := os.Open(tmpFile.Name())
-		if err != nil {
-			HandleError(w, r, model.NewS3Error(model.ErrInternalError, "Failed to reopen assembled object", 500))
-			return
-		}
+		// The parts are streamed into the write path in order, so the assembled
+		// object is erasure coded as it is read back rather than staged whole.
+		assembled := streamParts(ctx, mc, bc, cfg, bucket, key, uploadID, parts)
 		defer assembled.Close()
 
 		objectHash := model.ObjectHash(bucket, key)
-		if _, err := writeObject(ctx, bc, ring, cfg, assembled, finalInfo.Size(), objectHash); err != nil {
+		if _, err := writeObject(ctx, bc, ring, cfg, assembled, finalSize, objectHash); err != nil {
 			slog.ErrorContext(ctx, "Failed to store final object", "uploadID", uploadID, "error", err)
 			HandleError(w, r, mapPutErr(err))
 			return
 		}
 
-		place, err := placeShards(ring, cfg, objectHash, finalInfo.Size())
+		place, err := placeShards(ring, cfg, objectHash, finalSize)
 		if err != nil {
 			HandleError(w, r, model.NewS3Error(model.ErrInternalError, "Failed to get shard placement", 500))
 			return
@@ -191,7 +144,79 @@ func CompleteMultipartUpload(mc MetaClient, bc BlobClient, ring *placement.Ring,
 	})
 }
 
-// getPartData reads one part back from its shards.
+// streamParts reads the parts back and writes them, in order, to the returned
+// reader. Parts are fetched concurrently but only a bounded number are held at
+// once: a fetch cannot start until the writer has consumed an earlier part, so
+// completion stays parallel without ever holding the whole object.
+//
+// The caller must Close the reader. Closing it unblocks the writer and cancels
+// any fetch still in flight, which is what stops an abandoned completion from
+// leaking goroutines.
+func streamParts(
+	ctx context.Context, mc MetaClient, bc BlobClient, cfg Config,
+	bucket, key, uploadID string, parts []model.CompletedPart,
+) *io.PipeReader {
+	type fetched struct {
+		data []byte
+		err  error
+	}
+
+	pr, pw := io.Pipe()
+
+	go func() {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		// One slot per part in flight. The writer returns a slot after it has
+		// consumed a part, which is what bounds the window.
+		slots := make(chan struct{}, maxParallelPartFetches)
+		results := make([]chan fetched, len(parts))
+		for i := range results {
+			results[i] = make(chan fetched, 1)
+		}
+
+		go func() {
+			for i, part := range parts {
+				select {
+				case slots <- struct{}{}:
+				case <-ctx.Done():
+					return
+				}
+				go func(idx, partNumber int) {
+					data, err := getPartData(ctx, mc, bc, cfg, bucket, key, uploadID, partNumber)
+					results[idx] <- fetched{data: data, err: err}
+				}(i, part.PartNumber)
+			}
+		}()
+
+		for i := range parts {
+			var res fetched
+			select {
+			case res = <-results[i]:
+			case <-ctx.Done():
+				_ = pw.CloseWithError(ctx.Err())
+				return
+			}
+			if res.err != nil {
+				_ = pw.CloseWithError(res.err)
+				return
+			}
+			if _, err := pw.Write(res.data); err != nil {
+				_ = pw.CloseWithError(err)
+				return
+			}
+			<-slots
+		}
+		_ = pw.Close()
+	}()
+
+	return pr
+}
+
+// getPartData reads one part back from its shards. A part is an object under a
+// hidden key, so it is read exactly as GET reads one: the data shards are
+// joined directly, and parity is only pulled in if that join fails. Going
+// straight to reconstruction would read every shard twice for every part.
 func getPartData(ctx context.Context, mc MetaClient, bc BlobClient, cfg Config, bucket, key, uploadID string, partNumber int) ([]byte, error) {
 	data, err := metaGet(ctx, mc, model.TableObjects, partShardKey(uploadID, partNumber))
 	if err != nil {
@@ -203,16 +228,5 @@ func getPartData(ctx context.Context, mc MetaClient, bc BlobClient, cfg Config, 
 		return nil, err
 	}
 
-	enc, err := reedsolomon.NewStream(cfg.DataShards, cfg.ParityShards)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Reed-Solomon decoder: %w", err)
-	}
-
-	partKey := partObjectKey(key, uploadID, partNumber)
-	buf, err := reconstructObject(ctx, bc, model.ObjectHash(bucket, partKey), place, enc, place.Size)
-	if err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return readObject(ctx, bc, cfg, bucket, partObjectKey(key, uploadID, partNumber), place, place.Size)
 }

--- a/internal/gate/handlers/get_object.go
+++ b/internal/gate/handlers/get_object.go
@@ -97,6 +97,12 @@ func parseRangeHeader(header string) (start, end int64) {
 // readObject reconstructs the complete object from its data shards, falling
 // back to parity reconstruction when the data shards alone will not join.
 func readObject(ctx context.Context, bc BlobClient, cfg Config, bucket, key string, place ObjectToShardNodes, size int64) ([]byte, error) {
+	// An empty object has no shards to read: the write path stores none, since
+	// the blob protocol has no zero-length value to store.
+	if size == 0 {
+		return nil, nil
+	}
+
 	// The stream encoder is constructed per request; hoisting it into the
 	// gate belongs with the streaming refactor, not here.
 	enc, err := reedsolomon.NewStream(cfg.DataShards, cfg.ParityShards)

--- a/internal/gate/handlers/list_parts.go
+++ b/internal/gate/handlers/list_parts.go
@@ -1,0 +1,99 @@
+package handlers
+
+import (
+	"log/slog"
+	"net/http"
+	"sort"
+	"strconv"
+
+	"github.com/mulgadc/predastore/internal/gate/model"
+)
+
+// defaultMaxParts is the page size S3 uses when a request names none.
+const defaultMaxParts = 1000
+
+// ListParts serves GET /{bucket}/{key}?uploadId=X. Clients call this to learn
+// which parts the server holds before completing an upload, so without it a
+// completion arrives with an empty part list and is rejected.
+func ListParts(mc MetaClient, cache *BucketCache) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		resource, ok := routedObject(w, r)
+		if !ok {
+			return
+		}
+		bucket, key := resource.Bucket.Name, resource.Key
+		uploadID := r.URL.Query().Get("uploadId")
+
+		if err := requireBucket(ctx, mc, cache, bucket); err != nil {
+			HandleError(w, r, err)
+			return
+		}
+		if err := requireUpload(ctx, mc, bucket, key, uploadID); err != nil {
+			HandleError(w, r, err)
+			return
+		}
+
+		maxParts := queryInt(r, "max-parts", defaultMaxParts)
+		if maxParts < 0 || maxParts > defaultMaxParts {
+			maxParts = defaultMaxParts
+		}
+		marker := queryInt(r, "part-number-marker", 0)
+
+		storedParts, err := getStoredParts(ctx, mc, uploadID)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to list parts", "uploadID", uploadID, "error", err)
+			HandleError(w, r, model.NewS3Error(model.ErrInternalError, "Failed to list parts", 500))
+			return
+		}
+		sort.Slice(storedParts, func(i, j int) bool {
+			return storedParts[i].PartNumber < storedParts[j].PartNumber
+		})
+
+		// The marker is exclusive: a page resumes after the part it names.
+		result := ListPartsResult{
+			Bucket:           bucket,
+			Key:              key,
+			UploadId:         uploadID,
+			StorageClass:     "STANDARD",
+			PartNumberMarker: marker,
+			MaxParts:         maxParts,
+		}
+		for _, p := range storedParts {
+			if p.PartNumber <= marker {
+				continue
+			}
+			if len(result.Parts) == maxParts {
+				result.IsTruncated = true
+				break
+			}
+			result.Parts = append(result.Parts, ListPart{
+				PartNumber:   p.PartNumber,
+				LastModified: p.LastModified,
+				ETag:         p.ETag,
+				Size:         p.Size,
+			})
+		}
+		if n := len(result.Parts); n > 0 {
+			result.NextPartNumberMarker = result.Parts[n-1].PartNumber
+		}
+
+		if err := writeXML(w, http.StatusOK, result); err != nil {
+			slog.DebugContext(ctx, "failed to write XML response", "error", err)
+		}
+	})
+}
+
+// queryInt reads a non-negative integer query parameter, falling back to the
+// default when it is absent or unparseable.
+func queryInt(r *http.Request, name string, fallback int) int {
+	raw := r.URL.Query().Get(name)
+	if raw == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return fallback
+	}
+	return n
+}

--- a/internal/gate/handlers/list_parts_test.go
+++ b/internal/gate/handlers/list_parts_test.go
@@ -1,0 +1,181 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testBucket = "b"
+
+// testCache declares the bucket in configuration, which is the cheaper of the
+// two ways a bucket exists and needs no encoded global-state row.
+func testCache() *BucketCache {
+	return NewBucketCache([]BucketConfig{{Name: testBucket, Region: "ap-southeast-2"}})
+}
+
+// seedUpload records an upload and its parts the way CreateMultipartUpload and
+// UploadPart do, so the handlers under test read what production wrote.
+func (f writeFixture) seedUpload(t *testing.T, key, uploadID string, sizes map[int]int64) {
+	t.Helper()
+	ctx := context.Background()
+
+	var meta bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&meta).Encode(model.UploadMetadata{
+		UploadID: uploadID, Bucket: testBucket, Key: key, CreatedAt: time.Now(),
+	}))
+	require.NoError(t, metaPut(ctx, f.mc, model.TableMultipart, uploadID, meta.Bytes()))
+
+	for partNumber, size := range sizes {
+		f.storePart(t, testBucket, key, uploadID, partNumber, randomBytes(t, int(size)))
+
+		var partBuf bytes.Buffer
+		require.NoError(t, gob.NewEncoder(&partBuf).Encode(model.PartMetadata{
+			PartNumber:   partNumber,
+			Size:         size,
+			ETag:         fmt.Sprintf("\"%032d\"", partNumber),
+			LastModified: time.Now(),
+		}))
+		require.NoError(t, metaPut(ctx, f.mc, model.TableParts,
+			multipartPartKey(uploadID, partNumber), partBuf.Bytes()))
+	}
+}
+
+// objectRequest builds a request carrying the resolved resource the router
+// would have attached.
+func objectRequest(method, key, query string) *http.Request {
+	r := httptest.NewRequest(method, "/"+testBucket+"/"+key+"?"+query, nil)
+	return r.WithContext(WithObject(r.Context(), model.Object{
+		Bucket: model.Bucket{Name: testBucket}, Key: key,
+	}))
+}
+
+// Clients enumerate an upload's parts before completing it. Without this the
+// route fell through to GetObject and they saw no parts at all.
+func TestListPartsReturnsTheStoredParts(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(1, 0)
+	f.seedUpload(t, "k", "u1", map[int]int64{1: 5 << 20, 2: 1 << 20})
+
+	w := httptest.NewRecorder()
+	ListParts(f.mc, testCache()).ServeHTTP(w, objectRequest(http.MethodGet, "k", "uploadId=u1"))
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var got ListPartsResult
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, testBucket, got.Bucket)
+	assert.Equal(t, "k", got.Key)
+	assert.Equal(t, "u1", got.UploadId)
+	assert.False(t, got.IsTruncated)
+
+	require.Len(t, got.Parts, 2)
+	assert.Equal(t, 1, got.Parts[0].PartNumber)
+	assert.Equal(t, int64(5<<20), got.Parts[0].Size)
+	assert.Equal(t, 2, got.Parts[1].PartNumber)
+	assert.Equal(t, 2, got.NextPartNumberMarker)
+}
+
+// Paging is what makes the 10,000-part limit listable, so the marker has to be
+// exclusive and truncation has to be reported.
+func TestListPartsPagesFromTheMarker(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(1, 0)
+	f.seedUpload(t, "k", "u1", map[int]int64{1: 1 << 10, 2: 1 << 10, 3: 1 << 10})
+
+	w := httptest.NewRecorder()
+	ListParts(f.mc, testCache()).ServeHTTP(w,
+		objectRequest(http.MethodGet, "k", "uploadId=u1&part-number-marker=1&max-parts=1"))
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var got ListPartsResult
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &got))
+	require.Len(t, got.Parts, 1)
+	assert.Equal(t, 2, got.Parts[0].PartNumber, "the marker is exclusive")
+	assert.True(t, got.IsTruncated)
+	assert.Equal(t, 2, got.NextPartNumberMarker)
+}
+
+func TestListPartsUnknownUploadIsAnError(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(1, 0)
+
+	w := httptest.NewRecorder()
+	ListParts(f.mc, testCache()).ServeHTTP(w, objectRequest(http.MethodGet, "k", "uploadId=missing"))
+
+	assert.GreaterOrEqual(t, w.Code, 400)
+}
+
+// completionBody is the XML a client posts to finish an upload. An empty parts
+// list is what MinIO-targeting clients send when they want every stored part.
+func completionBody(parts ...int) string {
+	body := `<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">`
+	for _, n := range parts {
+		body += fmt.Sprintf(`<Part><PartNumber>%d</PartNumber><ETag>"%032d"</ETag></Part>`, n, n)
+	}
+	return body + `</CompleteMultipartUpload>`
+}
+
+func completionRequest(key, uploadID, body string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost,
+		"/"+testBucket+"/"+key+"?uploadId="+uploadID, bytes.NewReader([]byte(body)))
+	return r.WithContext(WithObject(r.Context(), model.Object{
+		Bucket: model.Bucket{Name: testBucket}, Key: key,
+	}))
+}
+
+// Warp and other MinIO-targeting clients complete with no part list at all and
+// expect every uploaded part to be used. AWS rejects that, so it is a
+// deliberate extension rather than something the spec asks for.
+func TestCompleteMultipartUploadWithNoPartsUsesEveryStoredPart(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(1, 0)
+	f.seedUpload(t, "k", "u1", map[int]int64{1: 5 << 20, 2: 1 << 20})
+
+	w := httptest.NewRecorder()
+	CompleteMultipartUpload(f.mc, f.bc, f.ring, testCache(), f.cfg).
+		ServeHTTP(w, completionRequest("k", "u1", completionBody()))
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var got CompleteMultipartUploadResult
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, "k", got.Key)
+	// Two parts assembled, which the ETag suffix records.
+	assert.Contains(t, got.ETag, "-2")
+
+	place, _, err := loadPlacement(context.Background(), f.mc, f.ring, f.cfg, testBucket, "k")
+	require.NoError(t, err)
+	assert.Equal(t, int64(6<<20), place.Size, "the object is the parts concatenated")
+}
+
+// A client that does name its parts is still held to exactly those, so the
+// extension cannot mask a client that sent the wrong list.
+func TestCompleteMultipartUploadHonoursAGivenPartList(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(1, 0)
+	f.seedUpload(t, "k", "u1", map[int]int64{1: 5 << 20, 2: 1 << 20})
+
+	w := httptest.NewRecorder()
+	CompleteMultipartUpload(f.mc, f.bc, f.ring, testCache(), f.cfg).
+		ServeHTTP(w, completionRequest("k", "u1", completionBody(3)))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Part 3 does not exist")
+}

--- a/internal/gate/handlers/multipart_stream_test.go
+++ b/internal/gate/handlers/multipart_stream_test.go
@@ -1,0 +1,191 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore/internal/blob"
+	"github.com/mulgadc/predastore/internal/config"
+	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// storePart writes one part the way UploadPart does, so completion reads it
+// back through the same keys production uses.
+func (f writeFixture) storePart(t *testing.T, bucket, key, uploadID string, partNumber int, data []byte) {
+	t.Helper()
+	ctx := context.Background()
+
+	partKey := partObjectKey(key, uploadID, partNumber)
+	objectHash := model.ObjectHash(bucket, partKey)
+
+	_, err := writeObject(ctx, f.bc, f.ring, f.cfg, bytes.NewReader(data), int64(len(data)), objectHash)
+	require.NoError(t, err)
+
+	place, err := placeShards(f.ring, f.cfg, objectHash, int64(len(data)))
+	require.NoError(t, err)
+
+	var shardBuf bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&shardBuf).Encode(place))
+	require.NoError(t, metaPut(ctx, f.mc, model.TableObjects, partShardKey(uploadID, partNumber), shardBuf.Bytes()))
+}
+
+// completedParts names parts 1..n, which is the order S3 requires.
+func completedParts(n int) []model.CompletedPart {
+	parts := make([]model.CompletedPart, n)
+	for i := range parts {
+		parts[i] = model.CompletedPart{PartNumber: i + 1}
+	}
+	return parts
+}
+
+// Completion has to hand the write path the parts concatenated in part-number
+// order, whatever order the fetches happen to finish in.
+func TestStreamPartsConcatenatesInOrder(t *testing.T) {
+	t.Parallel()
+
+	const (
+		parts    = 12
+		partSize = 64 << 10
+	)
+	f := newWriteFixture(1, 0)
+
+	var want []byte
+	for i := 1; i <= parts; i++ {
+		data := randomBytes(t, partSize)
+		f.storePart(t, "b", "k", "upload-1", i, data)
+		want = append(want, data...)
+	}
+
+	r := streamParts(context.Background(), f.mc, f.bc, f.cfg, "b", "k", "upload-1", completedParts(parts))
+	defer r.Close()
+
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+// The whole point of streaming completion is that the object is never held at
+// once. This bounds what the pipeline holds while the reader is slow.
+func TestStreamPartsHoldsOnlyABoundedWindow(t *testing.T) {
+	t.Parallel()
+
+	const parts = maxParallelPartFetches * 4
+	f := newWriteFixture(1, 0)
+	for i := 1; i <= parts; i++ {
+		f.storePart(t, "b", "k", "upload-1", i, randomBytes(t, 1024))
+	}
+
+	counting := &countingGets{BlobClient: f.bc}
+	r := streamParts(context.Background(), f.mc, counting, f.cfg, "b", "k", "upload-1", completedParts(parts))
+	defer r.Close()
+
+	// Read one part's worth, then let any runnable fetch make progress. Only
+	// the window may have been fetched: an unbounded pipeline would have
+	// pulled every part by now.
+	_, err := io.ReadFull(r, make([]byte, 1024))
+	require.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+
+	assert.LessOrEqual(t, counting.gets.Load(), int64(maxParallelPartFetches+1),
+		"completion fetched ahead without bound")
+}
+
+// An abandoned completion must not leave the fetchers running: closing the
+// reader is the only signal they get.
+func TestStreamPartsCloseStopsTheFetchers(t *testing.T) {
+	t.Parallel()
+
+	const parts = maxParallelPartFetches * 4
+	f := newWriteFixture(1, 0)
+	for i := 1; i <= parts; i++ {
+		f.storePart(t, "b", "k", "upload-1", i, randomBytes(t, 1024))
+	}
+
+	counting := &countingGets{BlobClient: f.bc}
+	r := streamParts(context.Background(), f.mc, counting, f.cfg, "b", "k", "upload-1", completedParts(parts))
+
+	_, err := io.ReadFull(r, make([]byte, 1024))
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+
+	time.Sleep(50 * time.Millisecond)
+	settled := counting.gets.Load()
+	time.Sleep(50 * time.Millisecond)
+
+	assert.Equal(t, settled, counting.gets.Load(), "fetches continued after the reader was closed")
+}
+
+// A part that cannot be read has to fail the completion rather than silently
+// producing a short object, so the error must reach the reader.
+func TestStreamPartsSurfacesAFetchError(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(1, 0)
+	f.storePart(t, "b", "k", "upload-1", 1, randomBytes(t, 1024))
+	// Part 2 is never stored, so its placement lookup fails.
+
+	r := streamParts(context.Background(), f.mc, f.bc, f.cfg, "b", "k", "upload-1", completedParts(2))
+	defer r.Close()
+
+	_, err := io.ReadAll(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "part not found")
+}
+
+// countingGets counts part reads so a test can see how far ahead completion ran.
+type countingGets struct {
+	BlobClient
+
+	gets atomic.Int64
+}
+
+func (c *countingGets) Get(ctx context.Context, id config.NodeID, req blob.GetRequest) (io.ReadCloser, error) {
+	c.gets.Add(1)
+	return c.BlobClient.Get(ctx, id, req)
+}
+
+// A completed upload must read back byte for byte, at every erasure width.
+func TestMultipartAssemblyRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	for _, rs := range []struct{ data, parity int }{{1, 0}, {2, 1}} {
+		t.Run(fmt.Sprintf("rs-%d-%d", rs.data, rs.parity), func(t *testing.T) {
+			t.Parallel()
+
+			const parts = 5
+			f := newWriteFixture(rs.data, rs.parity)
+
+			var want []byte
+			var finalSize int64
+			for i := 1; i <= parts; i++ {
+				data := randomBytes(t, 100<<10)
+				f.storePart(t, "b", "k", "upload-1", i, data)
+				want = append(want, data...)
+				finalSize += int64(len(data))
+			}
+
+			ctx := context.Background()
+			objectHash := model.ObjectHash("b", "k")
+
+			assembled := streamParts(ctx, f.mc, f.bc, f.cfg, "b", "k", "upload-1", completedParts(parts))
+			_, err := writeObject(ctx, f.bc, f.ring, f.cfg, assembled, finalSize, objectHash)
+			require.NoError(t, err)
+			require.NoError(t, assembled.Close())
+
+			place, err := placeShards(f.ring, f.cfg, objectHash, finalSize)
+			require.NoError(t, err)
+
+			got, err := readObject(ctx, f.bc, f.cfg, "b", "k", place, place.Size)
+			require.NoError(t, err)
+			assert.Equal(t, want, got)
+		})
+	}
+}

--- a/internal/gate/handlers/shards.go
+++ b/internal/gate/handlers/shards.go
@@ -74,6 +74,39 @@ func placeShards(ring *placement.Ring, cfg Config, objectHash [32]byte, size int
 	}, nil
 }
 
+// countingReader records how many bytes were actually read, so a body that
+// stops short of its declared length can be told from a complete one once the
+// stream has already been consumed.
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
+}
+
+// writeSingleShard streams the body to one node without staging it. The blob
+// client reads at most size bytes, so an over-long body is truncated rather
+// than overrunning the shard; a short one is caught here, because placement
+// records size and a short value would read back as a corrupt object.
+func writeSingleShard(
+	ctx context.Context, bc BlobClient, node config.NodeID, body io.Reader, size int64, objectHash [32]byte,
+) (poolNearFull bool, err error) {
+	counted := &countingReader{r: body}
+
+	resp, err := bc.Put(ctx, node, blob.PutRequest{Key: objectHash, Size: size, Index: 0}, counted)
+	if err != nil {
+		return false, err
+	}
+	if counted.n != size {
+		return false, fmt.Errorf("body delivered %d bytes, declared %d", counted.n, size)
+	}
+	return resp.PoolNearFull, nil
+}
+
 // writeObject splits body into RS shards and sends each to the appropriate
 // node. size is what the caller declared the body to be: the splitter needs it
 // up front, and it is what placement records, so a body that does not deliver
@@ -83,13 +116,26 @@ func placeShards(ring *placement.Ring, cfg Config, objectHash [32]byte, size int
 // The stream encoder is constructed per request; hoisting it into the gate
 // belongs with the streaming refactor, not here.
 func writeObject(ctx context.Context, bc BlobClient, ring *placement.Ring, cfg Config, body io.Reader, size int64, objectHash [32]byte) (poolNearFull bool, err error) {
-	enc, err := reedsolomon.NewStream(cfg.DataShards, cfg.ParityShards)
-	if err != nil {
-		return false, err
+	// An empty object has no shard to write: the blob protocol rejects a
+	// zero-length value, and recorded placement is enough to serve the GET.
+	if size == 0 {
+		return false, nil
 	}
 
 	// Use objectHash for hash ring placement for consistency with storage and retrieval
 	shardNodes, err := ring.Nodes(objectHash, cfg.TotalShards())
+	if err != nil {
+		return false, err
+	}
+
+	// RS(1,0) is the whole object on one node: nothing to split and no parity
+	// to encode. Streaming it straight through is what keeps a single-node
+	// write off the heap, so it is its own path rather than a degenerate split.
+	if cfg.DataShards == 1 && cfg.ParityShards == 0 {
+		return writeSingleShard(ctx, bc, shardNodes[0], body, size, objectHash)
+	}
+
+	enc, err := reedsolomon.NewStream(cfg.DataShards, cfg.ParityShards)
 	if err != nil {
 		return false, err
 	}

--- a/internal/gate/handlers/upload_part.go
+++ b/internal/gate/handlers/upload_part.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"encoding/gob"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -39,17 +40,15 @@ func UploadPart(mc MetaClient, bc BlobClient, ring *placement.Ring, cache *Bucke
 			return
 		}
 
-		body, _ := decodeBody(r)
-		etag, data, err := model.CalculatePartETagFromReader(body)
-		if err != nil {
-			slog.ErrorContext(ctx, "Failed to read part data", "uploadID", uploadID, "part", partNumber, "error", err)
-			HandleError(w, r, model.NewS3Error(model.ErrInternalError, "Failed to read part data", 500))
+		// The part is written as it arrives, so its length has to be known
+		// before the body is read rather than measured from what was buffered.
+		body, partSize := decodeBody(r)
+		if partSize < 0 {
+			HandleError(w, r, model.ErrMissingContentLengthError)
 			return
 		}
-
 		// The last part may be arbitrarily small, so only the upper bound is
 		// enforceable here.
-		partSize := int64(len(data))
 		if partSize > model.MaxPartSize {
 			HandleError(w, r, model.NewS3Error(model.ErrEntityTooLarge, "Part exceeds maximum size", 400))
 			return
@@ -58,13 +57,19 @@ func UploadPart(mc MetaClient, bc BlobClient, ring *placement.Ring, cache *Bucke
 		partKey := partObjectKey(key, uploadID, partNumber)
 		objectHash := model.ObjectHash(bucket, partKey)
 
+		// The ETag is MD5 over the part, and the write path already reads the
+		// part end to end, so the hash is teed off that read instead of costing
+		// a second pass over a buffered copy.
+		digest := model.NewPartETagHasher()
+
 		// Placement comes from the part's own object hash, so a retried part
 		// lands on the same nodes without anything deterministic on disk.
-		if _, err := writeObject(ctx, bc, ring, cfg, bytes.NewReader(data), partSize, objectHash); err != nil {
+		if _, err := writeObject(ctx, bc, ring, cfg, io.TeeReader(body, digest), partSize, objectHash); err != nil {
 			slog.ErrorContext(ctx, "Failed to store part", "uploadID", uploadID, "part", partNumber, "error", err)
 			HandleError(w, r, mapPutErr(err))
 			return
 		}
+		etag := model.PartETagFrom(digest)
 
 		partMeta := model.PartMetadata{
 			PartNumber:   partNumber,

--- a/internal/gate/handlers/writepath_test.go
+++ b/internal/gate/handlers/writepath_test.go
@@ -1,0 +1,328 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mulgadc/predastore/internal/blob"
+	"github.com/mulgadc/predastore/internal/config"
+	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/mulgadc/predastore/internal/gate/placement"
+	"github.com/mulgadc/predastore/internal/meta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeMeta is a map standing in for the raft-backed global state.
+type fakeMeta struct {
+	mu   sync.Mutex
+	rows map[string][]byte
+}
+
+func newFakeMeta() *fakeMeta { return &fakeMeta{rows: make(map[string][]byte)} }
+
+func (m *fakeMeta) Get(_ context.Context, key string) ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, ok := m.rows[key]
+	if !ok {
+		// The real client's sentinel: callers branch on it to tell a missing
+		// row from a broken one.
+		return nil, meta.ErrNotFound
+	}
+	return append([]byte(nil), v...), nil
+}
+
+func (m *fakeMeta) Put(_ context.Context, key string, value []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rows[key] = append([]byte(nil), value...)
+	return nil
+}
+
+func (m *fakeMeta) Delete(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.rows, key)
+	return nil
+}
+
+func (m *fakeMeta) Scan(_ context.Context, prefix string, limit int) ([]meta.Item, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var items []meta.Item
+	for k, v := range m.rows {
+		if strings.HasPrefix(k, prefix) {
+			items = append(items, meta.Item{Key: k, Value: append([]byte(nil), v...)})
+		}
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Key < items[j].Key })
+	if limit > 0 && len(items) > limit {
+		items = items[:limit]
+	}
+	return items, nil
+}
+
+// shardID identifies one shard of one object, which is what a blob node keys by.
+type shardID struct {
+	key   [32]byte
+	index uint32
+}
+
+// fakeBlob stands in for the blob nodes. It records the largest single Write it
+// was handed, which is how a streaming write is told from a staged one: a
+// staged write arrives as one buffer the size of the object.
+type fakeBlob struct {
+	mu     sync.Mutex
+	shards map[shardID][]byte
+
+	maxWrite  atomic.Int64
+	putCalls  atomic.Int64
+	declaring func(size int64) error
+}
+
+func newFakeBlob() *fakeBlob { return &fakeBlob{shards: make(map[shardID][]byte)} }
+
+func (b *fakeBlob) Put(_ context.Context, _ config.NodeID, req blob.PutRequest, body io.Reader) (*blob.PutResponse, error) {
+	b.putCalls.Add(1)
+	if req.Size <= 0 {
+		return nil, errors.New("no size specified")
+	}
+	if b.declaring != nil {
+		if err := b.declaring(req.Size); err != nil {
+			return nil, err
+		}
+	}
+
+	// Mirror the node: never read past the declared size, and observe the
+	// chunking the caller actually produced.
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, &observingReader{r: io.LimitReader(body, req.Size), blob: b}); err != nil {
+		return nil, err
+	}
+
+	b.mu.Lock()
+	b.shards[shardID{key: req.Key, index: req.Index}] = buf.Bytes()
+	b.mu.Unlock()
+
+	return &blob.PutResponse{Size: int64(buf.Len())}, nil
+}
+
+func (b *fakeBlob) Get(_ context.Context, _ config.NodeID, req blob.GetRequest) (io.ReadCloser, error) {
+	b.mu.Lock()
+	data, ok := b.shards[shardID{key: req.Key, index: req.Index}]
+	b.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("shard %x/%d not found", req.Key[:4], req.Index)
+	}
+	if req.RangeStart >= 0 && req.RangeEnd >= 0 {
+		data = data[req.RangeStart : req.RangeEnd+1]
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (b *fakeBlob) Delete(_ context.Context, _ config.NodeID, req blob.DeleteRequest) (*blob.DeleteResponse, error) {
+	id := shardID{key: req.Key, index: req.Index}
+	b.mu.Lock()
+	_, ok := b.shards[id]
+	delete(b.shards, id)
+	b.mu.Unlock()
+	return &blob.DeleteResponse{Deleted: ok}, nil
+}
+
+// observingReader records the largest chunk handed to the node.
+type observingReader struct {
+	r    io.Reader
+	blob *fakeBlob
+}
+
+func (o *observingReader) Read(p []byte) (int, error) {
+	n, err := o.r.Read(p)
+	for {
+		prev := o.blob.maxWrite.Load()
+		if int64(n) <= prev || o.blob.maxWrite.CompareAndSwap(prev, int64(n)) {
+			break
+		}
+	}
+	return n, err
+}
+
+var _ MetaClient = (*fakeMeta)(nil)
+var _ BlobClient = (*fakeBlob)(nil)
+
+// writeFixture is a gate write path at one erasure width.
+type writeFixture struct {
+	mc   *fakeMeta
+	bc   *fakeBlob
+	ring *placement.Ring
+	cfg  Config
+}
+
+func newWriteFixture(data, parity int) writeFixture {
+	nodes := make([]config.NodeID, data+parity)
+	for i := range nodes {
+		nodes[i] = config.NodeID(i + 1)
+	}
+	return writeFixture{
+		mc:   newFakeMeta(),
+		bc:   newFakeBlob(),
+		ring: placement.NewRing(nodes),
+		cfg:  Config{Region: "ap-southeast-2", DataShards: data, ParityShards: parity},
+	}
+}
+
+// roundTrip writes an object and reads it back through the same placement the
+// handlers record, which is the only thing that proves a write is retrievable.
+func (f writeFixture) roundTrip(t *testing.T, bucket, key string, body []byte) []byte {
+	t.Helper()
+	ctx := context.Background()
+	objectHash := model.ObjectHash(bucket, key)
+
+	_, err := writeObject(ctx, f.bc, f.ring, f.cfg, bytes.NewReader(body), int64(len(body)), objectHash)
+	require.NoError(t, err)
+
+	place, err := placeShards(f.ring, f.cfg, objectHash, int64(len(body)))
+	require.NoError(t, err)
+
+	got, err := readObject(ctx, f.bc, f.cfg, bucket, key, place, place.Size)
+	require.NoError(t, err)
+	return got
+}
+
+func randomBytes(t *testing.T, n int) []byte {
+	t.Helper()
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	require.NoError(t, err)
+	return b
+}
+
+// The fast path has to produce exactly what the general path would, at every
+// size, or RS(1,0) is a different storage format rather than a shortcut.
+func TestWriteObjectSingleShardRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	for _, size := range []int{1, 7, 8192, 8193, 1 << 20} {
+		t.Run(fmt.Sprintf("%d-bytes", size), func(t *testing.T) {
+			t.Parallel()
+			f := newWriteFixture(1, 0)
+			want := randomBytes(t, size)
+			assert.Equal(t, want, f.roundTrip(t, "b", "k", want))
+		})
+	}
+}
+
+// RS(1,0) is one shard, so the object must be stored whole and unencoded — not
+// split, and not padded out to a shard boundary.
+func TestWriteObjectSingleShardStoresTheObjectWhole(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(1, 0)
+	want := randomBytes(t, 4096)
+	f.roundTrip(t, "b", "k", want)
+
+	f.bc.mu.Lock()
+	defer f.bc.mu.Unlock()
+	require.Len(t, f.bc.shards, 1, "RS(1,0) writes exactly one shard")
+	for id, data := range f.bc.shards {
+		assert.Zero(t, id.index)
+		assert.Equal(t, want, data, "the shard is the object")
+	}
+}
+
+// The point of the fast path is that the object never lands in one buffer, so
+// this asserts on how the body reaches the node rather than on the result.
+func TestWriteObjectSingleShardDoesNotStageTheObject(t *testing.T) {
+	t.Parallel()
+
+	const size = 4 << 20
+	f := newWriteFixture(1, 0)
+	f.roundTrip(t, "b", "k", randomBytes(t, size))
+
+	assert.Less(t, f.bc.maxWrite.Load(), int64(size),
+		"a %d-byte object reached the node in one write, so it was staged whole", size)
+}
+
+// A wider code still has to work: the fast path must not have changed it.
+func TestWriteObjectMultiShardRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	for _, rs := range []struct{ data, parity int }{{2, 1}, {3, 2}} {
+		t.Run(fmt.Sprintf("rs-%d-%d", rs.data, rs.parity), func(t *testing.T) {
+			t.Parallel()
+			f := newWriteFixture(rs.data, rs.parity)
+			want := randomBytes(t, 1<<20)
+			assert.Equal(t, want, f.roundTrip(t, "b", "k", want))
+			assert.Equal(t, int64(rs.data+rs.parity), f.bc.putCalls.Load())
+		})
+	}
+}
+
+// The blob protocol has no zero-length value, so an empty object is placement
+// and nothing else. It used to fail the write outright.
+func TestWriteObjectEmptyWritesNoShards(t *testing.T) {
+	t.Parallel()
+
+	for _, rs := range []struct{ data, parity int }{{1, 0}, {2, 1}} {
+		t.Run(fmt.Sprintf("rs-%d-%d", rs.data, rs.parity), func(t *testing.T) {
+			t.Parallel()
+			f := newWriteFixture(rs.data, rs.parity)
+			assert.Empty(t, f.roundTrip(t, "b", "empty", []byte{}))
+			assert.Zero(t, f.bc.putCalls.Load(), "an empty object has no shard to write")
+		})
+	}
+}
+
+// Streaming gives up the splitter's short-body check, so the fast path has to
+// make that check itself: placement records the declared size, and a short
+// value would read back as a corrupt object.
+func TestWriteObjectSingleShardRejectsAShortBody(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(1, 0)
+	body := bytes.NewReader(randomBytes(t, 100))
+
+	_, err := writeObject(context.Background(), f.bc, f.ring, f.cfg, body, 200, model.ObjectHash("b", "k"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "declared 200")
+}
+
+// A pool-pressure signal from the node has to survive the fast path, because it
+// is what makes a nearfull write set the backoff header.
+func TestWriteObjectSingleShardReportsPoolPressure(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(1, 0)
+	f.bc.declaring = func(int64) error { return nil }
+
+	nearFull := &nearFullBlob{fakeBlob: f.bc}
+	poolNearFull, err := writeObject(
+		context.Background(), nearFull, f.ring, f.cfg,
+		bytes.NewReader([]byte("payload")), 7, model.ObjectHash("b", "k"),
+	)
+
+	require.NoError(t, err)
+	assert.True(t, poolNearFull)
+}
+
+// nearFullBlob answers every put with pressure set.
+type nearFullBlob struct{ *fakeBlob }
+
+func (n *nearFullBlob) Put(ctx context.Context, id config.NodeID, req blob.PutRequest, body io.Reader) (*blob.PutResponse, error) {
+	resp, err := n.fakeBlob.Put(ctx, id, req, body)
+	if err != nil {
+		return nil, err
+	}
+	resp.PoolNearFull = true
+	return resp, nil
+}

--- a/internal/gate/handlers/xmltypes.go
+++ b/internal/gate/handlers/xmltypes.go
@@ -72,6 +72,31 @@ type InitiateMultipartUploadResult struct {
 	UploadId string   `xml:"UploadId"`
 }
 
+// ListPartsResult answers GET /{bucket}/{key}?uploadId=X. Clients call this
+// before completing an upload to learn which parts the server holds, so an
+// empty or missing response makes them send an empty completion.
+type ListPartsResult struct {
+	XMLName              xml.Name    `xml:"ListPartsResult"`
+	Bucket               string      `xml:"Bucket"`
+	Key                  string      `xml:"Key"`
+	UploadId             string      `xml:"UploadId"`
+	StorageClass         string      `xml:"StorageClass"`
+	PartNumberMarker     int         `xml:"PartNumberMarker"`
+	NextPartNumberMarker int         `xml:"NextPartNumberMarker"`
+	MaxParts             int         `xml:"MaxParts"`
+	IsTruncated          bool        `xml:"IsTruncated"`
+	Parts                []ListPart  `xml:"Part"`
+	Initiator            BucketOwner `xml:"Initiator"`
+	Owner                BucketOwner `xml:"Owner"`
+}
+
+type ListPart struct {
+	PartNumber   int       `xml:"PartNumber"`
+	LastModified time.Time `xml:"LastModified"`
+	ETag         string    `xml:"ETag"`
+	Size         int64     `xml:"Size"`
+}
+
 type CompleteMultipartUploadRequest struct {
 	XMLName xml.Name              `xml:"CompleteMultipartUpload"`
 	Parts   []MultipartUploadPart `xml:"Part"`

--- a/internal/gate/model/multipart.go
+++ b/internal/gate/model/multipart.go
@@ -4,7 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"io"
+	"hash"
 	"strings"
 	"time"
 )
@@ -173,16 +173,16 @@ func CalculatePartETag(data []byte) string {
 	return fmt.Sprintf("\"%x\"", hash)
 }
 
-// CalculatePartETagFromReader calculates the MD5-based ETag while reading from a reader
-// Returns the ETag and all data read.
-func CalculatePartETagFromReader(r io.Reader) (etag string, data []byte, err error) {
-	hash := md5.New()
-	data, err = io.ReadAll(io.TeeReader(r, hash))
-	if err != nil {
-		return "", nil, err
-	}
-	etag = fmt.Sprintf("\"%x\"", hash.Sum(nil))
-	return etag, data, nil
+// NewPartETagHasher returns the hash a part ETag is computed over. A caller
+// that already reads the part end to end tees into this rather than buffering
+// the part a second time to hash it.
+func NewPartETagHasher() hash.Hash {
+	return md5.New()
+}
+
+// PartETagFrom formats a finished part hash as an S3 ETag.
+func PartETagFrom(h hash.Hash) string {
+	return fmt.Sprintf("\"%x\"", h.Sum(nil))
 }
 
 // CalculateMultipartETag calculates the ETag for a completed multipart upload

--- a/internal/gate/model/multipart_test.go
+++ b/internal/gate/model/multipart_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -213,15 +214,19 @@ func TestCalculatePartETag(t *testing.T) {
 	assert.Equal(t, expectedETag, etag)
 }
 
-func TestCalculatePartETagFromReader(t *testing.T) {
+// The streaming hasher has to agree with the buffered one, because the two
+// ETags are compared against each other when an upload completes.
+func TestPartETagFromMatchesCalculatePartETag(t *testing.T) {
 	data := []byte("test data for etag calculation")
-	expected := md5.Sum(data)
-	expectedETag := fmt.Sprintf("\"%x\"", expected)
+	expectedETag := fmt.Sprintf("\"%x\"", md5.Sum(data))
 
-	etag, readData, err := CalculatePartETagFromReader(bytes.NewReader(data))
+	h := NewPartETagHasher()
+	n, err := io.Copy(h, bytes.NewReader(data))
 	require.NoError(t, err)
-	assert.Equal(t, expectedETag, etag)
-	assert.Equal(t, data, readData)
+	assert.Equal(t, int64(len(data)), n)
+
+	assert.Equal(t, expectedETag, PartETagFrom(h))
+	assert.Equal(t, CalculatePartETag(data), PartETagFrom(h))
 }
 
 func TestCalculateMultipartETag(t *testing.T) {

--- a/internal/gate/routes.go
+++ b/internal/gate/routes.go
@@ -59,7 +59,9 @@ func (s *Server) setupRoutes(ring *placement.Ring) {
 		s.useRequestChain(r)
 
 		r.Method(http.MethodHead, "/{bucket}/*", handlers.HeadObject(mc, ring, cache, cfg))
-		r.Method(http.MethodGet, "/{bucket}/*", handlers.GetObject(mc, bc, ring, cache, cfg))
+		r.Method(http.MethodGet, "/{bucket}/*", byQuery("uploadId",
+			handlers.ListParts(mc, cache),
+			handlers.GetObject(mc, bc, ring, cache, cfg)))
 		r.Method(http.MethodPut, "/{bucket}/*", byQuery("partNumber",
 			handlers.UploadPart(mc, bc, ring, cache, cfg),
 			handlers.PutObject(mc, bc, ring, cache, cfg)))

--- a/predastore.go
+++ b/predastore.go
@@ -131,13 +131,14 @@ func buildNode(cfg *Config, host HostConfig, n NodeConfig, opts Options, barrier
 
 	// The pipe carries traffic between colocated nodes and the QUIC socket
 	// traffic to other hosts, so each exists only when the cluster puts a peer
-	// on the other end of it.
+	// on the other end of it. Both are the cluster plane and bind the host's
+	// address; only the gate's S3 listener may be given a public one.
 	var trs []transport.Transport
 	if len(host.Nodes) > 1 {
 		trs = append(trs, transport.NewPipeTransport(host.Addr, port))
 	}
 	if hasRemoteNodes(cfg, host.ID) {
-		quic, qerr := transport.NewQUICTransport(host.BindAddr, port, host.TLSCert, host.TLSKey)
+		quic, qerr := transport.NewQUICTransport(config.HostBindAddr(host), port, host.TLSCert, host.TLSKey)
 		if qerr != nil {
 			return nil, nil, fmt.Errorf("node %d quic transport: %w", n.ID, qerr)
 		}

--- a/scripts/bench/compare-performance.sh
+++ b/scripts/bench/compare-performance.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# compare-performance.sh - Diff two e2e-performance runs, workload by workload.
+#
+# Warp compares its own artifacts, so this pairs them by relative path and
+# leaves the statistics to `warp cmp`.
+#
+# Usage:
+#   ./scripts/bench/compare-performance.sh BEFORE_DIR AFTER_DIR
+#   make e2e-performance-compare PERF_BEFORE=... PERF_AFTER=...
+#
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 BEFORE_DIR AFTER_DIR" >&2
+    exit 2
+fi
+
+BEFORE="$1"
+AFTER="$2"
+WARP="${WARP:-warp}"
+
+[ -d "$BEFORE" ] || { echo "missing before directory: $BEFORE" >&2; exit 1; }
+[ -d "$AFTER" ] || { echo "missing after directory: $AFTER" >&2; exit 1; }
+
+# A missing counterpart has to fail the comparison rather than be skipped: a
+# run that quietly compared fewer workloads would read as a clean result.
+missing=0
+while IFS= read -r before_file; do
+    relative="${before_file#"$BEFORE"/}"
+    after_file="$AFTER/$relative"
+    if [ ! -f "$after_file" ]; then
+        echo "missing matching result: $after_file" >&2
+        missing=1
+        continue
+    fi
+    echo "Comparing $relative"
+    "$WARP" cmp --no-color "$before_file" "$after_file"
+done < <(find "$BEFORE" -mindepth 2 -maxdepth 2 -type f \
+    \( -name '*.json.zst' -o -name '*.csv.zst' \) -print | sort)
+
+exit "$missing"

--- a/scripts/bench/e2e-performance.sh
+++ b/scripts/bench/e2e-performance.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+#
+# e2e-performance.sh - Correctness round trips followed by isolated Warp workloads.
+#
+# Each profile is started, proved correct with the AWS CLI, measured with Warp,
+# and stopped before the next one starts, so the profiles never contend.
+#
+# Usage:
+#   ./scripts/bench/e2e-performance.sh          # or: make e2e-performance
+#
+# Environment:
+#   PERF_PRESET      smoke (30s per workload, default) or compare (2m)
+#   PERF_CONFIGS     Profiles to run, space separated (default: "1host 3host")
+#   PERF_RESULTS_ROOT Where runs are written
+#   PERF_KEEP_WORK   1 to keep the cluster work directory after the run
+#   PERF_PORT_OFFSET Added to every node port, so a run does not collide with a
+#                    cluster already on the defaults (default: 10000)
+#   WARP             Path to the warp binary (default: bin/tools/warp)
+#
+# Preset overrides: PERF_DURATION, PERF_CONCURRENT, PERF_PUT_SIZE,
+# PERF_PART_SIZE, PERF_PARTS, PERF_GET_SIZE.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd -P)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
+SCRIPTS_DIR="$REPO_DIR/scripts"
+CONFIG_DIR="$REPO_DIR/config"
+RESULTS_ROOT="${PERF_RESULTS_ROOT:-$SCRIPT_DIR/results/e2e-performance}"
+PERF_PRESET="${PERF_PRESET:-smoke}"
+PERF_CONFIGS="${PERF_CONFIGS:-1host 3host}"
+WARP="${WARP:-$REPO_DIR/bin/tools/warp}"
+
+# shellcheck source=scripts/lib.sh
+source "$SCRIPTS_DIR/lib.sh"
+
+ACCESS_KEY="AKIAIOSFODNN7EXAMPLE"
+SECRET_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+REGION="ap-southeast-2"
+
+case "$PERF_PRESET" in
+    smoke)
+        DURATION="${PERF_DURATION:-30s}"
+        CONCURRENT="${PERF_CONCURRENT:-4}"
+        PUT_SIZE="${PERF_PUT_SIZE:-1MiB}"
+        MULTIPART_SIZE="${PERF_PART_SIZE:-5MiB}"
+        MULTIPART_PARTS="${PERF_PARTS:-2}"
+        GET_SIZE="${PERF_GET_SIZE:-10MiB}"
+        ;;
+    compare)
+        DURATION="${PERF_DURATION:-2m}"
+        CONCURRENT="${PERF_CONCURRENT:-8}"
+        PUT_SIZE="${PERF_PUT_SIZE:-64MiB}"
+        MULTIPART_SIZE="${PERF_PART_SIZE:-8MiB}"
+        MULTIPART_PARTS="${PERF_PARTS:-16}"
+        GET_SIZE="${PERF_GET_SIZE:-128MiB}"
+        ;;
+    *)
+        echo "unknown PERF_PRESET: $PERF_PRESET (want smoke or compare)" >&2
+        exit 2
+        ;;
+esac
+
+for command in aws diff git go openssl; do
+    command -v "$command" >/dev/null || { echo "$command is required" >&2; exit 1; }
+done
+[ -x "$WARP" ] || { echo "Warp not executable: $WARP (run make warp-install)" >&2; exit 1; }
+
+mkdir -p "$RESULTS_ROOT"
+STAMP="$(date -u +%Y-%m-%dT%H%M%SZ)"
+RUN_ID="$(printf '%s' "$STAMP" | tr '[:upper:]' '[:lower:]')"
+SHA="$(git -C "$REPO_DIR" rev-parse --short HEAD)"
+RUN_DIR="$RESULTS_ROOT/${STAMP}-${SHA}"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/predastore-e2e-performance.XXXXXX")"
+
+case "$WORK_DIR" in
+    ""|/|"${TMPDIR:-/tmp}") echo "refusing unsafe work directory: $WORK_DIR" >&2; exit 1 ;;
+esac
+
+mkdir -p "$RUN_DIR/logs" "$RUN_DIR/correctness"
+export PREDA_DIR="$WORK_DIR/predastore"
+
+# Profiles are rendered rather than used in place, so a benchmark can run
+# beside a cluster already holding the default ports.
+PERF_PORT_OFFSET="${PERF_PORT_OFFSET:-10000}"
+export PREDA_CONFIG_DIR="$WORK_DIR/config"
+mkdir -p "$PREDA_CONFIG_DIR"
+
+# render_profile shifts every node port by the offset. Ports appear only under
+# [[host.node]], so a plain key match is enough and stays readable.
+render_profile() {
+    awk -v offset="$PERF_PORT_OFFSET" '
+        /^[[:space:]]*port[[:space:]]*=/ {
+            match($0, /[0-9]+/)
+            printf "%s%d%s\n", substr($0, 1, RSTART - 1), \
+                substr($0, RSTART, RLENGTH) + offset, substr($0, RSTART + RLENGTH)
+            next
+        }
+        { print }
+    ' "$1" > "$2"
+}
+
+# Warp stages multi-MB upload payloads in TMPDIR. Keeping it under the work
+# directory stops those competing with the cluster for a small /tmp tmpfs.
+export TMPDIR="$WORK_DIR/tmp"
+mkdir -p "$PREDA_DIR" "$TMPDIR"
+
+CURRENT_CONFIG=""
+cleanup() {
+    "$SCRIPTS_DIR/stop.sh" >/dev/null 2>&1 || true
+    if [ -n "$CURRENT_CONFIG" ] && [ -d "$PREDA_DIR/$CURRENT_CONFIG/logs" ]; then
+        mkdir -p "$RUN_DIR/logs/$CURRENT_CONFIG"
+        cp -R "$PREDA_DIR/$CURRENT_CONFIG/logs/." "$RUN_DIR/logs/$CURRENT_CONFIG/" || true
+    fi
+    if [ "${PERF_KEEP_WORK:-0}" = "1" ]; then
+        echo "Work directory retained: $WORK_DIR"
+    else
+        rm -rf "$WORK_DIR"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+sha256_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+aws_s3() {
+    AWS_ACCESS_KEY_ID="$ACCESS_KEY" \
+    AWS_SECRET_ACCESS_KEY="$SECRET_KEY" \
+    AWS_DEFAULT_REGION="$REGION" \
+    AWS_REQUEST_CHECKSUM_CALCULATION=when_required \
+    AWS_RESPONSE_CHECKSUM_VALIDATION=when_required \
+    PYTHONWARNINGS=ignore \
+        aws --no-cli-pager --no-verify-ssl --endpoint-url "$ENDPOINT" "$@"
+}
+
+write_aws_config() {
+    printf '%s\n' \
+        '[default]' \
+        "region = $REGION" \
+        's3 =' \
+        '    addressing_style = path' \
+        '    multipart_threshold = 8MB' \
+        '    multipart_chunksize = 5MB' > "$1"
+}
+
+# run_correctness proves the data path before anything is timed: a run that is
+# fast and wrong is worse than no number at all.
+run_correctness() {
+    local config_name="$1" output_dir="$2"
+    local bucket="predastore-correctness-${config_name}-${RUN_ID}"
+    local single_src="$WORK_DIR/single.bin" single_dst="$WORK_DIR/single.out"
+    local multipart_src="$WORK_DIR/multipart.bin" multipart_dst="$WORK_DIR/multipart.out"
+    local empty_src="$WORK_DIR/empty.bin" empty_dst="$WORK_DIR/empty.out"
+    local aws_config="$WORK_DIR/aws-config"
+
+    openssl rand -out "$single_src" "${PERF_CORRECTNESS_SINGLE_BYTES:-1048576}"
+    openssl rand -out "$multipart_src" "${PERF_CORRECTNESS_MULTIPART_BYTES:-20971520}"
+    : > "$empty_src"
+    write_aws_config "$aws_config"
+    export AWS_CONFIG_FILE="$aws_config"
+
+    aws_s3 s3 mb "s3://$bucket"
+
+    aws_s3 s3api put-object --bucket "$bucket" --key single.bin --body "$single_src" >/dev/null
+    aws_s3 s3 cp "s3://$bucket/single.bin" "$single_dst" --only-show-errors
+    diff -q "$single_src" "$single_dst"
+
+    # A zero-length object has no shard to store, so it exercises a path no
+    # other case reaches.
+    aws_s3 s3api put-object --bucket "$bucket" --key empty.bin --body "$empty_src" >/dev/null
+    aws_s3 s3 cp "s3://$bucket/empty.bin" "$empty_dst" --only-show-errors
+    diff -q "$empty_src" "$empty_dst"
+
+    # The configured 8 MiB threshold forces this through explicit UploadPart
+    # and CompleteMultipartUpload calls rather than a single PUT.
+    aws_s3 s3 cp "$multipart_src" "s3://$bucket/multipart.bin" --only-show-errors
+    aws_s3 s3 cp "s3://$bucket/multipart.bin" "$multipart_dst" --only-show-errors
+    diff -q "$multipart_src" "$multipart_dst"
+
+    mkdir -p "$output_dir"
+    {
+        echo "single_source=$(sha256_file "$single_src")"
+        echo "single_download=$(sha256_file "$single_dst")"
+        echo "empty_source=$(sha256_file "$empty_src")"
+        echo "empty_download=$(sha256_file "$empty_dst")"
+        echo "multipart_source=$(sha256_file "$multipart_src")"
+        echo "multipart_download=$(sha256_file "$multipart_dst")"
+    } > "$output_dir/sha256.txt"
+
+    aws_s3 s3 rb "s3://$bucket" --force >/dev/null
+}
+
+# run_warp measures each workload on its own. A mixed workload cannot say which
+# path regressed, which is the whole question a before/after run is asked.
+run_warp() {
+    local config_name="$1" output_dir="$2"
+    local part_concurrent="$CONCURRENT"
+    if [ "$part_concurrent" -gt "$MULTIPART_PARTS" ]; then
+        part_concurrent="$MULTIPART_PARTS"
+    fi
+    local common=(
+        --host="$HOST_LIST"
+        --tls
+        --insecure
+        --region="$REGION"
+        --access-key="$ACCESS_KEY"
+        --secret-key="$SECRET_KEY"
+        --duration="$DURATION"
+        --concurrent="$CONCURRENT"
+        --no-color
+        --noclear
+        --full
+    )
+
+    mkdir -p "$output_dir"
+    run_warp_checked "$output_dir/put.log" "$WARP" put "${common[@]}" \
+        --disable-multipart --obj.size="$PUT_SIZE" \
+        --bucket="warp-${config_name}-put-${RUN_ID}" --benchdata="$output_dir/put"
+    run_warp_checked "$output_dir/multipart-put.log" "$WARP" multipart-put "${common[@]}" \
+        --part.size="$MULTIPART_SIZE" --parts="$MULTIPART_PARTS" \
+        --part.concurrent="$part_concurrent" --bucket="warp-${config_name}-multipart-put-${RUN_ID}" \
+        --benchdata="$output_dir/multipart-put"
+    # The GET set is seeded by multipart upload and then read whole. Warp's
+    # `multipart` command reads with GET ?partNumber=N, a separate S3 feature
+    # predastore does not implement.
+    run_warp_checked "$output_dir/get.log" "$WARP" get "${common[@]}" \
+        --objects=16 --obj.size="$GET_SIZE" --part.size="$MULTIPART_SIZE" \
+        --bucket="warp-${config_name}-get-${RUN_ID}" --benchdata="$output_dir/get"
+
+    write_warp_analysis "$output_dir"
+}
+
+write_warp_analysis() {
+    local output_dir="$1" workload artifact
+    for workload in put multipart-put get; do
+        artifact="$(find "$output_dir" -maxdepth 1 -type f \
+            \( -name "${workload}.json.zst" -o -name "${workload}.csv.zst" \) -print -quit)"
+        [ -n "$artifact" ] || { echo "missing Warp artifact for $workload" >&2; return 1; }
+        "$WARP" analyze --no-color --analyze.v "$artifact" > "$output_dir/${workload}-latency.txt"
+    done
+}
+
+run_warp_checked() {
+    local log_file="$1"
+    shift
+    local status
+
+    set +e
+    "$@" 2>&1 | tee "$log_file"
+    status="${PIPESTATUS[0]}"
+    set -e
+
+    # Warp reports some failures in its output while still exiting zero, so the
+    # log is checked as well as the status.
+    if [ "$status" -ne 0 ] || grep -q 'warp: <ERROR>' "$log_file"; then
+        echo "Warp workload failed; see $log_file" >&2
+        return 1
+    fi
+}
+
+DIRTY="false"
+[ -z "$(git -C "$REPO_DIR" status --porcelain --untracked-files=no)" ] || DIRTY="true"
+{
+    echo "Predastore end-to-end performance run"
+    echo "===================================="
+    echo
+    echo "Run identity"
+    echo "------------"
+    echo "date_utc=$STAMP"
+    echo "predastore_sha=$(git -C "$REPO_DIR" rev-parse HEAD)"
+    echo "predastore_dirty=$DIRTY"
+    echo "go_version=$(go version)"
+    echo "warp_version=$($WARP --version 2>&1 | head -n 1)"
+    echo "warp_module_version=${WARP_VERSION:-unknown}"
+    echo "host=$(hostname)"
+    echo "os=$(uname -s)"
+    echo "arch=$(uname -m)"
+    echo "cpu=$(uname -p)"
+    echo "logical_cpus=$(getconf _NPROCESSORS_ONLN)"
+    echo "memory_bytes=$(awk '/MemTotal/ {print $2 * 1024}' /proc/meminfo 2>/dev/null || echo unknown)"
+    echo
+    echo "Workload controls"
+    echo "-----------------"
+    echo "preset=$PERF_PRESET"
+    echo "duration=$DURATION"
+    echo "concurrent=$CONCURRENT"
+    echo "put_size=$PUT_SIZE"
+    echo "multipart_part_size=$MULTIPART_SIZE"
+    echo "multipart_parts=$MULTIPART_PARTS"
+    echo "get_object_size=$GET_SIZE"
+    echo "configs=$PERF_CONFIGS"
+    echo "port_offset=$PERF_PORT_OFFSET"
+    echo "full_request_samples=true"
+    echo "correctness=AWS_CLI_PUT,empty_object,multipart_upload,GET,diff,SHA256"
+    echo
+    echo "Outputs"
+    echo "-------"
+    echo "raw_samples=<config>/<workload>.json.zst"
+    echo "latency_reports=<config>/<workload>-latency.txt"
+    echo "client_logs=<config>/<workload>.log"
+    echo "server_logs=logs/<config>/"
+    echo "correctness_hashes=correctness/<config>/sha256.txt"
+} > "$RUN_DIR/run-info.txt"
+
+for config_name in $PERF_CONFIGS; do
+    [ -f "$CONFIG_DIR/$config_name.toml" ] || { echo "missing config: $config_name" >&2; exit 1; }
+    CONFIG_FILE="$PREDA_CONFIG_DIR/$config_name.toml"
+    render_profile "$CONFIG_DIR/$config_name.toml" "$CONFIG_FILE"
+
+    # The profile decides where S3 answers, so the endpoints are read from it
+    # rather than assumed to be one gate on the default port.
+    HOST_LIST="$(gate_endpoints "$CONFIG_FILE" | paste -sd,)"
+    [ -n "$HOST_LIST" ] || { echo "no host in $config_name runs a gate" >&2; exit 1; }
+    ENDPOINT="https://$(gate_endpoints "$CONFIG_FILE" | head -1)"
+
+    CURRENT_CONFIG="$config_name"
+    echo "Starting $config_name ($HOST_LIST)"
+    "$SCRIPTS_DIR/start.sh" -w "$config_name"
+    cp "$CONFIG_FILE" "$RUN_DIR/$config_name.toml"
+
+    run_correctness "$config_name" "$RUN_DIR/correctness/$config_name"
+    run_warp "$config_name" "$RUN_DIR/$config_name"
+
+    {
+        echo
+        echo "Latency reports: $config_name"
+        echo "---------------------------"
+        for report in "$RUN_DIR/$config_name"/*-latency.txt; do
+            echo
+            echo "### $(basename "$report")"
+            sed 's/^/  /' "$report"
+        done
+    } >> "$RUN_DIR/run-info.txt"
+
+    "$SCRIPTS_DIR/stop.sh"
+    if [ -d "$PREDA_DIR/$config_name/logs" ]; then
+        mkdir -p "$RUN_DIR/logs/$config_name"
+        cp -R "$PREDA_DIR/$config_name/logs/." "$RUN_DIR/logs/$config_name/"
+    fi
+    rm -rf "${PREDA_DIR:?}/$config_name"
+    CURRENT_CONFIG=""
+done
+
+echo "Performance results: $RUN_DIR"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -14,8 +14,9 @@
 #   -w    Wait for every gate to answer (60s timeout)
 #
 # Environment:
-#   PREDA_DIR   Root for cluster data, certs and the master key
-#   LOG_LEVEL   Passed through as -log-level (debug|info|warn|error)
+#   PREDA_DIR          Root for cluster data, certs and the master key
+#   PREDA_CONFIG_DIR   Where profiles are read from (default: repo config/)
+#   LOG_LEVEL          Passed through as -log-level (debug|info|warn|error)
 #
 # Examples:
 #   ./scripts/start.sh 1host          # one process, pipe only
@@ -26,7 +27,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 REPO_DIR="$SCRIPT_DIR/.."
-CONFIG_DIR="$REPO_DIR/config"
+# PREDA_CONFIG_DIR lets a harness run generated profiles — on shifted ports, so
+# a benchmark does not collide with a cluster already using the defaults.
+CONFIG_DIR="${PREDA_CONFIG_DIR:-$REPO_DIR/config}"
 S3D_BINARY="$REPO_DIR/bin/s3d"
 
 # shellcheck source=scripts/lib.sh


### PR DESCRIPTION
## Summary

Three changes that ship together because the ISO installer needs all of them.

**Split the cluster and S3 bind planes.** A host's `bind_addr` covered both raft/blob replication and the S3 API, so publishing S3 on every interface published replication with it. `bind_addr` now binds the cluster plane alone and a gate node carries its own, giving S3 the public interface while raft and blob stay on the address peers dial. Only a gate may set a node-level `bind_addr`.

**Stream the multipart write path.** Uploading a part hashed it into memory to compute its ETag, and completion staged the assembled object in a temp file, so a large upload cost RAM and a disk round trip proportional to the object. Parts now tee into the ETag hash while they stream to the blob nodes, and completion feeds the write path from a bounded ordered pipeline. RS(1,0) skips the Reed-Solomon encoder entirely, and reading a part back joins the data shards directly where it previously went through reconstruction and read every shard twice.

**Two S3 API gaps found by the new harness.** `ListParts` was never routed, so a client enumerating an upload in progress got GetObject's 404 for the bare key. And a completion carrying an empty part list was rejected — AWS requires the list, but MinIO treats the empty case as "everything uploaded" and clients written against MinIO rely on it. A client that does send a list is still held to that list exactly.

## Measured

`make e2e-performance`, both sides carrying the compatibility fixes so the comparison isolates the performance change.

| Workload | Before | After | Change |
|---|---|---|---|
| `put` 1 MiB | 724.8 MiB/s, p99 8.6 ms | 840.3 MiB/s, p99 7.7 ms | **+16%** |
| `multipart-put` 2 x 5 MiB | 333.9 MiB/s, p99 71.0 ms | 521.7 MiB/s, p99 47.4 ms | **+56%**, p99 -33% |
| `get` 10 MiB | 778.8 MiB/s, p50 49.0 ms | 782.2 MiB/s, p50 49.7 ms | unchanged (control) |

## Verification

- Bind planes confirmed at runtime: a single-node colocated host opens exactly one socket (the gate) and builds no QUIC transport at all; a two-host config puts S3 on the wildcard and raft/blob strictly on the LAN address.
- New tests cover the write path at RS(1,0), (2,1) and (3,2), empty objects, short bodies, the bounded completion window, fetcher shutdown on close, and ListParts paging.
- `make preflight`: lint 0 issues, govulncheck clean. **The coverage gate fails at 51.9% against the 65% minimum** — pre-existing, and this branch raises it from the 44.6% dev baseline.

## Note for the reviewer

Spinifex has a companion PR that renders the templates with the planes split. It cannot build until this merges, because `spinifex/services/predastore/predastore.go` sets a gate's `BindAddr` and dev's `config.Node` has no such field. Merge this first, then repin spinifex's go.mod to the merged dev commit.