### PR TITLE
feat: report meta replica raft status over the rpc mux

### DIFF
--- a/internal/meta/client.go
+++ b/internal/meta/client.go
@@ -223,6 +223,35 @@ func (c *Client) ListKeys(ctx context.Context, prefix string) ([]string, error) 
 	return keys, nil
 }
 
+// Status queries target directly for its raft state. Unlike Get and Scan, it
+// consults exactly the replica named: it never tries another replica and
+// never follows a not-leader redirect, because the caller is asking what
+// this specific process observes, not for a leader-consistent answer.
+func (c *Client) Status(ctx context.Context, target config.NodeID) (MetaStatus, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	stream, err := rpc.OpenStream(ctx, c.rpc, target, OpMetaStatus, &MetaStatusRequest{})
+	if err != nil {
+		return MetaStatus{}, fmt.Errorf("open stream to replica %d: %w", target, err)
+	}
+	if err := stream.Close(); err != nil {
+		return MetaStatus{}, fmt.Errorf("half-close stream to replica %d: %w", target, err)
+	}
+
+	// The response can block until the deadline; abort the read side when
+	// the context fires so the decode does not outlive the attempt.
+	stop := context.AfterFunc(ctx, func() { stream.CancelRead(0) })
+	defer stop()
+
+	var status MetaStatus
+	if err := json.NewDecoder(stream).Decode(&status); err != nil {
+		stream.CancelRead(0)
+		return MetaStatus{}, fmt.Errorf("decode status from replica %d: %w", target, err)
+	}
+	return status, nil
+}
+
 // Put stores a key-value pair through the leader.
 func (c *Client) Put(ctx context.Context, key string, value []byte) error {
 	return c.write(ctx, OpMetaPut, request(key, 0), value)

--- a/internal/meta/handlers.go
+++ b/internal/meta/handlers.go
@@ -64,6 +64,14 @@ func (s *Server) writeResult(err error) *MetaResponse {
 	return &MetaResponse{}
 }
 
+// handleStatus reports this replica's raft state. It is answered from local
+// state, never blocks on consensus, and cannot fail the way a data operation
+// can, so there is no error envelope to fill in.
+func (s *Server) handleStatus(ctx context.Context, h MetaStatusRequest, stream transport.Stream) error {
+	status := s.status()
+	return json.NewEncoder(stream).Encode(&status)
+}
+
 func (s *Server) handleScan(ctx context.Context, h MetaRequest, stream transport.Stream) error {
 	// errScanLimit stops iteration once the limit is reached without
 	// surfacing an error to the client.

--- a/internal/meta/protocol.go
+++ b/internal/meta/protocol.go
@@ -23,6 +23,10 @@ const (
 	OpMetaPut    rpc.Opcode = 0x1002
 	OpMetaDelete rpc.Opcode = 0x1003
 	OpMetaScan   rpc.Opcode = 0x1004
+
+	// OpMetaStatus asks a replica to report its own raft state, rather than
+	// any data it holds.
+	OpMetaStatus rpc.Opcode = 0x1005
 )
 
 // Response error codes with protocol meaning; anything else in Err is an
@@ -102,3 +106,45 @@ type ScanItem struct {
 	Key   []byte `json:"key"`
 	Value []byte `json:"value"`
 }
+
+// MetaStatusRequest carries no fields: OpMetaStatus asks about the replica
+// answering the stream, never about a key.
+type MetaStatusRequest struct{}
+
+func (h *MetaStatusRequest) Append(buf []byte) ([]byte, error) { return appendJSON(buf, h) }
+func (h *MetaStatusRequest) Unmarshal(b []byte) error          { return json.Unmarshal(b, h) }
+
+// MetaStatus is one replica's raft state, closing an OpMetaStatus stream. A
+// caller outside this module already decodes this exact JSON shape, so the
+// field names are a wire contract and must not change independently of it.
+//
+// Leader and LeaderAddr are both empty while raft has no leader, which is a
+// successful answer rather than an error: "answered, but reports no leader"
+// is the condition a status probe exists to surface.
+type MetaStatus struct {
+	// NodeID is the replica that answered, not the one asked about.
+	NodeID string `json:"node_id"`
+	// State is this replica's own raft.State(): "Follower", "Candidate",
+	// "Leader" or "Shutdown".
+	State string `json:"state"`
+	// Leader is the raft advertise address ("node-<id>") of the leader this
+	// replica currently observes, empty when it observes none.
+	Leader string `json:"leader"`
+	// LeaderAddr is the address this replica would dial Leader on, resolved
+	// from the same routing table its own rpc traffic uses. It is left
+	// empty rather than repeating Leader when no distinct dial address is
+	// known — including when this replica is itself the leader, since a
+	// replica holds no route to dial itself.
+	LeaderAddr string `json:"leader_addr"`
+	// Term, CommitIndex and AppliedIndex come from raft.Stats(), which
+	// already renders them as strings.
+	Term         string `json:"term"`
+	CommitIndex  string `json:"commit_index"`
+	AppliedIndex string `json:"applied_index"`
+	// IsLeader is State == "Leader", spelled out for callers that only care
+	// about that.
+	IsLeader bool `json:"is_leader"`
+}
+
+func (h *MetaStatus) Append(buf []byte) ([]byte, error) { return appendJSON(buf, h) }
+func (h *MetaStatus) Unmarshal(b []byte) error          { return json.Unmarshal(b, h) }

--- a/internal/meta/server.go
+++ b/internal/meta/server.go
@@ -122,6 +122,7 @@ func (s *Server) open() (*rpc.Server, error) {
 	rpc.RegisterHandler(mux, OpMetaPut, s.handlePut)
 	rpc.RegisterHandler(mux, OpMetaDelete, s.handleDelete)
 	rpc.RegisterHandler(mux, OpMetaScan, s.handleScan)
+	rpc.RegisterHandler(mux, OpMetaStatus, s.handleStatus)
 	srv, err := rpc.NewServer(mux, s.cfg.Listeners, s.pool)
 	if err != nil {
 		return nil, err
@@ -348,4 +349,44 @@ func (s *Server) scan(prefix string, fn func(key string, value []byte) error) er
 func (s *Server) leaderAddr() string {
 	addr, _ := s.raft.LeaderWithID()
 	return string(addr)
+}
+
+// status reports this replica's own view of the cluster: its raft state, the
+// leader it currently observes and where that leader would be dialed, and
+// its log position. It reads only local raft state, so it always succeeds —
+// including while there is no leader to report.
+func (s *Server) status() MetaStatus {
+	stats := s.raft.Stats()
+	leader := string(s.raft.Leader())
+
+	return MetaStatus{
+		NodeID:       strconv.FormatUint(uint64(s.cfg.NodeID), 10),
+		State:        stats["state"],
+		Leader:       leader,
+		LeaderAddr:   s.leaderDialAddr(leader),
+		Term:         stats["term"],
+		CommitIndex:  stats["commit_index"],
+		AppliedIndex: stats["applied_index"],
+		IsLeader:     s.raft.State() == raft.Leader,
+	}
+}
+
+// leaderDialAddr resolves a raft advertise address to the address this
+// replica would dial it on, using the same routing table its own rpc traffic
+// uses. It returns empty whenever that resolution adds nothing new: no
+// leader, an address this replica's table does not name, or this replica's
+// own address, since nothing dials itself.
+func (s *Server) leaderDialAddr(leader string) string {
+	if leader == "" {
+		return ""
+	}
+	id, err := ParseRaftAddress(leader)
+	if err != nil {
+		return ""
+	}
+	route, err := s.cfg.Resolver.Route(id)
+	if err != nil {
+		return ""
+	}
+	return route.Addr.String()
 }

--- a/internal/meta/status_test.go
+++ b/internal/meta/status_test.go
@@ -1,0 +1,119 @@
+package meta_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore/internal/config"
+	"github.com/mulgadc/predastore/internal/meta"
+	"github.com/mulgadc/predastore/internal/rpc"
+	"github.com/mulgadc/predastore/internal/transport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// statusTestCfg names two meta nodes on one host: node 1 is the replica
+// under test and node 2 exists only so a resolver can be built for a
+// distinct "client" source, addressed to node 1 over the pipe.
+func statusTestCfg() *config.Config {
+	return &config.Config{
+		Hosts: []config.Host{{
+			ID:   1,
+			Addr: "status-test-host",
+			Nodes: []config.Node{
+				{ID: 1, Role: config.RoleMeta, Port: 6101},
+				{ID: 2, Role: config.RoleMeta, Port: 6102},
+			},
+		}},
+	}
+}
+
+// startStatusReplica runs one meta replica over a pipe transport, bootstrapping
+// it as a single-node cluster only when bootstrap is true, and returns a
+// client addressed to it plus a cleanup that stops the replica.
+func startStatusReplica(t *testing.T, bootstrap bool) *meta.Client {
+	t.Helper()
+	cfg := statusTestCfg()
+
+	serverTr := transport.NewPipeTransport("status-test-host", 6101)
+	t.Cleanup(func() { serverTr.Close() })
+	ln, err := serverTr.Listen()
+	require.NoError(t, err)
+
+	serverRes, err := rpc.NewResolver(cfg, 1, serverTr)
+	require.NoError(t, err)
+
+	svc, err := meta.New(meta.Config{
+		NodeID:    1,
+		DataDir:   t.TempDir(),
+		Peers:     []config.NodeID{1},
+		Bootstrap: bootstrap,
+		Listeners: []transport.Listener{ln},
+		Resolver:  serverRes,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- svc.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+
+	clientTr := transport.NewPipeTransport("status-test-client", 0)
+	t.Cleanup(func() { clientTr.Close() })
+	clientRes, err := rpc.NewResolver(cfg, 2, clientTr)
+	require.NoError(t, err)
+	connPool := rpc.NewConnPool(2, clientRes)
+	t.Cleanup(func() { connPool.Close() })
+
+	cli, err := meta.NewClient(meta.ClientConfig{
+		Client:   rpc.NewClient(connPool),
+		Replicas: []config.NodeID{1},
+	})
+	require.NoError(t, err)
+	return cli
+}
+
+// TestClient_Status_Leader confirms a bootstrapped single-node replica
+// eventually reports itself as leader, with the wire fields sourced from
+// the plan: node id, raft state, its own leader observation and log
+// position.
+func TestClient_Status_Leader(t *testing.T) {
+	cli := startStatusReplica(t, true)
+
+	require.Eventually(t, func() bool {
+		st, err := cli.Status(context.Background(), 1)
+		return err == nil && st.IsLeader
+	}, 5*time.Second, 20*time.Millisecond, "replica never became leader")
+
+	st, err := cli.Status(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Equal(t, "1", st.NodeID)
+	assert.Equal(t, "Leader", st.State)
+	assert.True(t, st.IsLeader)
+	assert.Equal(t, meta.RaftAddress(1), st.Leader)
+	assert.NotEmpty(t, st.Term)
+	assert.NotEmpty(t, st.CommitIndex)
+	// A replica holds no route to dial itself, so it cannot resolve a dial
+	// address for a leader that is itself.
+	assert.Empty(t, st.LeaderAddr)
+}
+
+// TestClient_Status_NoLeader pins the exact condition this feature exists
+// for: a replica that has never bootstrapped stays a follower with no
+// leader indefinitely, and Status must answer that successfully rather than
+// returning an error.
+func TestClient_Status_NoLeader(t *testing.T) {
+	cli := startStatusReplica(t, false)
+
+	st, err := cli.Status(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Equal(t, "1", st.NodeID)
+	assert.Equal(t, "Follower", st.State)
+	assert.False(t, st.IsLeader)
+	assert.Empty(t, st.Leader)
+	assert.Empty(t, st.LeaderAddr)
+}

--- a/internal/rpc/resolver.go
+++ b/internal/rpc/resolver.go
@@ -94,6 +94,35 @@ func NewResolver(cfg *config.Config, source config.NodeID, trs ...transport.Tran
 	return r, nil
 }
 
+// NewRemoteResolver builds a route table that reaches every node over quic,
+// including ones NewResolver would put on the pipe. It is for callers that
+// are not a node in the cluster at all — a status probe run from another
+// binary, say — which have no in-process pipe to any node, even one
+// colocated on the same physical host: the pipe transport rendezvous is a
+// process-wide registry, and such a caller is never in that process.
+func NewRemoteResolver(cfg *config.Config, quic transport.Transport) (*Resolver, error) {
+	r := &Resolver{
+		routes: make(map[config.NodeID]Route),
+		nodes:  make(map[addrKey]config.NodeID),
+	}
+	for _, h := range cfg.Hosts {
+		for _, n := range h.Nodes {
+			if n.Role == config.RoleGate {
+				continue
+			}
+			addr := transport.NewAddr(transport.NetworkQUIC, net.JoinHostPort(h.Addr, strconv.Itoa(n.Port)))
+			// Two nodes at one address is a configuration the table cannot
+			// reverse, so NodeAt would have to guess between them.
+			if other, ok := r.nodes[addrKeyOf(addr)]; ok {
+				return nil, fmt.Errorf("nodes %d and %d are both at %s %s", other, n.ID, addr.Network(), addr)
+			}
+			r.routes[n.ID] = Route{Transport: quic, Addr: addr}
+			r.nodes[addrKeyOf(addr)] = n.ID
+		}
+	}
+	return r, nil
+}
+
 // Route is the route to a node. A node with no route is one nothing dials:
 // this node itself, or a gate.
 func (r *Resolver) Route(remote config.NodeID) (Route, error) {

--- a/internal/transport/quic.go
+++ b/internal/transport/quic.go
@@ -42,7 +42,7 @@ func WithRootCAs(p *x509.CertPool) QUICOption {
 type QUICTransport struct {
 	pc      *net.UDPConn
 	tr      *quic.Transport
-	cert    tls.Certificate
+	cert    *tls.Certificate
 	rootCAs *x509.CertPool
 	addr    *Addr
 
@@ -58,6 +58,37 @@ func NewQUICTransport(addr string, port int, cert, key string, opts ...QUICOptio
 	if err != nil {
 		return nil, fmt.Errorf("load x509 key pair from %s/%s: %w", cert, key, err)
 	}
+	qt, err := bindQUIC(addr, port)
+	if err != nil {
+		return nil, err
+	}
+	qt.cert = &kp
+	for _, opt := range opts {
+		opt(qt)
+	}
+	return qt, nil
+}
+
+// NewQUICDialTransport binds a UDP socket at addr:port for dialing only, with
+// no TLS identity of its own. Dial never presents a client certificate — the
+// wire has nowhere for one, since nothing in this cluster requests one back —
+// so a transport built to dial rather than listen needs none to load, and
+// asking a caller with no stake in this cluster's PKI for one would be asking
+// for something it has no business holding. Listen on it always fails.
+func NewQUICDialTransport(addr string, port int, opts ...QUICOption) (*QUICTransport, error) {
+	qt, err := bindQUIC(addr, port)
+	if err != nil {
+		return nil, err
+	}
+	for _, opt := range opts {
+		opt(qt)
+	}
+	return qt, nil
+}
+
+// bindQUIC opens the UDP socket both constructors share; the caller fills in
+// whatever TLS identity its own use of the transport needs, if any.
+func bindQUIC(addr string, port int) (*QUICTransport, error) {
 	hostPort := net.JoinHostPort(addr, strconv.Itoa(port))
 	udpAddr, err := net.ResolveUDPAddr("udp", hostPort)
 	if err != nil {
@@ -68,16 +99,11 @@ func NewQUICTransport(addr string, port int, cert, key string, opts ...QUICOptio
 		return nil, fmt.Errorf("quic bind %s: %w", hostPort, err)
 	}
 
-	qt := &QUICTransport{
+	return &QUICTransport{
 		pc:   pc,
 		tr:   &quic.Transport{Conn: pc},
-		cert: kp,
 		addr: NewAddr(NetworkQUIC, pc.LocalAddr().String()),
-	}
-	for _, opt := range opts {
-		opt(qt)
-	}
-	return qt, nil
+	}, nil
 }
 
 func (qt *QUICTransport) Network() string { return string(NetworkQUIC) }
@@ -97,9 +123,12 @@ func (qt *QUICTransport) Listen() (Listener, error) {
 	if qt.ln != nil {
 		return nil, &net.OpError{Op: "listen", Net: string(NetworkQUIC), Addr: qt.addr, Err: ErrAddrAlreadyInUse}
 	}
+	if qt.cert == nil {
+		return nil, fmt.Errorf("quic transport at %s has no TLS identity to listen with", qt.addr)
+	}
 
 	tlsConf := &tls.Config{
-		Certificates:     []tls.Certificate{qt.cert},
+		Certificates:     []tls.Certificate{*qt.cert},
 		MinVersion:       tls.VersionTLS13,
 		CurvePreferences: tlsconfig.Curves,
 		NextProtos:       []string{alpnProto},

--- a/internal/transport/quic_test.go
+++ b/internal/transport/quic_test.go
@@ -230,3 +230,92 @@ func TestQUICDialUntrustedServer(t *testing.T) {
 		t.Fatal("Dial with untrusted CA succeeded")
 	}
 }
+
+// TestQUICDialTransportRoundTrip confirms a transport built with no TLS
+// identity of its own can still dial and carry a stream: Dial has never
+// presented a client certificate, so a dial-only transport losing the
+// ability to load one changes nothing about what a peer sees.
+func TestQUICDialTransportRoundTrip(t *testing.T) {
+	certPath, keyPath, pool := testcerts.Generate(t)
+	server, err := transport.NewQUICTransport("127.0.0.1", 0, certPath, keyPath)
+	if err != nil {
+		t.Fatalf("NewQUICTransport: %v", err)
+	}
+	defer server.Close()
+	ln, err := server.Listen()
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+
+	client, err := transport.NewQUICDialTransport("127.0.0.1", 0, transport.WithRootCAs(pool))
+	if err != nil {
+		t.Fatalf("NewQUICDialTransport: %v", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	acceptedCh := make(chan transport.Conn, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		c, err := ln.Accept(ctx)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		acceptedCh <- c
+	}()
+
+	dial, err := client.Dial(ctx, ln.Addr())
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer dial.Close()
+
+	var accepted transport.Conn
+	select {
+	case accepted = <-acceptedCh:
+	case err := <-errCh:
+		t.Fatalf("Accept: %v", err)
+	}
+	defer accepted.Close()
+
+	opened, err := dial.OpenStream(ctx)
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	msg := []byte("hello over a dial-only transport")
+	if _, err := opened.Write(msg); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	opened.Close()
+
+	stream, err := accepted.AcceptStream(ctx)
+	if err != nil {
+		t.Fatalf("AcceptStream: %v", err)
+	}
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, msg) {
+		t.Fatalf("got %q, want %q", got, msg)
+	}
+}
+
+// TestQUICDialTransportListenFails confirms a dial-only transport refuses to
+// listen rather than crashing a peer's handshake against an empty
+// certificate: it has none to present, so Listen must say so up front.
+func TestQUICDialTransportListenFails(t *testing.T) {
+	client, err := transport.NewQUICDialTransport("127.0.0.1", 0)
+	if err != nil {
+		t.Fatalf("NewQUICDialTransport: %v", err)
+	}
+	defer client.Close()
+
+	if _, err := client.Listen(); err == nil {
+		t.Fatal("Listen on a dial-only transport succeeded")
+	}
+}

--- a/status.go
+++ b/status.go
@@ -1,0 +1,116 @@
+package predastore
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	"github.com/mulgadc/predastore/internal/meta"
+	"github.com/mulgadc/predastore/internal/rpc"
+	"github.com/mulgadc/predastore/internal/transport"
+)
+
+// Status is one meta replica's raft state: its own node id, its raft.State,
+// the leader it currently observes (empty when the cluster has none), and
+// the raft term and log positions behind that view. It is a type alias
+// because this is exactly the response OpMetaStatus answers with, and a
+// consumer outside this module already decodes its JSON shape.
+type Status = meta.MetaStatus
+
+// MetaNodesOnHost returns the meta node ids pinned to host, in id order. A
+// host running no meta node, or an id naming no host, returns nil: neither
+// is an error, since a host is free to run no consensus replica of its own.
+func MetaNodesOnHost(cfg *Config, host HostID) []NodeID {
+	h, ok := hostOf(cfg, host)
+	if !ok {
+		return nil
+	}
+	var ids []NodeID
+	for _, n := range h.Nodes {
+		if n.Role == RoleMeta {
+			ids = append(ids, n.ID)
+		}
+	}
+	return ids
+}
+
+// NodeStatus dials the meta replica named by node directly, over the
+// network, and returns its raft status. It queries that one replica only:
+// unlike a data read it never falls back to another replica or follows a
+// leader redirect, because the caller is asking what this specific process
+// observes, which is exactly what a health probe needs.
+//
+// The caller need not be a member of the cluster or hold any identity of
+// its own — a monitoring daemon reading the same configuration file
+// predastore runs from is the intended shape. Building the quic transport a
+// dial-only connection needs still requires loading a TLS keypair (the type
+// serves listening too), so NodeStatus reuses the target's own host
+// identity for it; that keypair is never presented on a dial-only
+// connection; TLS trust is not the OS store but a pool holding exactly the
+// certificate the configuration names for that host, which is the
+// verification a caller with nothing but the config file can do without an
+// externally supplied CA.
+func NodeStatus(ctx context.Context, cfg *Config, node NodeID) (Status, error) {
+	host, ok := hostOfNode(cfg, node)
+	if !ok {
+		return Status{}, fmt.Errorf("node %d is not in the configuration", node)
+	}
+
+	pool, err := trustedPool(host.TLSCert)
+	if err != nil {
+		return Status{}, fmt.Errorf("load host %d TLS identity: %w", host.ID, err)
+	}
+
+	quic, err := transport.NewQUICTransport(HostBindAddr(host), 0, host.TLSCert, host.TLSKey, transport.WithRootCAs(pool))
+	if err != nil {
+		return Status{}, fmt.Errorf("create status transport: %w", err)
+	}
+	defer quic.Close()
+
+	res, err := rpc.NewRemoteResolver(cfg, quic)
+	if err != nil {
+		return Status{}, fmt.Errorf("build status resolver: %w", err)
+	}
+
+	connPool := rpc.NewConnPool(node, res)
+	defer connPool.Close()
+
+	cli, err := meta.NewClient(meta.ClientConfig{
+		Client:   rpc.NewClient(connPool),
+		Replicas: []NodeID{node},
+	})
+	if err != nil {
+		return Status{}, fmt.Errorf("create status client: %w", err)
+	}
+
+	return cli.Status(ctx, node)
+}
+
+// trustedPool reads a PEM certificate file and returns a pool trusting
+// exactly it. A status probe verifies the one identity its own
+// configuration names for the target host, rather than any certificate a
+// public CA happened to issue.
+func trustedPool(certPath string) (*x509.CertPool, error) {
+	pem, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, err
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("no certificates found in %s", certPath)
+	}
+	return pool, nil
+}
+
+// hostOfNode returns the host a node id is pinned to.
+func hostOfNode(c *Config, id NodeID) (HostConfig, bool) {
+	for _, h := range c.Hosts {
+		for _, n := range h.Nodes {
+			if n.ID == id {
+				return h, true
+			}
+		}
+	}
+	return HostConfig{}, false
+}

--- a/status.go
+++ b/status.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"os"
 
 	"github.com/mulgadc/predastore/internal/meta"
 	"github.com/mulgadc/predastore/internal/rpc"
@@ -41,28 +40,22 @@ func MetaNodesOnHost(cfg *Config, host HostID) []NodeID {
 // leader redirect, because the caller is asking what this specific process
 // observes, which is exactly what a health probe needs.
 //
-// The caller need not be a member of the cluster or hold any identity of
-// its own — a monitoring daemon reading the same configuration file
-// predastore runs from is the intended shape. Building the quic transport a
-// dial-only connection needs still requires loading a TLS keypair (the type
-// serves listening too), so NodeStatus reuses the target's own host
-// identity for it; that keypair is never presented on a dial-only
-// connection; TLS trust is not the OS store but a pool holding exactly the
-// certificate the configuration names for that host, which is the
-// verification a caller with nothing but the config file can do without an
-// externally supplied CA.
-func NodeStatus(ctx context.Context, cfg *Config, node NodeID) (Status, error) {
-	host, ok := hostOfNode(cfg, node)
-	if !ok {
+// The caller supplies rootCAs: the cluster's certificate authority, or any
+// pool naming exactly the certificates it should accept. cfg's per-host
+// tls_cert/tls_key name files on that host's own filesystem — a different
+// file under the same path on every host — so a caller reaching a node on
+// another machine cannot read them and must not guess at them. rootCAs is
+// how it verifies every node's identity instead. No local TLS identity of
+// the caller's own is required: nothing on this wire ever asks a dialer to
+// present one back, so NodeStatus asks for none either.
+func NodeStatus(ctx context.Context, cfg *Config, node NodeID, rootCAs *x509.CertPool) (Status, error) {
+	if _, ok := hostOfNode(cfg, node); !ok {
 		return Status{}, fmt.Errorf("node %d is not in the configuration", node)
 	}
 
-	pool, err := trustedPool(host.TLSCert)
-	if err != nil {
-		return Status{}, fmt.Errorf("load host %d TLS identity: %w", host.ID, err)
-	}
-
-	quic, err := transport.NewQUICTransport(HostBindAddr(host), 0, host.TLSCert, host.TLSKey, transport.WithRootCAs(pool))
+	// The transport binds its own outbound socket; it is not the target's
+	// address, so there is no host-specific bind address to pick.
+	quic, err := transport.NewQUICDialTransport("", 0, transport.WithRootCAs(rootCAs))
 	if err != nil {
 		return Status{}, fmt.Errorf("create status transport: %w", err)
 	}
@@ -85,22 +78,6 @@ func NodeStatus(ctx context.Context, cfg *Config, node NodeID) (Status, error) {
 	}
 
 	return cli.Status(ctx, node)
-}
-
-// trustedPool reads a PEM certificate file and returns a pool trusting
-// exactly it. A status probe verifies the one identity its own
-// configuration names for the target host, rather than any certificate a
-// public CA happened to issue.
-func trustedPool(certPath string) (*x509.CertPool, error) {
-	pem, err := os.ReadFile(certPath)
-	if err != nil {
-		return nil, err
-	}
-	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(pem) {
-		return nil, fmt.Errorf("no certificates found in %s", certPath)
-	}
-	return pool, nil
 }
 
 // hostOfNode returns the host a node id is pinned to.

--- a/status_test.go
+++ b/status_test.go
@@ -1,0 +1,124 @@
+package predastore_test
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore"
+	"github.com/mulgadc/predastore/internal/config"
+	"github.com/mulgadc/predastore/internal/meta"
+	"github.com/mulgadc/predastore/internal/rpc"
+	"github.com/mulgadc/predastore/internal/testcerts"
+	"github.com/mulgadc/predastore/internal/transport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// startStatusCluster runs one meta replica reachable over quic on loopback,
+// the shape a caller outside the predastore process — the intended use of
+// predastore.NodeStatus — actually reaches a node through. It returns the
+// config describing that one-node cluster and blocks until the replica has
+// elected itself leader.
+func startStatusCluster(t *testing.T) *predastore.Config {
+	t.Helper()
+
+	certPath, keyPath, _ := testcerts.Generate(t)
+
+	quic, err := transport.NewQUICTransport("127.0.0.1", 0, certPath, keyPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { quic.Close() })
+	ln, err := quic.Listen()
+	require.NoError(t, err)
+
+	_, portStr, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		Hosts: []config.Host{{
+			ID:      1,
+			Addr:    "127.0.0.1",
+			TLSCert: certPath,
+			TLSKey:  keyPath,
+			Nodes: []config.Node{
+				{ID: 1, Role: config.RoleMeta, Port: port},
+			},
+		}},
+	}
+
+	res, err := rpc.NewResolver(cfg, 1, quic)
+	require.NoError(t, err)
+
+	leader := make(chan struct{})
+	svc, err := meta.New(meta.Config{
+		NodeID:    1,
+		DataDir:   t.TempDir(),
+		Peers:     []config.NodeID{1},
+		Bootstrap: true,
+		Listeners: []transport.Listener{ln},
+		Resolver:  res,
+		OnLeader:  sync.OnceFunc(func() { close(leader) }),
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- svc.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+
+	select {
+	case <-leader:
+	case <-time.After(5 * time.Second):
+		t.Fatal("replica never elected a leader")
+	}
+
+	return cfg
+}
+
+// TestNodeStatus_EndToEnd exercises the whole re-exported surface a caller
+// outside this module has: build a Config, hand it and a node id to
+// NodeStatus, get back the raft status that Config's own node answers with —
+// with no other predastore import required, which is the point of status.go.
+func TestNodeStatus_EndToEnd(t *testing.T) {
+	cfg := startStatusCluster(t)
+
+	require.Equal(t, []predastore.NodeID{1}, predastore.MetaNodesOnHost(cfg, 1))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	st, err := predastore.NodeStatus(ctx, cfg, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "1", st.NodeID)
+	assert.Equal(t, "Leader", st.State)
+	assert.True(t, st.IsLeader)
+	assert.NotEmpty(t, st.Leader)
+	assert.NotEmpty(t, st.Term)
+}
+
+// TestNodeStatus_UnknownNode confirms a node id absent from the
+// configuration is a plain error rather than a nil-pointer surprise: this is
+// the mistake a caller passing the wrong id makes, not the cluster's, so it
+// should read as one.
+func TestNodeStatus_UnknownNode(t *testing.T) {
+	cfg := startStatusCluster(t)
+
+	_, err := predastore.NodeStatus(context.Background(), cfg, 99)
+	require.Error(t, err)
+}
+
+// TestMetaNodesOnHost_NoHost confirms an id naming no host is nil rather
+// than an error: a host running no meta node of its own is a normal
+// topology, not a mistake.
+func TestMetaNodesOnHost_NoHost(t *testing.T) {
+	cfg := startStatusCluster(t)
+	assert.Nil(t, predastore.MetaNodesOnHost(cfg, 99))
+}

--- a/status_test.go
+++ b/status_test.go
@@ -2,7 +2,15 @@ package predastore_test
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"net"
+	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"testing"
@@ -18,15 +26,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// startStatusCluster runs one meta replica reachable over quic on loopback,
-// the shape a caller outside the predastore process — the intended use of
-// predastore.NodeStatus — actually reaches a node through. It returns the
-// config describing that one-node cluster and blocks until the replica has
-// elected itself leader.
-func startStatusCluster(t *testing.T) *predastore.Config {
+// startReplicaOverQUIC runs one meta replica reachable over quic on
+// loopback, presenting certPath/keyPath, and blocks until it has
+// bootstrapped and elected itself leader. It returns the one-node cluster
+// config the replica answers as.
+func startReplicaOverQUIC(t *testing.T, certPath, keyPath string) *predastore.Config {
 	t.Helper()
-
-	certPath, keyPath, _ := testcerts.Generate(t)
 
 	quic, err := transport.NewQUICTransport("127.0.0.1", 0, certPath, keyPath)
 	require.NoError(t, err)
@@ -83,19 +88,27 @@ func startStatusCluster(t *testing.T) *predastore.Config {
 	return cfg
 }
 
+// startStatusCluster is startReplicaOverQUIC with a self-signed certificate,
+// returning the pool that trusts exactly it alongside the cluster config.
+func startStatusCluster(t *testing.T) (*predastore.Config, *x509.CertPool) {
+	t.Helper()
+	certPath, keyPath, pool := testcerts.Generate(t)
+	return startReplicaOverQUIC(t, certPath, keyPath), pool
+}
+
 // TestNodeStatus_EndToEnd exercises the whole re-exported surface a caller
-// outside this module has: build a Config, hand it and a node id to
-// NodeStatus, get back the raft status that Config's own node answers with —
-// with no other predastore import required, which is the point of status.go.
+// outside this module has: build a Config, hand it, a node id and a trusted
+// CA pool to NodeStatus, get back the raft status that Config's own node
+// answers with — with no other predastore import required.
 func TestNodeStatus_EndToEnd(t *testing.T) {
-	cfg := startStatusCluster(t)
+	cfg, pool := startStatusCluster(t)
 
 	require.Equal(t, []predastore.NodeID{1}, predastore.MetaNodesOnHost(cfg, 1))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	st, err := predastore.NodeStatus(ctx, cfg, 1)
+	st, err := predastore.NodeStatus(ctx, cfg, 1, pool)
 	require.NoError(t, err)
 	assert.Equal(t, "1", st.NodeID)
 	assert.Equal(t, "Leader", st.State)
@@ -109,9 +122,9 @@ func TestNodeStatus_EndToEnd(t *testing.T) {
 // the mistake a caller passing the wrong id makes, not the cluster's, so it
 // should read as one.
 func TestNodeStatus_UnknownNode(t *testing.T) {
-	cfg := startStatusCluster(t)
+	cfg, pool := startStatusCluster(t)
 
-	_, err := predastore.NodeStatus(context.Background(), cfg, 99)
+	_, err := predastore.NodeStatus(context.Background(), cfg, 99, pool)
 	require.Error(t, err)
 }
 
@@ -119,6 +132,92 @@ func TestNodeStatus_UnknownNode(t *testing.T) {
 // than an error: a host running no meta node of its own is a normal
 // topology, not a mistake.
 func TestMetaNodesOnHost_NoHost(t *testing.T) {
-	cfg := startStatusCluster(t)
+	cfg, _ := startStatusCluster(t)
 	assert.Nil(t, predastore.MetaNodesOnHost(cfg, 99))
+}
+
+// TestNodeStatus_CrossHostCertificate is the shape a real deployment is:
+// every [[host]] names the same tls_cert/tls_key path, but each host's file
+// there holds a different certificate. The caller here holds neither the
+// target's certificate nor its key — only the CA that issued it — and the
+// target's config entry points at paths that do not exist on this machine
+// at all, so the test fails outright if NodeStatus ever tries to read them.
+func TestNodeStatus_CrossHostCertificate(t *testing.T) {
+	ca, caKey := genTestCA(t)
+	caPool := x509.NewCertPool()
+	caPool.AddCert(ca)
+
+	// A leaf distinct from anything the caller holds, signed by the shared
+	// CA rather than self-signed.
+	remoteCert, remoteKey := genTestLeaf(t, ca, caKey, "remote-meta-node")
+	cfg := startReplicaOverQUIC(t, remoteCert, remoteKey)
+
+	// Point the host's config entry at paths this process cannot read, to
+	// prove NodeStatus never touches them for a node it did not start.
+	cfg.Hosts[0].TLSCert = "/nonexistent/remote-host/server.pem"
+	cfg.Hosts[0].TLSKey = "/nonexistent/remote-host/server.key"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	st, err := predastore.NodeStatus(ctx, cfg, 1, caPool)
+	require.NoError(t, err)
+	assert.True(t, st.IsLeader)
+}
+
+// genTestCA creates a self-signed CA cert/key pair for issuing leaf
+// certificates from, distinct from testcerts.Generate's single self-signed
+// leaf: a status client must verify a node's cert through a CA it did not
+// itself present.
+func genTestCA(t *testing.T) (*x509.Certificate, *rsa.PrivateKey) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "predastore-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert, key
+}
+
+// genTestLeaf issues a certificate for name signed by ca/caKey, writes the
+// cert and key as PEM files under t.TempDir(), and returns their paths.
+func genTestLeaf(t *testing.T, ca *x509.Certificate, caKey *rsa.PrivateKey, name string) (certPath, keyPath string) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: name},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &key.PublicKey, caKey)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "leaf.pem")
+	keyPath = filepath.Join(dir, "leaf.key")
+	require.NoError(t, os.WriteFile(certPath,
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
+	require.NoError(t, os.WriteFile(keyPath,
+		pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}), 0o600))
+	return certPath, keyPath
 }


### PR DESCRIPTION
## Problem

`/health` on a spinifex node reports every service as `ok` without contacting it, and the one place that does try to probe predastore — `spx admin storage status`, via `queryMetaNodeStatus` — dials `https://<meta-host>:<port>/health` and `/status` on each meta node. Predastore's meta node has no HTTP server at all: it answers an opcode-multiplexed RPC (`internal/rpc`), registering `OpRaftDial`, `OpMetaGet`, `OpMetaPut`, `OpMetaDelete` and `OpMetaScan`. Both dials fail, so every meta node is reported unhealthy with blank raft fields, and a real outage (env19: no raft leader while a volume create was failing) went unnoticed because nothing was actually contacted.

The `MetaNodeStatus` shape spinifex already decodes — `node_id`, `state`, `leader`, `leader_addr`, `term`, `commit_index`, `applied_index`, `is_leader` — describes a producer that was never built.

## Fix

This is PR 1 of 2 (spinifex lands second, off this).

- `internal/meta/protocol.go` — `OpMetaStatus = 0x1005`, `MetaStatusRequest` (empty, following `RaftDial`), and `MetaStatus`, matching the exact JSON field names spinifex decodes. Leader and LeaderAddr are both legitimately empty when raft has no leader — that is a successful answer, not an error, since "answered, but reports no leader" is the exact condition this exists to make visible.
- `internal/meta/handlers.go` — `handleStatus`, answered from local raft state only, so it cannot fail the way a data operation can.
- `internal/meta/server.go` — registers the handler and adds `status()`/`leaderDialAddr()`, sourced from `raft.State()`, `raft.Leader()` and `raft.Stats()`. `leader` is the leader's raft advertise address (`node-<id>`); `leader_addr` is that address resolved through this replica's own routing table, left empty when there's nothing new to add (no leader, or the leader is this replica itself, which holds no route to dial itself).
- `internal/meta/client.go` — `Client.Status(ctx, target)`, a direct call to one named replica. Unlike `Get`/`Scan` it never falls back to another replica or follows a leader redirect, because the caller is asking what that specific process observes.
- `internal/rpc/resolver.go` — `NewRemoteResolver`, a new constructor alongside `NewResolver`. `NewResolver` treats a source node's own host as reachable over the in-process pipe, which only holds within the process that node actually runs in. A caller outside the cluster's own process (spinifex, in PR 2) has no such pipe even to a node on the same physical host, so it needs every route over quic regardless of host colocation — `NewResolver` cannot express that.
- `internal/transport/quic.go` — `NewQUICDialTransport`, a dial-only constructor that loads no TLS keypair. `Dial` has never presented a client certificate on this wire (only `Listen`'s side sets `Certificates`), so a transport built to dial rather than listen needs no identity of its own to load, and `Listen` on one now fails explicitly instead of handshaking with an empty certificate.
- `status.go` (new, root package) — the re-exported surface: a `Status` alias, `NodeStatus(ctx, cfg, node, rootCAs)` to dial one replica, and `MetaNodesOnHost(cfg, host)` to enumerate a host's meta nodes. `NodeStatus` takes the trust root explicitly from the caller rather than deriving one from `cfg`: `internal/config` has no CA field, only a per-host `tls_cert`/`tls_key` pair, and every host in a real cluster names the *same config path* for a *different* certificate, so there is no way to read the right trust material for a remote node off the local filesystem — the caller (spinifex, holding the cluster CA at `/etc/spinifex/ca.pem`) has to supply it. No local TLS identity is required either, matching what `Dial` actually needs.

## Testing

- `internal/meta/status_test.go` — a bootstrapped single-node replica eventually reports itself leader with the full field set populated; a replica that is never bootstrapped stays a follower with no leader indefinitely and `Status` still answers successfully (the no-leader case, tested explicitly, over a real single-node raft via pipe transport).
- `internal/transport/quic_test.go` — `NewQUICDialTransport` carries a real stream round trip with no TLS identity loaded, and `Listen` on one fails.
- `status_test.go` (root) — end to end against a real single-node cluster over quic; the unknown-node and no-meta-host error paths; and `TestNodeStatus_CrossHostCertificate`, which issues the target's certificate from a CA distinct from the caller, points the target's config entry at TLS paths that do not exist on the test process's filesystem at all, and confirms `NodeStatus` still verifies and succeeds using only the caller-supplied CA pool — the exact cross-host shape a multi-node cluster is.
- `make preflight`: `golangci-lint run ./...` clean, `govulncheck` reports no vulnerabilities in code reached by this change, diff coverage 82.5% (threshold 40%), overall coverage 41.9% (threshold 40%). `internal/blob/engine`'s property-based tests hang/OOM-kill in this sandbox on `origin/dev` as well as on this branch — confirmed pre-existing and unrelated via `git stash`.