### PR TITLE
ci: run build, test, race and lint on pull requests

### DIFF
--- a/.github/workflows/predastore.yml
+++ b/.github/workflows/predastore.yml
@@ -11,6 +11,10 @@ on:
       - go.sum
       - Makefile
       - .github/workflows/predastore.yml
+  pull_request:
+    branches:
+      - main
+      - dev
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem

`.github/workflows/predastore.yml` triggers only on `push` to `main` and `dev`, plus `workflow_dispatch`. There is no `pull_request` trigger, so every predastore PR reports `no checks reported on the ... branch` and can be merged entirely unverified. The workflow first runs on `dev` after the merge has already landed, which is the wrong end of the process to discover a break.

This matters beyond predastore: spinifex pins predastore by pseudo-version, so a broken `dev` reaches spinifex through a go.mod bump. Spinifex enforces four required checks on every PR; predastore enforces none.

## Change

Adds a `pull_request` trigger against `main` and `dev`, mirroring `spinifex.yml` exactly.

Deliberately no `paths:` filter on `pull_request`, matching spinifex. A filtered PR trigger would leave doc-only PRs reporting no checks at all, which is the state this change exists to remove and would make the checks unusable as branch-protection requirements.

Nothing else needs to change. The existing `fetch-depth: 2` and `scripts/diff-coverage.sh coverage.out --base HEAD~1` are already correct for a PR: GitHub checks out the `refs/pull/N/merge` commit, whose first parent is the base branch tip, so `HEAD~1` resolves to the right base.

## Follow-up, not in this PR

Making these checks **required** for merge is a branch-protection setting rather than a file, so it needs doing in the repo settings once this lands. Worth confirming the `internal/blob/engine` property tests are stable on a CI runner before requiring them — they hang under a memory-constrained sandbox, though they pass on a normal local run.