### PR TITLE
fix: serve pooled connections in both directions

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -122,9 +122,11 @@ Callers name peers by node id and never handle an address. `rpc.Resolver` is the
 
 ## Connection pooling
 
-`rpc.ConnPool` keys connections by node id, so a connection dialed to a peer and one accepted from it are the same entry on either transport, and a replica pair reuses one connection in both directions. An accepted connection is offered to the pool by `Donate`, which reverses the route table to name the peer behind it; a peer dialing from an ephemeral socket resolves to no node and is simply not pooled. When both ends open at once, both keep the connection the lower of the two node ids dialed and close the other, which each side computes from the same two ids.
+`rpc.ConnPool` keys connections by node id, so a connection dialed to a peer and one accepted from it are the same entry on either transport, and a replica pair reuses one connection in both directions. An accepted connection is offered to the pool by `Donate`, which reverses the route table to name the peer behind it; a peer dialing from an ephemeral socket resolves to no node and is simply not pooled. Reuse in both directions only holds if both ends answer streams on one connection, so `rpc.Server` serves what the pool dials as well as what a listener accepts: the pool hands each connection it opens to the server through `OnDial`, and a node with no server of its own — a gate — simply registers nothing and sends over what it dialed without being sent anything back.
 
-The pool runs no idle sweeper. A connection leaves through `Evict`, called by whichever side observes it die, or through `Close` when the node shuts down. Concurrent dials to one peer collapse onto a single connection via singleflight.
+The tiebreak that keeps one connection per pair is the same whether the slot is empty or not: each end keeps the connection the lower of the two node ids dialed, which both compute from the same two ids. An empty slot therefore refuses a donation the node would rather have dialed itself, and the peer keeps that connection for its own outbound use until this node's dial displaces it. A node's own dial is always kept, since refusing it would leave the end that prefers to accept with no way to open a connection at all.
+
+The pool runs no idle sweeper. A connection leaves through `Evict`, called by whichever side observes it die, or through `Close` when the node shuts down. It also leaves once `maxStreamStalls` (3) consecutive streams opened on it get no response byte at all, which is the only evidence available that a connection alive at the transport is answering nothing at the rpc layer; any response clears the run. Concurrent dials to one peer collapse onto a single connection via singleflight.
 
 | Layer | Lifetime | Cost |
 |---|---|---|

--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -3,7 +3,10 @@ package rpc
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
+	"io"
+	"sync/atomic"
 
 	"github.com/mulgadc/predastore/internal/config"
 	"github.com/mulgadc/predastore/internal/transport"
@@ -70,5 +73,45 @@ func OpenStream[T Header](
 		return nil, fmt.Errorf("write metadata + header: %w", err)
 	}
 
-	return stream, nil
+	return &healthStream{Stream: stream, pool: c.pool, conn: conn}, nil
+}
+
+var _ transport.Stream = (*healthStream)(nil)
+
+// healthStream reports the outcome of a response read back to the pool, which
+// has no other way to tell a connection that is serviced from one that takes
+// requests and answers none. A stream reports once: the first read decides.
+type healthStream struct {
+	transport.Stream
+
+	pool     *ConnPool
+	conn     transport.Conn
+	reported atomic.Bool
+}
+
+func (s *healthStream) note(n int64, err error) {
+	switch {
+	// A clean EOF with no bytes still means the peer served the stream and
+	// closed it, which is the opposite of a stall.
+	case n > 0 || errors.Is(err, io.EOF):
+		if s.reported.CompareAndSwap(false, true) {
+			s.pool.noteProgress(s.conn)
+		}
+	case err != nil:
+		if s.reported.CompareAndSwap(false, true) {
+			s.pool.noteStall(s.conn)
+		}
+	}
+}
+
+func (s *healthStream) Read(p []byte) (int, error) {
+	n, err := s.Stream.Read(p)
+	s.note(int64(n), err)
+	return n, err
+}
+
+func (s *healthStream) WriteTo(w io.Writer) (int64, error) {
+	n, err := s.Stream.WriteTo(w)
+	s.note(n, err)
+	return n, err
 }

--- a/internal/rpc/pool.go
+++ b/internal/rpc/pool.go
@@ -166,6 +166,21 @@ func (p *ConnPool) held(remote config.NodeID) (transport.Conn, error) {
 	return nil, nil
 }
 
+// Dialed is every connection the pool opened itself. A server starting after a
+// dial needs them: OnDial fires once, so a pool entry is the only record that a
+// connection was dialed while nothing was there to serve it.
+func (p *ConnPool) Dialed() []transport.Conn {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	conns := make([]transport.Conn, 0, len(p.conns))
+	for _, e := range p.conns {
+		if e.dialed {
+			conns = append(conns, e.conn)
+		}
+	}
+	return conns
+}
+
 // insert offers a connection to a peer's slot and reports what the pool holds
 // afterwards, plus whether that is c. Each end keeps the connection the lower
 // node id dialed, which they compute alike, whether the slot already holds one

--- a/internal/rpc/pool.go
+++ b/internal/rpc/pool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"sync"
 	"time"
@@ -18,6 +19,11 @@ import (
 // reconnect must build a new one.
 var ErrPoolClosed = errors.New("connection pool closed")
 
+// maxStreamStalls is how many streams in a row may get no response at all
+// before the pool drops the connection carrying them. One stall is ordinary
+// and three in a row is not a connection worth keeping.
+const maxStreamStalls = 3
+
 type PoolOption func(*ConnPool)
 
 // WithDialTimeout bounds a single dial. It does not bound Dial, which stops
@@ -26,12 +32,13 @@ func WithDialTimeout(d time.Duration) PoolOption {
 	return func(p *ConnPool) { p.dialTimeout = d }
 }
 
-// pooled is a connection and which side opened it. Both ends of a pair know
-// both node ids, so the side that opened one is all the extra input the
-// simultaneous-open tiebreak needs.
+// pooled is a connection, which side opened it, and the run of streams it has
+// answered nothing on. Both ends of a pair know both node ids, so the side that
+// opened one is all the extra input the simultaneous-open tiebreak needs.
 type pooled struct {
 	conn   transport.Conn
 	dialed bool
+	stalls int
 }
 
 // ConnPool holds one connection per peer node, whichever side opened it, and
@@ -48,6 +55,7 @@ type ConnPool struct {
 
 	mu     sync.RWMutex
 	conns  map[config.NodeID]pooled
+	serve  func(transport.Conn)
 	closed bool
 }
 
@@ -63,6 +71,16 @@ func NewConnPool(source config.NodeID, res *Resolver, opts ...PoolOption) *ConnP
 		opt(p)
 	}
 	return p
+}
+
+// OnDial registers what the pool hands each connection it dials to, so that
+// streams the peer opens on one are answered. A pool with nothing registered
+// carries only what this node sends over what it dialed, which is what a
+// caller that runs no server of its own wants.
+func (p *ConnPool) OnDial(serve func(transport.Conn)) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.serve = serve
 }
 
 // Dial returns the connection to a node, opening one if the pool holds none.
@@ -98,6 +116,9 @@ func (p *ConnPool) Dial(ctx context.Context, remote config.NodeID) (transport.Co
 		}
 		if kept == nil {
 			return nil, ErrPoolClosed
+		}
+		if kept == conn {
+			p.serveDialed(conn)
 		}
 		return kept, nil
 	})
@@ -146,10 +167,10 @@ func (p *ConnPool) held(remote config.NodeID) (transport.Conn, error) {
 }
 
 // insert offers a connection to a peer's slot and reports what the pool holds
-// afterwards, plus whether that is c. When both ends open at once each keeps
-// the connection the lower node id dialed, which they compute alike; anything
-// else is last-write-wins. A displaced connection is closed, a rejected one is
-// left to its caller.
+// afterwards, plus whether that is c. Each end keeps the connection the lower
+// node id dialed, which they compute alike, whether the slot already holds one
+// or not; anything else is last-write-wins. A displaced connection is closed, a
+// rejected one is left to its caller.
 func (p *ConnPool) insert(remote config.NodeID, c transport.Conn, dialed bool) (transport.Conn, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -157,16 +178,83 @@ func (p *ConnPool) insert(remote config.NodeID, c transport.Conn, dialed bool) (
 		return nil, false
 	}
 
+	preferred := p.source < remote
 	e, ok := p.conns[remote]
-	if ok && e.conn != c {
-		preferred := p.source < remote
+	switch {
+	case ok && e.conn != c:
 		if e.dialed != dialed && e.conn.Context().Err() == nil && e.dialed == preferred {
 			return e.conn, false
 		}
 		e.conn.Close()
+	case !ok && !dialed && preferred:
+		// An empty slot taking whatever arrived is how a node came to hold a
+		// connection the peer opened. Our own dial fills it instead; refusing
+		// our own would leave the other end of the tiebreak unable to open one
+		// at all.
+		return nil, false
 	}
 	p.conns[remote] = pooled{conn: c, dialed: dialed}
 	return c, true
+}
+
+// serveDialed hands a freshly dialed connection to whoever answers streams on
+// this node, so the peer can send over it too.
+func (p *ConnPool) serveDialed(c transport.Conn) {
+	p.mu.RLock()
+	serve := p.serve
+	p.mu.RUnlock()
+	if serve != nil {
+		serve(c)
+	}
+}
+
+// noteStall records a stream that got no response on c, evicting the connection
+// once the run of them reaches maxStreamStalls. A connection can be alive at
+// the transport and answer nothing at this layer, and this is the only evidence
+// of it there is.
+func (p *ConnPool) noteStall(c transport.Conn) {
+	p.mu.Lock()
+	remote, e, ok := p.entry(c)
+	if !ok {
+		p.mu.Unlock()
+		return
+	}
+	e.stalls++
+	if e.stalls < maxStreamStalls {
+		p.conns[remote] = e
+		p.mu.Unlock()
+		return
+	}
+	delete(p.conns, remote)
+	p.mu.Unlock()
+
+	slog.Warn("evicting unresponsive connection",
+		"node", remote,
+		"addr", c.RemoteAddr(),
+		"stalls", e.stalls)
+	c.Close()
+}
+
+// noteProgress clears the run of stalls on c: a connection that answered is
+// being serviced, whatever came before it.
+func (p *ConnPool) noteProgress(c transport.Conn) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if remote, e, ok := p.entry(c); ok && e.stalls != 0 {
+		e.stalls = 0
+		p.conns[remote] = e
+	}
+}
+
+// entry finds the slot holding c. The pool holds one connection per peer, so
+// the scan is over the peers of a single node.
+func (p *ConnPool) entry(c transport.Conn) (config.NodeID, pooled, bool) {
+	for remote, e := range p.conns {
+		if e.conn == c {
+			return remote, e, true
+		}
+	}
+	return 0, pooled{}, false
 }
 
 // Evict drops a connection and closes it. It is the only way a connection
@@ -174,11 +262,8 @@ func (p *ConnPool) insert(remote config.NodeID, c transport.Conn, dialed bool) (
 // release one through here.
 func (p *ConnPool) Evict(c transport.Conn) {
 	p.mu.Lock()
-	for remote, held := range p.conns {
-		if held.conn == c {
-			delete(p.conns, remote)
-			break
-		}
+	if remote, _, ok := p.entry(c); ok {
+		delete(p.conns, remote)
 	}
 	p.mu.Unlock()
 	c.Close()

--- a/internal/rpc/pool_test.go
+++ b/internal/rpc/pool_test.go
@@ -1,0 +1,273 @@
+package rpc
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore/internal/config"
+	"github.com/mulgadc/predastore/internal/transport"
+)
+
+const opPing Opcode = 0x7f01
+
+// pingHeader is the smallest header the mux can carry: a name the peer echoes
+// back, encoded as its own bytes.
+type pingHeader struct{ Name string }
+
+var _ Header = (*pingHeader)(nil)
+
+func (h *pingHeader) Append(buf []byte) ([]byte, error) { return append(buf, h.Name...), nil }
+func (h *pingHeader) Unmarshal(b []byte) error          { h.Name = string(b); return nil }
+
+// testNode is one node of a test cluster: its transport, the pool it dials
+// peers from and the server answering the streams it is sent.
+type testNode struct {
+	id     config.NodeID
+	tr     *transport.PipeTransport
+	pool   *ConnPool
+	client *Client
+	done   chan error
+}
+
+// testResolver builds a route table by hand, so a test names its peers without
+// a configuration behind them.
+func testResolver(own *transport.PipeTransport, peers map[config.NodeID]*transport.PipeTransport) *Resolver {
+	r := &Resolver{
+		routes: make(map[config.NodeID]Route, len(peers)),
+		nodes:  make(map[addrKey]config.NodeID, len(peers)),
+	}
+	for id, peer := range peers {
+		r.routes[id] = Route{Transport: own, Addr: peer.Addr()}
+		r.nodes[addrKeyOf(peer.Addr())] = id
+	}
+	return r
+}
+
+// newTestCluster wires one pipe-connected node per id, each running a server
+// that answers opPing. Every node is torn down when the test ends.
+func newTestCluster(t *testing.T, ids ...config.NodeID) map[config.NodeID]*testNode {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	trs := make(map[config.NodeID]*transport.PipeTransport, len(ids))
+	for _, id := range ids {
+		trs[id] = transport.NewPipeTransport(t.Name(), int(id))
+	}
+
+	nodes := make(map[config.NodeID]*testNode, len(ids))
+	for _, id := range ids {
+		peers := make(map[config.NodeID]*transport.PipeTransport, len(ids)-1)
+		for _, peer := range ids {
+			if peer != id {
+				peers[peer] = trs[peer]
+			}
+		}
+
+		ln, err := trs[id].Listen()
+		if err != nil {
+			t.Fatalf("listen for node %d: %v", id, err)
+		}
+
+		pool := NewConnPool(id, testResolver(trs[id], peers))
+		srv, err := NewServer(pingMux(), []transport.Listener{ln}, pool, WithDrainTimeout(2*time.Second))
+		if err != nil {
+			t.Fatalf("server for node %d: %v", id, err)
+		}
+
+		n := &testNode{id: id, tr: trs[id], pool: pool, client: NewClient(pool), done: make(chan error, 1)}
+		go func() { n.done <- srv.Run(ctx) }()
+		nodes[id] = n
+	}
+
+	t.Cleanup(func() {
+		cancel()
+		for _, n := range nodes {
+			select {
+			case <-n.done:
+			case <-time.After(10 * time.Second):
+				t.Errorf("node %d did not stop", n.id)
+			}
+			_ = n.pool.Close()
+			_ = n.tr.Close()
+		}
+	})
+	return nodes
+}
+
+func pingMux() *Mux {
+	mux := NewMux()
+	RegisterHandler(mux, opPing, func(_ context.Context, h pingHeader, stream transport.Stream) error {
+		_, err := stream.Write([]byte("pong:" + h.Name))
+		return err
+	})
+	return mux
+}
+
+// ping runs one request round trip, aborting the read side when ctx expires
+// the way a client with a deadline does.
+func ping(ctx context.Context, from *testNode, to config.NodeID) (string, error) {
+	stream, err := OpenStream(ctx, from.client, to, opPing, &pingHeader{Name: "hello"})
+	if err != nil {
+		return "", err
+	}
+	if err := stream.Close(); err != nil {
+		return "", err
+	}
+	stop := context.AfterFunc(ctx, func() { stream.CancelRead(0) })
+	defer stop()
+
+	b, err := io.ReadAll(stream)
+	return string(b), err
+}
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// TestDonatedConnectionAnswersOutboundCalls is the direction regression: a node
+// that adopts a connection its peer dialed must still get answers on it.
+func TestDonatedConnectionAnswersOutboundCalls(t *testing.T) {
+	nodes := newTestCluster(t, 1, 2)
+	// The lower id is the preferred dialer, so node 2 keeps what node 1 dials.
+	dialer, adopter := nodes[1], nodes[2]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if _, err := dialer.pool.Dial(ctx, adopter.id); err != nil {
+		t.Fatalf("dial node %d: %v", adopter.id, err)
+	}
+	waitFor(t, "the donated connection to be pooled", func() bool {
+		c, _ := adopter.pool.held(dialer.id)
+		return c != nil
+	})
+
+	callCtx, callCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer callCancel()
+
+	got, err := ping(callCtx, adopter, dialer.id)
+	if err != nil {
+		t.Fatalf("ping over the donated connection: %v", err)
+	}
+	if got != "pong:hello" {
+		t.Fatalf("ping returned %q, want %q", got, "pong:hello")
+	}
+}
+
+// TestEmptySlotFollowsTiebreak covers the slot the tiebreak used to skip: an
+// empty one adopted whatever arrived, in either direction.
+func TestEmptySlotFollowsTiebreak(t *testing.T) {
+	const low, high = config.NodeID(1), config.NodeID(2)
+	trLow := transport.NewPipeTransport(t.Name(), int(low))
+	trHigh := transport.NewPipeTransport(t.Name(), int(high))
+	t.Cleanup(func() { _ = trLow.Close(); _ = trHigh.Close() })
+
+	lnLow, err := trLow.Listen()
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	accepted := make(chan transport.Conn, 4)
+	go func() {
+		for {
+			c, err := lnLow.Accept(ctx)
+			if err != nil {
+				return
+			}
+			accepted <- c
+		}
+	}()
+
+	poolLow := NewConnPool(low, testResolver(trLow, map[config.NodeID]*transport.PipeTransport{high: trHigh}))
+	poolHigh := NewConnPool(high, testResolver(trHigh, map[config.NodeID]*transport.PipeTransport{low: trLow}))
+	t.Cleanup(func() { _ = poolLow.Close(); _ = poolHigh.Close() })
+
+	// The lower id prefers to dial, so it must not adopt what the higher id
+	// dialed even with nothing in the slot.
+	if _, err := trHigh.Dial(ctx, trLow.Addr()); err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	if poolLow.Donate(<-accepted) {
+		t.Fatal("node 1 adopted a connection it prefers to dial itself")
+	}
+	if c, _ := poolLow.held(high); c != nil {
+		t.Fatal("node 1 pooled a connection it prefers to dial itself")
+	}
+
+	// Its own dial is kept whichever way the tiebreak points: refusing that
+	// would leave the higher id with no way to open a connection at all.
+	conn, err := poolHigh.Dial(ctx, low)
+	if err != nil {
+		t.Fatalf("dial node %d: %v", low, err)
+	}
+	<-accepted
+	if c, _ := poolHigh.held(low); c != conn {
+		t.Fatal("node 2 dropped the connection it dialed")
+	}
+}
+
+// TestStalledStreamsEvictConnection covers the escape hatch: a connection alive
+// at the transport but answering nothing is dropped so a dial can replace it.
+func TestStalledStreamsEvictConnection(t *testing.T) {
+	nodes := newTestCluster(t, 1, 2)
+	caller, peer := nodes[1], nodes[2]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	conn, err := caller.pool.Dial(ctx, peer.id)
+	if err != nil {
+		t.Fatalf("dial node %d: %v", peer.id, err)
+	}
+
+	stall := func() {
+		t.Helper()
+		stream, err := OpenStream(ctx, caller.client, peer.id, opPing, &pingHeader{Name: "hello"})
+		if err != nil {
+			t.Fatalf("open stream: %v", err)
+		}
+		// Aborting the read is what a caller's expiring deadline does, so the
+		// stream ends without a byte of response.
+		stream.CancelRead(0)
+		if _, err := io.ReadAll(stream); err == nil {
+			t.Fatal("read from an aborted stream succeeded")
+		}
+	}
+
+	// A round trip that gets an answer clears the run of stalls before it.
+	for range maxStreamStalls - 1 {
+		stall()
+	}
+	if got, err := ping(ctx, caller, peer.id); err != nil || got != "pong:hello" {
+		t.Fatalf("ping returned %q, %v", got, err)
+	}
+
+	for i := range maxStreamStalls {
+		stall()
+		held, _ := caller.pool.held(peer.id)
+		if i < maxStreamStalls-1 && held != conn {
+			t.Fatalf("connection evicted after %d stalls, want %d", i+1, maxStreamStalls)
+		}
+	}
+	if held, _ := caller.pool.held(peer.id); held == conn {
+		t.Fatalf("connection still pooled after %d stalls", maxStreamStalls)
+	}
+
+	// The pool must be usable again: the next call dials a replacement.
+	if got, err := ping(ctx, caller, peer.id); err != nil || got != "pong:hello" {
+		t.Fatalf("ping after eviction returned %q, %v", got, err)
+	}
+}

--- a/internal/rpc/pool_test.go
+++ b/internal/rpc/pool_test.go
@@ -164,6 +164,79 @@ func TestDonatedConnectionAnswersOutboundCalls(t *testing.T) {
 	}
 }
 
+// TestServerAdoptsConnectionsDialedBeforeStart covers the startup window: a
+// node dials a peer before its own server is running, so the dial's hook finds
+// nothing to serve with. Starting the server must still pick that connection up.
+func TestServerAdoptsConnectionsDialedBeforeStart(t *testing.T) {
+	const dialer, adopter = config.NodeID(1), config.NodeID(2)
+	trDialer := transport.NewPipeTransport(t.Name(), int(dialer))
+	trAdopter := transport.NewPipeTransport(t.Name(), int(adopter))
+	t.Cleanup(func() { _ = trDialer.Close(); _ = trAdopter.Close() })
+
+	lnDialer, err := trDialer.Listen()
+	if err != nil {
+		t.Fatalf("listen for node %d: %v", dialer, err)
+	}
+	lnAdopter, err := trAdopter.Listen()
+	if err != nil {
+		t.Fatalf("listen for node %d: %v", adopter, err)
+	}
+
+	poolDialer := NewConnPool(dialer, testResolver(trDialer, map[config.NodeID]*transport.PipeTransport{adopter: trAdopter}))
+	poolAdopter := NewConnPool(adopter, testResolver(trAdopter, map[config.NodeID]*transport.PipeTransport{dialer: trDialer}))
+	t.Cleanup(func() { _ = poolDialer.Close(); _ = poolAdopter.Close() })
+
+	srvDialer, err := NewServer(pingMux(), []transport.Listener{lnDialer}, poolDialer, WithDrainTimeout(2*time.Second))
+	if err != nil {
+		t.Fatalf("server for node %d: %v", dialer, err)
+	}
+	srvAdopter, err := NewServer(pingMux(), []transport.Listener{lnAdopter}, poolAdopter, WithDrainTimeout(2*time.Second))
+	if err != nil {
+		t.Fatalf("server for node %d: %v", adopter, err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	adopterDone, dialerDone := make(chan error, 1), make(chan error, 1)
+	t.Cleanup(func() {
+		cancel()
+		for _, done := range []chan error{adopterDone, dialerDone} {
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				t.Error("server did not stop")
+			}
+		}
+	})
+
+	// Only the adopter is running, so the dial below is accepted and donated
+	// while the dialer's own server has no session to serve it with.
+	go func() { adopterDone <- srvAdopter.Run(ctx) }()
+
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer dialCancel()
+	if _, err := poolDialer.Dial(dialCtx, adopter); err != nil {
+		t.Fatalf("dial node %d: %v", adopter, err)
+	}
+	waitFor(t, "the donated connection to be pooled", func() bool {
+		c, _ := poolAdopter.held(dialer)
+		return c != nil
+	})
+
+	go func() { dialerDone <- srvDialer.Run(ctx) }()
+
+	callCtx, callCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer callCancel()
+
+	caller := &testNode{id: adopter, tr: trAdopter, pool: poolAdopter, client: NewClient(poolAdopter)}
+	got, err := ping(callCtx, caller, dialer)
+	if err != nil {
+		t.Fatalf("ping over the connection dialed before start: %v", err)
+	}
+	if got != "pong:hello" {
+		t.Fatalf("ping returned %q, want %q", got, "pong:hello")
+	}
+}
+
 // TestEmptySlotFollowsTiebreak covers the slot the tiebreak used to skip: an
 // empty one adopted whatever arrived, in either direction.
 func TestEmptySlotFollowsTiebreak(t *testing.T) {

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -61,6 +61,7 @@ type Server struct {
 
 	mu      sync.Mutex
 	session *serveSession
+	served  map[transport.Conn]struct{}
 }
 
 // serveSession is what a running server lends to a connection it did not
@@ -77,7 +78,13 @@ func NewServer(mux *Mux, lns []transport.Listener, pool *ConnPool, opts ...Serve
 	}
 
 	const defaultDrainTimeout = 30 * time.Second
-	s := &Server{mux: mux, lns: lns, pool: pool, drainTimeout: defaultDrainTimeout}
+	s := &Server{
+		mux:          mux,
+		lns:          lns,
+		pool:         pool,
+		drainTimeout: defaultDrainTimeout,
+		served:       make(map[transport.Conn]struct{}),
+	}
 	for _, opt := range opts {
 		opt(s)
 	}
@@ -99,6 +106,15 @@ func (s *Server) Run(ctx context.Context) error {
 	s.mu.Lock()
 	s.session = &serveSession{acceptCtx: acceptCtx, handlerCtx: handlerCtx, conns: &conns}
 	s.mu.Unlock()
+
+	// A connection dialed before there was a session had its hook fire against
+	// nothing, and the pool is where it survives. Adopting those here is what
+	// stops one being outbound-only for the rest of its life.
+	if s.pool != nil {
+		for _, conn := range s.pool.Dialed() {
+			s.serveDialed(conn)
+		}
+	}
 
 	for _, ln := range s.lns {
 		g.Go(func() error {
@@ -199,8 +215,8 @@ func (s *Server) acceptConns(
 
 // serveDialed answers streams the peer opens on a connection this node dialed.
 // The pool calls it, because which end opened a pooled connection says nothing
-// about which end sends over it. A server that is not running serves nothing:
-// the connection is then outbound-only until the next one starts.
+// about which end sends over it. A server that is not running serves nothing
+// yet: Run adopts what the pool holds, so such a connection is picked up there.
 func (s *Server) serveDialed(conn transport.Conn) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -208,12 +224,28 @@ func (s *Server) serveDialed(conn transport.Conn) {
 		return
 	}
 
+	// Run's adoption and a concurrent dial can both offer one connection, and
+	// two serve loops on it would race to release it.
+	if _, ok := s.served[conn]; ok {
+		return
+	}
+	s.served[conn] = struct{}{}
+
 	sess := s.session
 	sess.conns.Go(func() {
+		defer s.forget(conn)
 		// The pool owns what it dialed, so a serve loop that ends releases the
 		// connection by evicting it rather than closing behind the pool's back.
 		s.serveConn(sess.acceptCtx, sess.handlerCtx, conn, func() { s.pool.Evict(conn) })
 	})
+}
+
+// forget drops a connection's serve record once its loop has ended, so a later
+// dial of the same connection is served again.
+func (s *Server) forget(conn transport.Conn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.served, conn)
 }
 
 // serveConn answers streams on one connection until it dies or the server

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -58,6 +58,17 @@ type Server struct {
 	lns          []transport.Listener
 	pool         *ConnPool
 	drainTimeout time.Duration
+
+	mu      sync.Mutex
+	session *serveSession
+}
+
+// serveSession is what a running server lends to a connection it did not
+// accept: the contexts that connection runs under and the group Run drains.
+type serveSession struct {
+	acceptCtx  context.Context
+	handlerCtx context.Context
+	conns      *sync.WaitGroup
 }
 
 func NewServer(mux *Mux, lns []transport.Listener, pool *ConnPool, opts ...ServerOption) (*Server, error) {
@@ -70,6 +81,12 @@ func NewServer(mux *Mux, lns []transport.Listener, pool *ConnPool, opts ...Serve
 	for _, opt := range opts {
 		opt(s)
 	}
+
+	// A pooled connection carries traffic in both directions, so the end that
+	// opened one still has to answer streams on it.
+	if pool != nil {
+		pool.OnDial(s.serveDialed)
+	}
 	return s, nil
 }
 
@@ -79,6 +96,9 @@ func (s *Server) Run(ctx context.Context) error {
 	defer cancelHandlers()
 
 	var conns sync.WaitGroup
+	s.mu.Lock()
+	s.session = &serveSession{acceptCtx: acceptCtx, handlerCtx: handlerCtx, conns: &conns}
+	s.mu.Unlock()
 
 	for _, ln := range s.lns {
 		g.Go(func() error {
@@ -101,6 +121,12 @@ func (s *Server) Run(ctx context.Context) error {
 	for _, ln := range s.lns {
 		ln.Close()
 	}
+
+	// Retiring the session is what makes the drain below safe: no dialed
+	// connection can join the group once Run is waiting on it.
+	s.mu.Lock()
+	s.session = nil
+	s.mu.Unlock()
 
 	// Each conns goroutine waits for its own handlers, so this covers every
 	// in-flight request: once it returns, nothing is still touching state the
@@ -159,48 +185,75 @@ func (s *Server) acceptConns(
 		backoff = 5 * time.Millisecond
 
 		conns.Go(func() {
-			// Handlers outlive the accept loop, so the connection is released
-			// here and only once they have drained. Waiting inside the conns
-			// goroutine is what makes Run's conns.Wait a full drain.
-			var streams sync.WaitGroup
-
 			// A donated connection belongs to the pool, so releasing it means
 			// evicting rather than closing: a connection that dies inbound is
 			// taken out of the pool instead of handed to a dialer dead.
+			release := func() { conn.Close() }
 			if s.pool != nil && s.pool.Donate(conn) {
-				defer s.pool.Evict(conn)
-			} else {
-				defer conn.Close()
+				release = func() { s.pool.Evict(conn) }
 			}
-
-			// Cancelled handlers mean the drain deadline expired. Aborting the
-			// connection is the only way to unblock a handler parked in a
-			// stream read, which has no deadline and never observes ctx.
-			drained := make(chan struct{})
-			defer close(drained)
-			go func() {
-				select {
-				case <-handlerCtx.Done():
-					conn.Close()
-				case <-drained:
-				}
-			}()
-
-			err := s.acceptStreams(acceptCtx, handlerCtx, conn, &streams)
-			streams.Wait()
-
-			switch {
-			case err == nil,
-				errors.Is(err, context.Canceled),
-				errors.Is(err, transport.ErrListenerClosed),
-				errors.Is(err, transport.ErrConnClosed):
-			default:
-				slog.ErrorContext(acceptCtx, "connection error",
-					"err", err,
-					"source", conn.LocalAddr(),
-					"addr", conn.RemoteAddr())
-			}
+			s.serveConn(acceptCtx, handlerCtx, conn, release)
 		})
+	}
+}
+
+// serveDialed answers streams the peer opens on a connection this node dialed.
+// The pool calls it, because which end opened a pooled connection says nothing
+// about which end sends over it. A server that is not running serves nothing:
+// the connection is then outbound-only until the next one starts.
+func (s *Server) serveDialed(conn transport.Conn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.session == nil {
+		return
+	}
+
+	sess := s.session
+	sess.conns.Go(func() {
+		// The pool owns what it dialed, so a serve loop that ends releases the
+		// connection by evicting it rather than closing behind the pool's back.
+		s.serveConn(sess.acceptCtx, sess.handlerCtx, conn, func() { s.pool.Evict(conn) })
+	})
+}
+
+// serveConn answers streams on one connection until it dies or the server
+// stops, and then releases it. Handlers outlive the accept loop, so release
+// runs only once they have drained: waiting here is what makes Run's conns.Wait
+// a full drain.
+func (s *Server) serveConn(
+	acceptCtx, handlerCtx context.Context,
+	conn transport.Conn,
+	release func(),
+) {
+	var streams sync.WaitGroup
+	defer release()
+
+	// Cancelled handlers mean the drain deadline expired. Aborting the
+	// connection is the only way to unblock a handler parked in a stream read,
+	// which has no deadline and never observes ctx.
+	drained := make(chan struct{})
+	defer close(drained)
+	go func() {
+		select {
+		case <-handlerCtx.Done():
+			conn.Close()
+		case <-drained:
+		}
+	}()
+
+	err := s.acceptStreams(acceptCtx, handlerCtx, conn, &streams)
+	streams.Wait()
+
+	switch {
+	case err == nil,
+		errors.Is(err, context.Canceled),
+		errors.Is(err, transport.ErrListenerClosed),
+		errors.Is(err, transport.ErrConnClosed):
+	default:
+		slog.ErrorContext(acceptCtx, "connection error",
+			"err", err,
+			"source", conn.LocalAddr(),
+			"addr", conn.RemoteAddr())
 	}
 }
 


### PR DESCRIPTION
## The bug

A pooled rpc connection could be used in a direction its peer would never service, which black-holed every request on it with no self-heal.

`rpc.Server.Run` iterated `s.lns` only. `acceptStreams` was reached solely through `acceptConns`, which is fed by `ln.Accept()`, so a connection the local node *dialed* had its incoming streams served by nobody. The pool did not know that: `Donate` inserts an accepted connection with `dialed=false`, and `held` returned whatever occupied the slot with no regard for direction. So a node could adopt a connection its peer had dialed and then open streams on it — the peer, which never serves streams on a connection it dialed itself, answered none of them.

`insert`'s simultaneous-open tiebreak could not catch this either, because it was gated behind `if ok && e.conn != c` and therefore only ran when the slot was already occupied. An empty slot stored whatever arrived, in either direction.

Nothing recovered from the resulting state. The connection stayed healthy at the QUIC layer on the peer's keepalives, so it was never evicted, and `held` kept returning it, so the node never re-dialed.

## Live evidence, env19, 2026-08-13

A rolling deploy restarted the leader first and forced an election. The new leader's pool slot for node-8 was empty when node-8 came up campaigning, and node-8's dial landed roughly half a second before the leader's own next dial attempt. The leader adopted node-8's connection, and its error signature transitioned exactly once and never reverted:

```
16:54:29  dial connection: dial node 8: quic dial 10.26.7.1:7660: timeout: no recent network activity
16:54:54  msgpack decode error [pos 0]: i/o timeout
```

After that point: 0 occurrences of `dial node 8`, 21 `msgpack decode error`. Node-8 sat out of quorum for ten minutes until a manual restart.

## Which shape, and why

Two shapes were available: serve streams on dialed connections as well, or never hand a donated connection back out of `Dial`.

This PR takes the first. `docs/DESIGN.md` §4 does not merely mention bidirectional reuse in passing — it is load-bearing throughout the section. "A replica pair reuses one connection in both directions", and the stream-cap paragraph goes further: "The caps match deliberately — a reused connection is dialed by one side and accepted by the other, so a lower dial-side cap would silently throttle it." The pool's key is the node id precisely so that a dialed and an accepted connection are one entry, and `meta.Server.open` says the same in a comment: "One pool serves both directions". The second shape would have meant deleting that design rather than implementing it, and it also doubles the connection count for every replica pair, on a code path where the stream caps were already tuned for the shared case. The missing piece was one accept loop, not the design.

So `rpc.Server` now serves what the pool dials as well as what its listeners accept. The pool hands each connection it opens to a registered `OnDial` callback; `NewServer` registers itself when it is given a pool. A caller with a pool and no server of its own — a gate, or the status probe — registers nothing and keeps exactly its current behaviour, which is correct: nothing dials a gate, and a gate's ephemeral socket resolves to no node, so its connections are never pooled at the peer.

## The other two changes

**The tiebreak now covers the empty slot.** Both ends already computed the same preference, that the pair keeps whichever connection the lower node id dialed; it simply was not consulted unless the slot was occupied. It is now consulted either way, so a node refuses a donation it would rather have dialed itself and fills the slot with its own dial instead. The refusal is one-sided on purpose: a node's *own* dial into an empty slot is always kept, because refusing that would leave the end that prefers to accept with no way to open a connection at all. A refused donation is not wasted — the peer keeps it in its own pool for its outbound traffic, this node still serves streams on it as an accepted connection, and the pair collapses back to one connection when this node's dial reaches the peer's occupied slot.

**Repeated stalls now evict.** The pool had no way to tell a connection that is serviced from one that takes requests and answers nothing, since both look identical at the transport. `rpc.OpenStream` now returns the stream wrapped so the first read outcome is reported back: any response byte, or a clean EOF, clears the run of stalls, while a read that ends with no byte of response counts as one. Three consecutive stalls on one connection evict it, so the next call dials a replacement.

Three, because one stall is ordinary — a peer restarting, a drain deadline, a caller cancelling — and two can still be coincidence during a rolling restart, which is exactly when this failure appears. Three consecutive streams that got a request out and never got a single byte back is not a transient. The pool cannot distinguish a peer that will not service the direction from one that is simply hung, and it does not need to: the remedy is the same either way. A false positive costs one extra dial; a false negative costs a node ten minutes out of quorum, as it did on env19.

## Tests

`internal/rpc` had no tests at all; this adds `pool_test.go`, driven over the in-process pipe transport.

The decisive regression is `TestDonatedConnectionAnswersOutboundCalls`: node 1 dials node 2, node 2 adopts the donation (it is the higher id, so the tiebreak says the connection node 1 dialed is the one the pair keeps), and node 2 then issues an rpc over it. Before the fix it failed in 5.01s with `ping over the donated connection: open-stream pipe ...: context deadline exceeded` — the pipe transport rendezvouses on stream open, so it blocks a step earlier than QUIC did in production, but the black hole is the same one. After the fix it returns the response.

`TestEmptySlotFollowsTiebreak` covers both halves of the empty-slot rule, and `TestStalledStreamsEvictConnection` covers the eviction threshold, that a successful round trip clears the run before it, and that the pool dials a replacement afterwards. Before the fix: `node 1 adopted a connection it prefers to dial itself` and `connection still pooled after 3 stalls` respectively. All three pass after, including under `-race -count=5`.

## Verification

- `make test` — full suite passes.
- `make preflight` — lint and tests pass. `govulncheck` fails on five stdlib advisories fixed in go1.26.6 against the installed go1.26.5, all in unrelated packages and all pre-existing on `dev`.
- Diff coverage 86.7% against a 40% threshold. `internal/rpc` goes from 0% to 68%.
- No cluster was touched.