### PR TITLE
chore: bump Go toolchain to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mulgadc/predastore
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.5


### PR DESCRIPTION
Four Go stdlib advisories (GO-2026-6088, 6089, 6090, 6091) were published after predastore dev last went green at 02:27 on 2026-08-13. They are reachable from `internal/gate`, `internal/meta` and `internal/transport`, so `govulncheck` now fails `Lint and Security` on every predastore PR and every push to dev, regardless of what the change touches.

The fixes are in go1.26.6. CI resolves the toolchain from go.mod via `go-version-file`, so the pin is the entire fix.

Verified locally: `govulncheck ./...` reports zero called vulnerabilities under 1.26.6, against four before. `make preflight` passes.

This unblocks #84, which is otherwise green.

Bead: mulga-0q99f