### PR TITLE
feat: name the caller account on S3 request spans

### DIFF
--- a/internal/gate/middleware.go
+++ b/internal/gate/middleware.go
@@ -199,6 +199,11 @@ func (s *Server) sigV4AuthMiddleware(next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), auth.ContextKeyAccessKeyID, accessKey)
 		ctx = context.WithValue(ctx, auth.ContextKeyAccountID, credResult.AccountID)
 		ctx = context.WithValue(ctx, auth.ContextKeyServiceAccount, credResult.SkipPolicyCheck)
+		// The transaction span opens before authentication, so the account it
+		// resolved to can only be named here. One cluster serves many accounts
+		// and S3 is where a tenant's data lives, so an unattributed request is
+		// one nobody can be asked about.
+		annotateSpanAccount(ctx, credResult.AccountID)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/gate/span_account.go
+++ b/internal/gate/span_account.go
@@ -1,0 +1,28 @@
+package gate
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// attrAccountID names the account a span was served for. It matches the key
+// the AWS gateway and the NATS helpers use, so one field attributes a request
+// across every service that touches it.
+const attrAccountID = "aws.account_id"
+
+// annotateSpanAccount records accountID on the request's transaction span. An
+// empty account is left off rather than recorded as blank: a request that never
+// authenticated belongs to nobody, and a blank value reads as a tenant whose id
+// went missing.
+func annotateSpanAccount(ctx context.Context, accountID string) {
+	if accountID == "" {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+	span.SetAttributes(attribute.String(attrAccountID, accountID))
+}

--- a/internal/gate/span_account_test.go
+++ b/internal/gate/span_account_test.go
@@ -1,0 +1,67 @@
+package gate
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// spanAccount returns the account attribute of the last recorded span, or "".
+func spanAccount(t *testing.T, sr *tracetest.SpanRecorder) string {
+	t.Helper()
+	spans := sr.Ended()
+	if len(spans) == 0 {
+		t.Fatal("no span recorded")
+	}
+	for _, kv := range spans[len(spans)-1].Attributes() {
+		if string(kv.Key) == attrAccountID {
+			return kv.Value.AsString()
+		}
+	}
+	return ""
+}
+
+// S3 is where a tenant's data lives, and predastore produces more spans than
+// any other service in the fleet. Unattributed, none of them can be tied to
+// the account that caused them.
+func TestAnnotateSpanAccountNamesTheCaller(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+
+	ctx, span := tp.Tracer("test").Start(t.Context(), "HTTP")
+	annotateSpanAccount(ctx, "000000000042")
+	span.End()
+
+	if got := spanAccount(t, sr); got != "000000000042" {
+		t.Errorf("%s = %q, want %q", attrAccountID, got, "000000000042")
+	}
+}
+
+// A request that never authenticated belongs to nobody. Recording a blank
+// account would read as a tenant whose id went missing.
+func TestAnnotateSpanAccountSkipsAnEmptyAccount(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+
+	ctx, span := tp.Tracer("test").Start(t.Context(), "HTTP")
+	annotateSpanAccount(ctx, "")
+	span.End()
+
+	if got := spanAccount(t, sr); got != "" {
+		t.Errorf("%s = %q, want it absent", attrAccountID, got)
+	}
+}
+
+// A context with no span must not panic: handlers run without tracing in
+// tests and whenever the SDK is disabled.
+func TestAnnotateSpanAccountWithoutASpan(t *testing.T) {
+	annotateSpanAccount(t.Context(), "000000000042")
+}


### PR DESCRIPTION
## Why

The public sandbox is one Spinifex cluster with tenancy at the account level, and predastore is the largest span producer in the fleet: 595,864 transactions in 24 hours, none carrying an account. S3 is where a tenant's data actually lives, so this is the biggest single gap in attributing cluster activity to the account that caused it.

Companion to spinifex #822, which does the same for the NATS path. Same attribute key (`aws.account_id`) as the AWS gateway already sets, so one field follows a request across every service that touches it.

## Change

`otelsetup.HTTPMiddleware` opens the transaction span before authentication runs, so the resolved account can only be recorded afterwards — `annotateSpanAccount` sets it on the current span at the point the SigV4 middleware has `credResult.AccountID`.

An empty account is skipped rather than recorded blank: an unauthenticated request belongs to nobody, and a blank value reads as a tenant whose id went missing.

## Testing

- the account is recorded on the active span
- an empty account leaves the attribute absent
- a context with no span does not panic, which is the case in tests and whenever the SDK is disabled
- `make lint` and `make govulncheck` pass; `./internal/gate/` passes in full

**`make preflight` did not complete on my machine**, and not because of this change: `internal/blob/engine` is OOM-killed (`signal: killed`) partway through the integration suite. I confirmed it fails the same way on a clean tree with the change stashed, on a box with ~7 GB already in use by other work. The package is untouched by this diff. CI should be treated as the authority here.