### PR TITLE
fix: two data races in the S3 gate read path

### DIFF
--- a/internal/gate/handlers/shards.go
+++ b/internal/gate/handlers/shards.go
@@ -389,7 +389,9 @@ func shardBytes(ctx context.Context, bc BlobClient, objectHash [32]byte, place O
 
 		mu.Lock()
 		defer mu.Unlock()
-		// Distinct indices, so only the counter needs the lock.
+		// Indices are distinct, but the lock still guards the slice itself: the
+		// caller snapshots it once enough shards land, while slower reads are
+		// still outstanding and may yet write their own entry.
 		shards[index] = data
 		available++
 		if available >= need {
@@ -435,13 +437,18 @@ func shardBytes(ctx context.Context, bc BlobClient, objectHash [32]byte, place O
 	case <-done:
 	}
 
+	// The hedge returns as soon as enough shards have landed, so the slower
+	// reads are still running. Hand back a snapshot: a straggler writing its
+	// entry must not mutate the slice the caller is reconstructing from.
 	mu.Lock()
 	defer mu.Unlock()
+	snapshot := make([][]byte, len(shards))
+	copy(snapshot, shards)
 	if available < need {
-		return shards, fmt.Errorf("%w: %d of %d shards available",
+		return snapshot, fmt.Errorf("%w: %d of %d shards available",
 			errInsufficientShards, available, need)
 	}
-	return shards, nil
+	return snapshot, nil
 }
 
 // slowShardThreshold is the point past which a shard read is worth naming its

--- a/internal/gate/handlers/shards_snapshot_test.go
+++ b/internal/gate/handlers/shards_snapshot_test.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore/internal/blob"
+	"github.com/mulgadc/predastore/internal/config"
+	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// lateBlob answers for one node only after a delay, and ignores cancellation
+// while it waits. Ignoring it is the point: the hedge cancels on return, so a
+// cancellable read would abandon itself instead of landing late.
+type lateBlob struct {
+	*fakeBlob
+
+	slow   config.NodeID
+	delay  time.Duration
+	landed chan struct{}
+}
+
+func (b *lateBlob) Get(ctx context.Context, node config.NodeID, req blob.GetRequest) (io.ReadCloser, error) {
+	if node != b.slow {
+		return b.fakeBlob.Get(ctx, node, req)
+	}
+	time.Sleep(b.delay)
+	rc, err := b.fakeBlob.Get(context.WithoutCancel(ctx), node, req)
+	close(b.landed)
+	return rc, err
+}
+
+var _ BlobClient = (*lateBlob)(nil)
+
+// The hedge returns once enough shards have landed, leaving the slower reads
+// running. They must not write into the slice the caller is reconstructing
+// from: the encoder decides what to rebuild by which entries are nil, so a
+// shard appearing mid-flight changes that answer underneath it.
+func TestShardBytesSnapshotsAgainstALateShard(t *testing.T) {
+	t.Parallel()
+
+	const late = 750 * time.Millisecond
+
+	f := newWriteFixture(2, 1)
+	want := randomBytes(t, 1<<16)
+
+	ctx := context.Background()
+	objectHash := model.ObjectHash("b", "k")
+	_, err := writeObject(ctx, f.bc, f.ring, f.cfg, bytes.NewReader(want), int64(len(want)), objectHash)
+	require.NoError(t, err)
+
+	place, err := placeShards(f.ring, f.cfg, objectHash, int64(len(want)))
+	require.NoError(t, err)
+
+	// The second data shard arrives long after the parity shard has already
+	// made the read answerable, so it is still outstanding on return.
+	slow := &lateBlob{fakeBlob: f.bc, slow: place.DataShardNodes[1], delay: late, landed: make(chan struct{})}
+
+	start := time.Now()
+	shards, err := shardBytes(ctx, slow, objectHash, place)
+	require.NoError(t, err)
+	require.Less(t, time.Since(start), late,
+		"the hedge must return before the late shard lands, or this proves nothing")
+
+	missingOnReturn := missingShards(shards, len(place.DataShardNodes))
+	require.Positive(t, missingOnReturn, "the late shard should be absent on return")
+
+	<-slow.landed
+	// The write follows the read the fake just answered; the race detector is
+	// what catches the overlap, this margin is for the value assertion below.
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, missingOnReturn, missingShards(shards, len(place.DataShardNodes)),
+		"a shard that arrived after the read returned mutated the caller's slice")
+}

--- a/internal/gate/http_protocol_test.go
+++ b/internal/gate/http_protocol_test.go
@@ -40,13 +40,15 @@ func negotiatedWith(t *testing.T, enableHTTP2 bool) string {
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(r.Proto))
 	}))
-	srv.EnableHTTP2 = true
+	// Both values must be in place before StartTLS spawns the serving
+	// goroutine, which reads them. StartTLS keeps a NextProtos that is already
+	// set and never touches Config.Protocols, so neither is overwritten.
+	srv.EnableHTTP2 = enableHTTP2
+	srv.Config.Protocols = httpProtocols(enableHTTP2)
+	srv.TLS = &tls.Config{NextProtos: alpnProtocols(enableHTTP2), MinVersion: tls.VersionTLS12}
+
 	srv.StartTLS()
 	t.Cleanup(srv.Close)
-
-	// Restart the handler under the gate's own settings rather than httptest's.
-	srv.Config.Protocols = httpProtocols(enableHTTP2)
-	srv.TLS.NextProtos = alpnProtocols(enableHTTP2)
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{


### PR DESCRIPTION
Two data races, both already on `dev` (d6a022b), both failing `make test-race`. They block every open predastore PR, which is how they were found — #87 went red on them.

## The one that matters: `shards.go`

`shardBytes` is hedged, returning as soon as enough shards have landed so that one stalled node cannot set every reader's latency. That part is right. What was wrong is that it returned the *shared* slice while the slower reads were still running, so a shard arriving after the return wrote into the slice the caller was already reconstructing from.

This is a correctness problem before it is a race. `reconstructObject` decides what to rebuild from which entries are `nil`, so a late shard changes that answer mid-flight. The window is exactly the degraded read — one slow or down node, parity covering for it — which is the case the hedge exists to serve.

The fix takes a snapshot under the existing lock and returns that. Stragglers keep writing to the original, which is then dropped. The copy is of the outer slice only, so it costs one small header array per read, not the shard data.

The old comment on the write claimed only the counter needed the lock. True among the writers, since the indices are distinct, but not against a caller reading the whole slice — updated to say so.

## The other: `http_protocol_test.go`

`negotiatedWith` called `StartTLS()`, which spawns the serving goroutine, then wrote `Config.Protocols` and `TLS.NextProtos`. The comment said it restarted the handler, but nothing restarted. `httptest.StartTLS` only consults `EnableHTTP2` for the `NextProtos` default (server.go:179) and the client's `ForceAttemptHTTP2` (:197), and never touches `Config.Protocols` — so both values can simply be set before the server starts.

## Testing

`TestShardBytesSnapshotsAgainstALateShard` covers the shard fix. It uses a blob client that ignores cancellation for one node, so the straggler genuinely lands after the hedge has returned rather than abandoning itself to the deferred `cancel()`. Verified to fail without the fix — both as a data race and on the value assertion — and to pass with it.

`make lint` clean. `./internal/gate/...` passes under `-race -count=2`.

Full `make preflight` was not run here: `internal/blob/engine` is being OOM-killed on this box, which reproduces on a clean tree and is unrelated to this change. CI is the authority on that package.