### PR TITLE
refactor: use the stdlib uuid package instead of github.com/google/uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/dgraph-io/badger/v4 v4.9.6
 	github.com/go-chi/chi/v5 v5.3.1
-	github.com/google/uuid v1.6.0
 	github.com/hashicorp/raft v1.7.3
 	github.com/hashicorp/raft-boltdb/v2 v2.3.1
 	github.com/klauspost/reedsolomon v1.14.1
@@ -37,6 +36,7 @@ require (
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/flatbuffers v25.12.19+incompatible // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect

--- a/internal/gate/handlers/create_multipart_upload.go
+++ b/internal/gate/handlers/create_multipart_upload.go
@@ -6,8 +6,8 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/mulgadc/predastore/internal/gate/model"
 )
 
@@ -27,7 +27,7 @@ func CreateMultipartUpload(mc MetaClient, cache *BucketCache) http.Handler {
 			return
 		}
 
-		uploadID := uuid.New().String()
+		uploadID := uuid.NewV4().String()
 		metadata := model.UploadMetadata{
 			UploadID:    uploadID,
 			Bucket:      bucket,

--- a/internal/gate/handlers/respond.go
+++ b/internal/gate/handlers/respond.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/mulgadc/bluebottle/pkg/otelsetup"
 	"github.com/mulgadc/bluebottle/pkg/sigv4"
 	"github.com/mulgadc/predastore/internal/gate/auth"
@@ -80,7 +80,7 @@ func WriteS3Error(w http.ResponseWriter, r *http.Request, statusCode int, code, 
 	s3error := S3Error{
 		Code:      code,
 		Message:   message,
-		RequestId: uuid.NewString(),
+		RequestId: uuid.NewV4().String(),
 		HostId:    r.Host,
 	}
 	otelsetup.SetRequestErrorCode(r.Context(), code)
@@ -128,7 +128,7 @@ func HandleError(w http.ResponseWriter, r *http.Request, err error) {
 		}
 	}
 
-	s3error.RequestId = uuid.NewString()
+	s3error.RequestId = uuid.NewV4().String()
 	s3error.HostId = r.Host
 	otelsetup.SetRequestErrorCode(r.Context(), s3error.Code)
 


### PR DESCRIPTION
Go 1.27 ships a `uuid` package implementing RFC 9562. The gate handlers used `github.com/google/uuid` in two files for three identifiers — two request IDs and a multipart upload ID — all random v4, with no parsing and no `UUID` values held.

## Changes

- Import `uuid` from the standard library and drop `github.com/google/uuid`.
- Rewrite `uuid.NewString()` and `uuid.New().String()` as `uuid.NewV4().String()`. The stdlib package has no `NewString` helper, and `New()` is documented only as "equivalent to `NewV4` at this time" — `NewV4()` pins v4 semantics explicitly rather than relying on that wording holding.