### PR TITLE
feat: meter predastore's raft state and multipart uploads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,9 @@ require (
 	github.com/quic-go/quic-go v0.61.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
+	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
+	go.opentelemetry.io/otel/sdk/metric v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
 	golang.org/x/sync v0.22.0
 	pgregory.net/rapid v1.3.0
@@ -59,9 +61,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect
 	go.opentelemetry.io/otel/log v0.21.0 // indirect
-	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.21.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.45.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.11.0 // indirect
 	go.uber.org/nilaway v0.0.0-20260721205819-4a0f7653488a // indirect
 	golang.org/x/crypto v0.54.0 // indirect

--- a/internal/gate/handlers/abort_multipart_upload.go
+++ b/internal/gate/handlers/abort_multipart_upload.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/mulgadc/predastore/internal/telemetry"
 )
 
 // AbortMultipartUpload serves DELETE /{bucket}/{key}?uploadId=X: it discards an
@@ -46,6 +47,7 @@ func AbortMultipartUpload(mc MetaClient, bc BlobClient, cache *BucketCache) http
 			slog.WarnContext(ctx, "Failed to cleanup multipart upload", "uploadID", uploadID, "error", err)
 		}
 
+		telemetry.RecordMultipartUpload(ctx, telemetry.UploadAborted)
 		slog.DebugContext(ctx, "Multipart upload aborted", "bucket", bucket, "key", key, "uploadID", uploadID)
 
 		w.WriteHeader(http.StatusNoContent)

--- a/internal/gate/handlers/complete_multipart_upload.go
+++ b/internal/gate/handlers/complete_multipart_upload.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mulgadc/predastore/internal/gate/model"
 	"github.com/mulgadc/predastore/internal/gate/placement"
+	"github.com/mulgadc/predastore/internal/telemetry"
 )
 
 // maxParallelPartFetches bounds the read-back fan-out while assembling an
@@ -74,6 +75,7 @@ func CompleteMultipartUpload(mc MetaClient, bc BlobClient, ring *placement.Ring,
 		if err := model.ValidatePartsForCompletion(parts, storedParts); err != nil {
 			// A rejected completion is a client-visible 400 and nothing else,
 			// so without this the upload simply disappears from the logs.
+			telemetry.RecordMultipartUpload(ctx, telemetry.UploadRejected)
 			slog.WarnContext(ctx, "Multipart completion rejected",
 				"uploadID", uploadID, "requested", len(parts), "stored", len(storedParts), "error", err)
 			HandleError(w, r, err)
@@ -131,6 +133,7 @@ func CompleteMultipartUpload(mc MetaClient, bc BlobClient, ring *placement.Ring,
 			slog.WarnContext(ctx, "Failed to cleanup multipart upload", "uploadID", uploadID, "error", err)
 		}
 
+		telemetry.RecordMultipartUpload(ctx, telemetry.UploadCompleted)
 		slog.DebugContext(ctx, "Multipart upload completed", "bucket", bucket, "key", key, "uploadID", uploadID, "parts", len(parts))
 
 		if err := writeXML(w, http.StatusOK, CompleteMultipartUploadResult{
@@ -220,13 +223,21 @@ func streamParts(
 func getPartData(ctx context.Context, mc MetaClient, bc BlobClient, cfg Config, bucket, key, uploadID string, partNumber int) ([]byte, error) {
 	data, err := metaGet(ctx, mc, model.TableObjects, partShardKey(uploadID, partNumber))
 	if err != nil {
+		telemetry.RecordMultipartPartFetch(ctx, telemetry.FetchReasonMetaMissing)
 		return nil, fmt.Errorf("part not found: uploadID=%s part=%d", uploadID, partNumber)
 	}
 
 	var place ObjectToShardNodes
 	if err := gob.NewDecoder(bytes.NewReader(data)).Decode(&place); err != nil {
+		telemetry.RecordMultipartPartFetch(ctx, telemetry.FetchReasonPlacementDecode)
 		return nil, err
 	}
 
-	return readObject(ctx, bc, cfg, bucket, partObjectKey(key, uploadID, partNumber), place, place.Size)
+	part, err := readObject(ctx, bc, cfg, bucket, partObjectKey(key, uploadID, partNumber), place, place.Size)
+	if err != nil {
+		telemetry.RecordMultipartPartFetch(ctx, telemetry.FetchReasonShardRead)
+		return nil, err
+	}
+	telemetry.RecordMultipartPartFetch(ctx, "")
+	return part, nil
 }

--- a/internal/gate/handlers/create_multipart_upload.go
+++ b/internal/gate/handlers/create_multipart_upload.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/mulgadc/predastore/internal/telemetry"
 )
 
 // CreateMultipartUpload serves POST /{bucket}/{key} without an uploadId: it
@@ -49,6 +50,7 @@ func CreateMultipartUpload(mc MetaClient, cache *BucketCache) http.Handler {
 			return
 		}
 
+		telemetry.RecordMultipartUpload(ctx, telemetry.UploadCreated)
 		slog.DebugContext(ctx, "Multipart upload created", "bucket", bucket, "key", key, "uploadID", uploadID)
 
 		w.Header().Set("X-Amz-Server-Side-Encryption", "AES256")

--- a/internal/gate/handlers/shards.go
+++ b/internal/gate/handlers/shards.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mulgadc/predastore/internal/config"
 	"github.com/mulgadc/predastore/internal/gate/model"
 	"github.com/mulgadc/predastore/internal/gate/placement"
+	"github.com/mulgadc/predastore/internal/telemetry"
 )
 
 // ObjectToShardNodes maps an object to its shard locations.
@@ -321,6 +322,7 @@ func readShard(ctx context.Context, bc BlobClient, objectHash [32]byte, node con
 		Index:      uint32(index), //nolint:gosec // G115: index bounded by shard count (small uint).
 	})
 	if err != nil {
+		recordShardReadError(ctx, err)
 		return nil, err
 	}
 	data, err := io.ReadAll(reader)
@@ -328,9 +330,21 @@ func readShard(ctx context.Context, bc BlobClient, objectHash [32]byte, node con
 		slog.DebugContext(ctx, "Failed to close shard stream reader", "node", node, "error", closeErr)
 	}
 	if err != nil {
+		recordShardReadError(ctx, err)
 		return nil, err
 	}
 	return data, nil
+}
+
+// recordShardReadError counts a failed shard read under a bounded reason. The
+// error text names a node and a key, so only the classification is recorded:
+// a node that answered without the shard, or anything else.
+func recordShardReadError(ctx context.Context, err error) {
+	reason := telemetry.ShardReasonTransport
+	if errors.Is(err, blob.ErrNotFound) {
+		reason = telemetry.ShardReasonNotFound
+	}
+	telemetry.RecordShardError(ctx, "read", reason)
 }
 
 // shardBytes reads an object's shards, concurrently, tolerantly and hedged.

--- a/internal/gate/handlers/upload_part.go
+++ b/internal/gate/handlers/upload_part.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mulgadc/predastore/internal/gate/model"
 	"github.com/mulgadc/predastore/internal/gate/placement"
+	"github.com/mulgadc/predastore/internal/telemetry"
 )
 
 // UploadPart serves PUT /{bucket}/{key}?partNumber=N&uploadId=X. A part is
@@ -104,6 +105,7 @@ func UploadPart(mc MetaClient, bc BlobClient, ring *placement.Ring, cache *Bucke
 			return
 		}
 
+		telemetry.RecordMultipartPart(ctx, partSize)
 		slog.DebugContext(ctx, "Part uploaded", "uploadID", uploadID, "partNumber", partNumber, "size", partSize, "etag", etag)
 
 		w.Header().Set("ETag", etag)

--- a/internal/meta/server.go
+++ b/internal/meta/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/raft"
 	raftboltdb "github.com/hashicorp/raft-boltdb/v2"
 	"github.com/mulgadc/predastore/internal/rpc"
+	"github.com/mulgadc/predastore/internal/telemetry"
 	"github.com/mulgadc/predastore/internal/transport"
 )
 
@@ -44,6 +45,10 @@ type Server struct {
 	fsm       *FSM
 	badgerDB  *badger.DB
 	bolt      *raftboltdb.BoltStore
+
+	// unregisterMetrics detaches the raft gauge callback. It is nil until
+	// raft exists, since the callback reads it on every collection.
+	unregisterMetrics func() error
 }
 
 // New validates cfg and applies its defaults. It creates no directory, opens
@@ -159,12 +164,35 @@ func (s *Server) open() (*rpc.Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create raft: %w", err)
 	}
+	// Consensus state is only observable once raft exists. A failure to
+	// register loses the gauges, not the replica, so it is logged and left.
+	unregister, err := telemetry.RegisterRaftGauges(s.raftSnapshot)
+	if err != nil {
+		slog.Warn("failed to register raft metrics", "node", s.cfg.NodeID, "error", err)
+	} else {
+		s.unregisterMetrics = unregister
+	}
+
 	if s.cfg.Bootstrap {
 		if err := s.bootstrap(); err != nil {
 			return nil, fmt.Errorf("bootstrap cluster: %w", err)
 		}
 	}
 	return srv, nil
+}
+
+// raftSnapshot adapts this replica's status to the shape the gauges observe.
+// It is called on every metric collection, so it reads local state only.
+func (s *Server) raftSnapshot() telemetry.RaftSnapshot {
+	st := s.status()
+	return telemetry.RaftSnapshot{
+		NodeID:       st.NodeID,
+		State:        st.State,
+		LeaderKnown:  st.Leader != "",
+		Term:         st.Term,
+		CommitIndex:  st.CommitIndex,
+		AppliedIndex: st.AppliedIndex,
+	}
 }
 
 // raftConfig applies this replica's identity and tuning over raft's own
@@ -250,6 +278,15 @@ func (s *Server) watchLeader(ctx context.Context) {
 func (s *Server) shutdown() error {
 	slog.Info("starting shutdown")
 	var errs []error
+
+	// Detached before raft goes away, so a collection landing mid-shutdown
+	// cannot read a replica that is already tearing itself down.
+	if s.unregisterMetrics != nil {
+		if err := s.unregisterMetrics(); err != nil {
+			errs = append(errs, fmt.Errorf("unregister raft metrics: %w", err))
+		}
+		s.unregisterMetrics = nil
+	}
 
 	// Closing the transport first stops all network activity: it prevents
 	// election loops when peers have already stopped, and turns their calls

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -1,0 +1,305 @@
+// Package telemetry holds predastore's own OpenTelemetry instruments: meta
+// raft consensus state, multipart upload counters and shard read errors. The
+// OTel bootstrap itself lives in bluebottle/pkg/otelsetup, which cmd/s3d calls
+// directly, and per-request HTTP metrics come from that package's middleware.
+package telemetry
+
+import (
+	"context"
+	"strconv"
+	"sync"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// meterName identifies the predastore meter, matching the package import path
+// convention used by bluebottle/pkg/otelsetup.
+const meterName = "github.com/mulgadc/predastore/internal/telemetry"
+
+var (
+	instrumentsOnce sync.Once
+	meter           metric.Meter
+
+	raftState        metric.Int64ObservableGauge
+	raftTerm         metric.Int64ObservableGauge
+	raftCommitIndex  metric.Int64ObservableGauge
+	raftAppliedIndex metric.Int64ObservableGauge
+	raftAppliedLag   metric.Int64ObservableGauge
+	raftLeaderKnown  metric.Int64ObservableGauge
+
+	multipartUploads       metric.Int64Counter
+	multipartActiveUploads metric.Int64UpDownCounter
+	multipartParts         metric.Int64Counter
+	multipartPartBytes     metric.Int64Counter
+	multipartPartFetches   metric.Int64Counter
+
+	shardErrors metric.Int64Counter
+)
+
+// instruments lazily creates the shared instruments. The global meter
+// delegates to the real provider once Init installs one; before that (or when
+// export is disabled) every recorded call is a cheap no-op.
+func instruments() {
+	instrumentsOnce.Do(func() {
+		meter = otel.Meter(meterName)
+		var err error
+
+		raftState, err = meter.Int64ObservableGauge("predastore.meta.raft.state",
+			metric.WithDescription("Constant 1 carrying the replica's own raft.State() as an attribute."),
+			metric.WithUnit("{replica}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		raftTerm, err = meter.Int64ObservableGauge("predastore.meta.raft.term",
+			metric.WithDescription("Current raft term. A term climbing while no leader is observed is an election storm."),
+			metric.WithUnit("{term}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		raftCommitIndex, err = meter.Int64ObservableGauge("predastore.meta.raft.commit_index",
+			metric.WithDescription("Last raft log index committed by this replica."),
+			metric.WithUnit("{index}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		raftAppliedIndex, err = meter.Int64ObservableGauge("predastore.meta.raft.applied_index",
+			metric.WithDescription("Last raft log index applied to this replica's FSM."),
+			metric.WithUnit("{index}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		raftAppliedLag, err = meter.Int64ObservableGauge("predastore.meta.raft.applied_lag",
+			metric.WithDescription("Committed minus applied index. A lag that does not drain is a stalled FSM."),
+			metric.WithUnit("{index}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		raftLeaderKnown, err = meter.Int64ObservableGauge("predastore.meta.raft.leader_known",
+			metric.WithDescription("1 when this replica observes a leader, 0 when it does not. Zero on every replica beyond an election timeout is a livelock."),
+			metric.WithUnit("{replica}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+
+		multipartUploads, err = meter.Int64Counter("predastore.multipart.uploads",
+			metric.WithDescription("Multipart uploads by outcome: created, completed, aborted or rejected."),
+			metric.WithUnit("{upload}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		multipartActiveUploads, err = meter.Int64UpDownCounter("predastore.multipart.uploads.active",
+			metric.WithDescription("Multipart uploads created but not yet completed or aborted. A floor that rises across runs is leaked upload state."),
+			metric.WithUnit("{upload}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		multipartParts, err = meter.Int64Counter("predastore.multipart.parts",
+			metric.WithDescription("Parts stored for multipart uploads."),
+			metric.WithUnit("{part}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		multipartPartBytes, err = meter.Int64Counter("predastore.multipart.part.bytes",
+			metric.WithDescription("Bytes stored as multipart upload parts."),
+			metric.WithUnit("By"))
+		if err != nil {
+			otel.Handle(err)
+		}
+		multipartPartFetches, err = meter.Int64Counter("predastore.multipart.part_fetches",
+			metric.WithDescription("Part read-backs during completion, by outcome and failure reason."),
+			metric.WithUnit("{fetch}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+
+		shardErrors, err = meter.Int64Counter("predastore.shard.errors",
+			metric.WithDescription("Shard operations that failed, by op and reason. Reads are tolerated by parity, so a rate here separates routine reconstruction from a node losing data."),
+			metric.WithUnit("{error}"))
+		if err != nil {
+			otel.Handle(err)
+		}
+	})
+}
+
+// RaftSnapshot is one meta replica's consensus state at collection time.
+//
+// Term, CommitIndex and AppliedIndex are the raw raft.Stats() strings, because
+// that is how raft renders them. Parsing happens here so an unparseable value
+// can be skipped rather than reported as a real zero, which is a legitimate
+// index.
+type RaftSnapshot struct {
+	NodeID       string
+	State        string
+	LeaderKnown  bool
+	Term         string
+	CommitIndex  string
+	AppliedIndex string
+}
+
+// RegisterRaftGauges observes one meta replica's consensus state on every
+// collection. snapshot is called once per collection and its result feeds
+// every gauge, so the indexes are always mutually consistent and applied_lag
+// is a real difference rather than two readings subtracted.
+//
+// The returned function unregisters the callback; the caller invokes it when
+// the replica shuts down. Registering more than one replica in a process is
+// supported: the instruments are shared and the node attribute separates them.
+func RegisterRaftGauges(snapshot func() RaftSnapshot) (func() error, error) {
+	instruments()
+	if meter == nil {
+		return func() error { return nil }, nil
+	}
+
+	reg, err := meter.RegisterCallback(
+		func(_ context.Context, o metric.Observer) error {
+			observeRaft(o, snapshot())
+			return nil
+		},
+		raftState, raftTerm, raftCommitIndex, raftAppliedIndex, raftAppliedLag, raftLeaderKnown,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return reg.Unregister, nil
+}
+
+// observeRaft emits one snapshot across the raft gauges.
+func observeRaft(o metric.Observer, s RaftSnapshot) {
+	node := metric.WithAttributeSet(attribute.NewSet(attribute.String("node", s.NodeID)))
+
+	o.ObserveInt64(raftState, 1, metric.WithAttributeSet(attribute.NewSet(
+		attribute.String("node", s.NodeID),
+		attribute.String("raft.state", s.State),
+	)))
+	o.ObserveInt64(raftLeaderKnown, boolToInt64(s.LeaderKnown), node)
+
+	if term, ok := parseIndex(s.Term); ok {
+		o.ObserveInt64(raftTerm, term, node)
+	}
+	commit, commitOK := parseIndex(s.CommitIndex)
+	if commitOK {
+		o.ObserveInt64(raftCommitIndex, commit, node)
+	}
+	applied, appliedOK := parseIndex(s.AppliedIndex)
+	if appliedOK {
+		o.ObserveInt64(raftAppliedIndex, applied, node)
+	}
+	if commitOK && appliedOK {
+		o.ObserveInt64(raftAppliedLag, max(commit-applied, 0), node)
+	}
+}
+
+// parseIndex reads one raft.Stats() numeric field. ok is false when the value
+// is absent or not a number, which the caller reports as no observation at all
+// rather than as zero.
+func parseIndex(v string) (int64, bool) {
+	if v == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+func boolToInt64(b bool) int64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// Multipart upload outcomes. rejected is a completion refused because the
+// parts named do not match what was stored — the client-visible 400, which is
+// otherwise indistinguishable from a client that never completed at all.
+const (
+	UploadCreated   = "created"
+	UploadCompleted = "completed"
+	UploadAborted   = "aborted"
+	UploadRejected  = "rejected"
+)
+
+// RecordMultipartUpload counts one upload reaching outcome, and keeps the
+// active-upload count in step: created opens one, completed and aborted each
+// close one. rejected leaves the upload open, because it is still there.
+func RecordMultipartUpload(ctx context.Context, outcome string) {
+	instruments()
+	opt := metric.WithAttributeSet(attribute.NewSet(attribute.String("outcome", outcome)))
+	if multipartUploads != nil {
+		multipartUploads.Add(ctx, 1, opt)
+	}
+	if multipartActiveUploads == nil {
+		return
+	}
+	switch outcome {
+	case UploadCreated:
+		multipartActiveUploads.Add(ctx, 1)
+	case UploadCompleted, UploadAborted:
+		multipartActiveUploads.Add(ctx, -1)
+	}
+}
+
+// RecordMultipartPart counts one part stored, and the bytes it carried.
+func RecordMultipartPart(ctx context.Context, size int64) {
+	instruments()
+	if multipartParts != nil {
+		multipartParts.Add(ctx, 1)
+	}
+	if multipartPartBytes != nil && size > 0 {
+		multipartPartBytes.Add(ctx, size)
+	}
+}
+
+// Part read-back failure reasons, recorded when an upload is completed.
+const (
+	// FetchReasonMetaMissing is a part whose shard placement is not in the
+	// meta store: the part index is gone, not the data.
+	FetchReasonMetaMissing = "meta_missing"
+	// FetchReasonPlacementDecode is placement metadata that will not decode.
+	FetchReasonPlacementDecode = "placement_decode"
+	// FetchReasonShardRead is too few surviving shards to reconstruct the
+	// part — the data itself is unreadable.
+	FetchReasonShardRead = "shard_read"
+)
+
+// RecordMultipartPartFetch counts one part read-back during completion.
+// reason is empty on success and one of the FetchReason constants otherwise.
+func RecordMultipartPartFetch(ctx context.Context, reason string) {
+	instruments()
+	if multipartPartFetches == nil {
+		return
+	}
+	attrs := []attribute.KeyValue{attribute.String("outcome", "success")}
+	if reason != "" {
+		attrs = []attribute.KeyValue{
+			attribute.String("outcome", "error"),
+			attribute.String("reason", reason),
+		}
+	}
+	multipartPartFetches.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(attrs...)))
+}
+
+// Shard failure reasons. Bounded on purpose: the underlying error text names
+// nodes and keys and would make this counter unbounded.
+const (
+	// ShardReasonNotFound is a node that answered and does not hold the shard.
+	ShardReasonNotFound = "not_found"
+	// ShardReasonTransport is any other failure reaching or reading the node.
+	ShardReasonTransport = "transport"
+)
+
+// RecordShardError counts one failed shard operation. op is "read"; reason is
+// one of the ShardReason constants.
+func RecordShardError(ctx context.Context, op, reason string) {
+	instruments()
+	if shardErrors == nil {
+		return
+	}
+	shardErrors.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
+		attribute.String("op", op),
+		attribute.String("reason", reason),
+	)))
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -29,11 +29,11 @@ var (
 	raftAppliedLag   metric.Int64ObservableGauge
 	raftLeaderKnown  metric.Int64ObservableGauge
 
-	multipartUploads       metric.Int64Counter
-	multipartActiveUploads metric.Int64UpDownCounter
-	multipartParts         metric.Int64Counter
-	multipartPartBytes     metric.Int64Counter
-	multipartPartFetches   metric.Int64Counter
+	multipartUploads     metric.Int64Counter
+	multipartSessions    metric.Int64UpDownCounter
+	multipartPartCount   metric.Int64Counter
+	multipartPartBytes   metric.Int64Counter
+	multipartPartFetches metric.Int64Counter
 
 	shardErrors metric.Int64Counter
 )
@@ -83,19 +83,24 @@ func instruments() {
 			otel.Handle(err)
 		}
 
+		// No metric name may also be another's prefix: Elasticsearch would
+		// have to map the same field as both a leaf and an object, and the
+		// second one to arrive is rejected. So "part" is a namespace only
+		// (count/bytes/fetches siblings), and the open-session gauge is a
+		// sibling of "uploads" rather than a child of it.
 		multipartUploads, err = meter.Int64Counter("predastore.multipart.uploads",
 			metric.WithDescription("Multipart uploads by outcome: created, completed, aborted or rejected."),
 			metric.WithUnit("{upload}"))
 		if err != nil {
 			otel.Handle(err)
 		}
-		multipartActiveUploads, err = meter.Int64UpDownCounter("predastore.multipart.uploads.active",
+		multipartSessions, err = meter.Int64UpDownCounter("predastore.multipart.sessions",
 			metric.WithDescription("Multipart uploads created but not yet completed or aborted. A floor that rises across runs is leaked upload state."),
 			metric.WithUnit("{upload}"))
 		if err != nil {
 			otel.Handle(err)
 		}
-		multipartParts, err = meter.Int64Counter("predastore.multipart.parts",
+		multipartPartCount, err = meter.Int64Counter("predastore.multipart.part.count",
 			metric.WithDescription("Parts stored for multipart uploads."),
 			metric.WithUnit("{part}"))
 		if err != nil {
@@ -107,7 +112,7 @@ func instruments() {
 		if err != nil {
 			otel.Handle(err)
 		}
-		multipartPartFetches, err = meter.Int64Counter("predastore.multipart.part_fetches",
+		multipartPartFetches, err = meter.Int64Counter("predastore.multipart.part.fetches",
 			metric.WithDescription("Part read-backs during completion, by outcome and failure reason."),
 			metric.WithUnit("{fetch}"))
 		if err != nil {
@@ -223,30 +228,30 @@ const (
 )
 
 // RecordMultipartUpload counts one upload reaching outcome, and keeps the
-// active-upload count in step: created opens one, completed and aborted each
-// close one. rejected leaves the upload open, because it is still there.
+// open-session count in step: created opens one, completed and aborted each
+// close one. rejected leaves the session open, because it is still there.
 func RecordMultipartUpload(ctx context.Context, outcome string) {
 	instruments()
 	opt := metric.WithAttributeSet(attribute.NewSet(attribute.String("outcome", outcome)))
 	if multipartUploads != nil {
 		multipartUploads.Add(ctx, 1, opt)
 	}
-	if multipartActiveUploads == nil {
+	if multipartSessions == nil {
 		return
 	}
 	switch outcome {
 	case UploadCreated:
-		multipartActiveUploads.Add(ctx, 1)
+		multipartSessions.Add(ctx, 1)
 	case UploadCompleted, UploadAborted:
-		multipartActiveUploads.Add(ctx, -1)
+		multipartSessions.Add(ctx, -1)
 	}
 }
 
 // RecordMultipartPart counts one part stored, and the bytes it carried.
 func RecordMultipartPart(ctx context.Context, size int64) {
 	instruments()
-	if multipartParts != nil {
-		multipartParts.Add(ctx, 1)
+	if multipartPartCount != nil {
+		multipartPartCount.Add(ctx, 1)
 	}
 	if multipartPartBytes != nil && size > 0 {
 		multipartPartBytes.Add(ctx, size)

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -1,0 +1,348 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// withManualReader installs a real MeterProvider backed by a ManualReader for
+// the duration of the test and restores the previous global provider on
+// cleanup. It also resets instrumentsOnce so the test's Record calls create
+// fresh instruments bound to the manual reader — otherwise the package-level
+// Once fired by an earlier test would keep pointing at whatever provider was
+// live when it first ran.
+func withManualReader(t testing.TB) *sdkmetric.ManualReader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	instrumentsOnce = sync.Once{}
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prev)
+		instrumentsOnce = sync.Once{}
+	})
+	return reader
+}
+
+// collect gathers one snapshot keyed by metric name.
+func collect(t *testing.T, reader *sdkmetric.ManualReader) map[string]metricdata.Aggregation {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	out := map[string]metricdata.Aggregation{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			out[m.Name] = m.Data
+		}
+	}
+	return out
+}
+
+// sumFor returns the value of the sum datapoint whose attributes match every
+// key/value in want, and fails when no datapoint matches.
+func sumFor(t *testing.T, data metricdata.Aggregation, want map[string]string) int64 {
+	t.Helper()
+	sum, ok := data.(metricdata.Sum[int64])
+	if !ok {
+		t.Fatalf("aggregation is %T, want Sum[int64]", data)
+	}
+	for _, dp := range sum.DataPoints {
+		if attrsMatch(dp.Attributes, want) {
+			return dp.Value
+		}
+	}
+	t.Fatalf("no datapoint with attributes %v", want)
+	return 0
+}
+
+// gaugeFor returns the value of the gauge datapoint matching want. found is
+// false when the gauge emitted no such datapoint, which is a real outcome:
+// an unparseable raft index is deliberately not observed at all.
+func gaugeFor(t *testing.T, data metricdata.Aggregation, want map[string]string) (int64, bool) {
+	t.Helper()
+	g, ok := data.(metricdata.Gauge[int64])
+	if !ok {
+		t.Fatalf("aggregation is %T, want Gauge[int64]", data)
+	}
+	for _, dp := range g.DataPoints {
+		if attrsMatch(dp.Attributes, want) {
+			return dp.Value, true
+		}
+	}
+	return 0, false
+}
+
+func attrsMatch(set attribute.Set, want map[string]string) bool {
+	for k, v := range want {
+		got, ok := set.Value(attribute.Key(k))
+		if !ok || got.AsString() != v {
+			return false
+		}
+	}
+	return true
+}
+
+func TestRecordMultipartUploadCountsOutcomes(t *testing.T) {
+	reader := withManualReader(t)
+	ctx := context.Background()
+
+	RecordMultipartUpload(ctx, UploadCreated)
+	RecordMultipartUpload(ctx, UploadCreated)
+	RecordMultipartUpload(ctx, UploadCompleted)
+	RecordMultipartUpload(ctx, UploadRejected)
+
+	m := collect(t, reader)
+	if got := sumFor(t, m["predastore.multipart.uploads"], map[string]string{"outcome": UploadCreated}); got != 2 {
+		t.Errorf("created uploads = %d, want 2", got)
+	}
+	if got := sumFor(t, m["predastore.multipart.uploads"], map[string]string{"outcome": UploadCompleted}); got != 1 {
+		t.Errorf("completed uploads = %d, want 1", got)
+	}
+	if got := sumFor(t, m["predastore.multipart.uploads"], map[string]string{"outcome": UploadRejected}); got != 1 {
+		t.Errorf("rejected uploads = %d, want 1", got)
+	}
+}
+
+// A rejected completion leaves the upload in place, so it must not close one
+// out: two creates, one completion and one rejection leaves one still active.
+func TestRecordMultipartUploadTracksActiveAndRejectionLeavesItOpen(t *testing.T) {
+	reader := withManualReader(t)
+	ctx := context.Background()
+
+	RecordMultipartUpload(ctx, UploadCreated)
+	RecordMultipartUpload(ctx, UploadCreated)
+	RecordMultipartUpload(ctx, UploadRejected)
+	RecordMultipartUpload(ctx, UploadCompleted)
+
+	m := collect(t, reader)
+	if got := sumFor(t, m["predastore.multipart.uploads.active"], nil); got != 1 {
+		t.Errorf("active uploads = %d, want 1", got)
+	}
+
+	RecordMultipartUpload(ctx, UploadAborted)
+	m = collect(t, reader)
+	if got := sumFor(t, m["predastore.multipart.uploads.active"], nil); got != 0 {
+		t.Errorf("active uploads after abort = %d, want 0", got)
+	}
+}
+
+func TestRecordMultipartPartCountsPartsAndBytes(t *testing.T) {
+	reader := withManualReader(t)
+	ctx := context.Background()
+
+	RecordMultipartPart(ctx, 8<<20)
+	RecordMultipartPart(ctx, 4<<20)
+	// A zero-length part still counts as a part; it just adds no bytes.
+	RecordMultipartPart(ctx, 0)
+
+	m := collect(t, reader)
+	if got := sumFor(t, m["predastore.multipart.parts"], nil); got != 3 {
+		t.Errorf("parts = %d, want 3", got)
+	}
+	if got := sumFor(t, m["predastore.multipart.part.bytes"], nil); got != 12<<20 {
+		t.Errorf("part bytes = %d, want %d", got, 12<<20)
+	}
+}
+
+func TestRecordMultipartPartFetchSeparatesOutcomes(t *testing.T) {
+	reader := withManualReader(t)
+	ctx := context.Background()
+
+	RecordMultipartPartFetch(ctx, "")
+	RecordMultipartPartFetch(ctx, FetchReasonShardRead)
+	RecordMultipartPartFetch(ctx, FetchReasonShardRead)
+	RecordMultipartPartFetch(ctx, FetchReasonMetaMissing)
+
+	m := collect(t, reader)
+	data := m["predastore.multipart.part_fetches"]
+	if got := sumFor(t, data, map[string]string{"outcome": "success"}); got != 1 {
+		t.Errorf("successful fetches = %d, want 1", got)
+	}
+	if got := sumFor(t, data, map[string]string{"outcome": "error", "reason": FetchReasonShardRead}); got != 2 {
+		t.Errorf("shard-read failures = %d, want 2", got)
+	}
+	if got := sumFor(t, data, map[string]string{"outcome": "error", "reason": FetchReasonMetaMissing}); got != 1 {
+		t.Errorf("meta-missing failures = %d, want 1", got)
+	}
+}
+
+func TestRecordShardErrorSeparatesReasons(t *testing.T) {
+	reader := withManualReader(t)
+	ctx := context.Background()
+
+	RecordShardError(ctx, "read", ShardReasonNotFound)
+	RecordShardError(ctx, "read", ShardReasonNotFound)
+	RecordShardError(ctx, "read", ShardReasonTransport)
+
+	m := collect(t, reader)
+	data := m["predastore.shard.errors"]
+	if got := sumFor(t, data, map[string]string{"op": "read", "reason": ShardReasonNotFound}); got != 2 {
+		t.Errorf("not-found shard errors = %d, want 2", got)
+	}
+	if got := sumFor(t, data, map[string]string{"op": "read", "reason": ShardReasonTransport}); got != 1 {
+		t.Errorf("transport shard errors = %d, want 1", got)
+	}
+}
+
+func TestRegisterRaftGaugesObservesOneSnapshot(t *testing.T) {
+	reader := withManualReader(t)
+
+	unregister, err := RegisterRaftGauges(func() RaftSnapshot {
+		return RaftSnapshot{
+			NodeID:       "3",
+			State:        "Leader",
+			LeaderKnown:  true,
+			Term:         "42",
+			CommitIndex:  "1200",
+			AppliedIndex: "1150",
+		}
+	})
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := unregister(); err != nil {
+			t.Errorf("unregister: %v", err)
+		}
+	})
+
+	m := collect(t, reader)
+	node := map[string]string{"node": "3"}
+
+	if v, ok := gaugeFor(t, m["predastore.meta.raft.state"], map[string]string{"node": "3", "raft.state": "Leader"}); !ok || v != 1 {
+		t.Errorf("raft state gauge = %d (found %v), want 1", v, ok)
+	}
+	for name, want := range map[string]int64{
+		"predastore.meta.raft.term":          42,
+		"predastore.meta.raft.commit_index":  1200,
+		"predastore.meta.raft.applied_index": 1150,
+		"predastore.meta.raft.applied_lag":   50,
+		"predastore.meta.raft.leader_known":  1,
+	} {
+		v, ok := gaugeFor(t, m[name], node)
+		if !ok {
+			t.Errorf("%s: no datapoint for node 3", name)
+			continue
+		}
+		if v != want {
+			t.Errorf("%s = %d, want %d", name, v, want)
+		}
+	}
+}
+
+// A replica observing no leader reports leader_known 0 rather than failing to
+// report: "answered, and sees no leader" is the condition worth alerting on.
+func TestRegisterRaftGaugesReportsNoLeaderAsZero(t *testing.T) {
+	reader := withManualReader(t)
+
+	unregister, err := RegisterRaftGauges(func() RaftSnapshot {
+		return RaftSnapshot{NodeID: "1", State: "Candidate", Term: "9", CommitIndex: "5", AppliedIndex: "5"}
+	})
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	defer func() { _ = unregister() }()
+
+	m := collect(t, reader)
+	if v, ok := gaugeFor(t, m["predastore.meta.raft.leader_known"], map[string]string{"node": "1"}); !ok || v != 0 {
+		t.Errorf("leader_known = %d (found %v), want 0", v, ok)
+	}
+	if v, ok := gaugeFor(t, m["predastore.meta.raft.applied_lag"], map[string]string{"node": "1"}); !ok || v != 0 {
+		t.Errorf("applied_lag = %d (found %v), want 0", v, ok)
+	}
+}
+
+// Zero is a legitimate raft index, so a value that will not parse must produce
+// no observation at all rather than a plausible-looking zero.
+func TestRegisterRaftGaugesSkipsUnparseableIndexes(t *testing.T) {
+	reader := withManualReader(t)
+
+	unregister, err := RegisterRaftGauges(func() RaftSnapshot {
+		return RaftSnapshot{NodeID: "2", State: "Follower", LeaderKnown: true, Term: "", CommitIndex: "not-a-number", AppliedIndex: "7"}
+	})
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	defer func() { _ = unregister() }()
+
+	m := collect(t, reader)
+	node := map[string]string{"node": "2"}
+
+	if _, ok := m["predastore.meta.raft.term"]; ok {
+		if _, found := gaugeFor(t, m["predastore.meta.raft.term"], node); found {
+			t.Error("term observed despite an empty value")
+		}
+	}
+	if _, ok := m["predastore.meta.raft.commit_index"]; ok {
+		if _, found := gaugeFor(t, m["predastore.meta.raft.commit_index"], node); found {
+			t.Error("commit index observed despite an unparseable value")
+		}
+	}
+	if _, ok := m["predastore.meta.raft.applied_lag"]; ok {
+		if _, found := gaugeFor(t, m["predastore.meta.raft.applied_lag"], node); found {
+			t.Error("applied lag observed without a commit index to subtract from")
+		}
+	}
+	if v, ok := gaugeFor(t, m["predastore.meta.raft.applied_index"], node); !ok || v != 7 {
+		t.Errorf("applied index = %d (found %v), want 7", v, ok)
+	}
+}
+
+// Two replicas in one process share the instruments, so the node attribute is
+// the only thing keeping their readings apart.
+func TestRegisterRaftGaugesSeparatesReplicasByNode(t *testing.T) {
+	reader := withManualReader(t)
+
+	for _, node := range []string{"1", "2"} {
+		unregister, err := RegisterRaftGauges(func() RaftSnapshot {
+			return RaftSnapshot{NodeID: node, State: "Follower", LeaderKnown: true, Term: "4", CommitIndex: node, AppliedIndex: node}
+		})
+		if err != nil {
+			t.Fatalf("register node %s: %v", node, err)
+		}
+		defer func() { _ = unregister() }()
+	}
+
+	m := collect(t, reader)
+	for _, want := range []struct {
+		node  string
+		value int64
+	}{{"1", 1}, {"2", 2}} {
+		v, ok := gaugeFor(t, m["predastore.meta.raft.commit_index"], map[string]string{"node": want.node})
+		if !ok || v != want.value {
+			t.Errorf("node %s commit index = %d (found %v), want %d", want.node, v, ok, want.value)
+		}
+	}
+}
+
+func TestRegisterRaftGaugesUnregisterStopsObservation(t *testing.T) {
+	reader := withManualReader(t)
+
+	unregister, err := RegisterRaftGauges(func() RaftSnapshot {
+		return RaftSnapshot{NodeID: "5", State: "Leader", LeaderKnown: true, Term: "1", CommitIndex: "1", AppliedIndex: "1"}
+	})
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if _, ok := gaugeFor(t, collect(t, reader)["predastore.meta.raft.term"], map[string]string{"node": "5"}); !ok {
+		t.Fatal("term not observed while registered")
+	}
+
+	if err := unregister(); err != nil {
+		t.Fatalf("unregister: %v", err)
+	}
+	m := collect(t, reader)
+	if data, ok := m["predastore.meta.raft.term"]; ok {
+		if _, found := gaugeFor(t, data, map[string]string{"node": "5"}); found {
+			t.Error("term still observed after unregister")
+		}
+	}
+}

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -2,6 +2,9 @@ package telemetry
 
 import (
 	"context"
+	"maps"
+	"slices"
+	"strings"
 	"sync"
 	"testing"
 
@@ -123,14 +126,14 @@ func TestRecordMultipartUploadTracksActiveAndRejectionLeavesItOpen(t *testing.T)
 	RecordMultipartUpload(ctx, UploadCompleted)
 
 	m := collect(t, reader)
-	if got := sumFor(t, m["predastore.multipart.uploads.active"], nil); got != 1 {
-		t.Errorf("active uploads = %d, want 1", got)
+	if got := sumFor(t, m["predastore.multipart.sessions"], nil); got != 1 {
+		t.Errorf("open sessions = %d, want 1", got)
 	}
 
 	RecordMultipartUpload(ctx, UploadAborted)
 	m = collect(t, reader)
-	if got := sumFor(t, m["predastore.multipart.uploads.active"], nil); got != 0 {
-		t.Errorf("active uploads after abort = %d, want 0", got)
+	if got := sumFor(t, m["predastore.multipart.sessions"], nil); got != 0 {
+		t.Errorf("open sessions after abort = %d, want 0", got)
 	}
 }
 
@@ -144,7 +147,7 @@ func TestRecordMultipartPartCountsPartsAndBytes(t *testing.T) {
 	RecordMultipartPart(ctx, 0)
 
 	m := collect(t, reader)
-	if got := sumFor(t, m["predastore.multipart.parts"], nil); got != 3 {
+	if got := sumFor(t, m["predastore.multipart.part.count"], nil); got != 3 {
 		t.Errorf("parts = %d, want 3", got)
 	}
 	if got := sumFor(t, m["predastore.multipart.part.bytes"], nil); got != 12<<20 {
@@ -162,7 +165,7 @@ func TestRecordMultipartPartFetchSeparatesOutcomes(t *testing.T) {
 	RecordMultipartPartFetch(ctx, FetchReasonMetaMissing)
 
 	m := collect(t, reader)
-	data := m["predastore.multipart.part_fetches"]
+	data := m["predastore.multipart.part.fetches"]
 	if got := sumFor(t, data, map[string]string{"outcome": "success"}); got != 1 {
 		t.Errorf("successful fetches = %d, want 1", got)
 	}
@@ -343,6 +346,40 @@ func TestRegisterRaftGaugesUnregisterStopsObservation(t *testing.T) {
 	if data, ok := m["predastore.meta.raft.term"]; ok {
 		if _, found := gaugeFor(t, data, map[string]string{"node": "5"}); found {
 			t.Error("term still observed after unregister")
+		}
+	}
+}
+
+// Elasticsearch maps a dotted metric name as a path, so a name that is also
+// another name's prefix would have to be both a leaf and an object. The second
+// one to arrive is rejected and its series are lost. Exercising every recorder
+// and then comparing the names that actually reached the reader keeps this
+// honest as instruments are added.
+func TestNoMetricNameIsAnotherPrefix(t *testing.T) {
+	reader := withManualReader(t)
+	ctx := context.Background()
+
+	RecordMultipartUpload(ctx, UploadCreated)
+	RecordMultipartPart(ctx, 1)
+	RecordMultipartPartFetch(ctx, "")
+	RecordShardError(ctx, "read", ShardReasonNotFound)
+	unregister, err := RegisterRaftGauges(func() RaftSnapshot {
+		return RaftSnapshot{NodeID: "1", State: "Leader", LeaderKnown: true, Term: "1", CommitIndex: "2", AppliedIndex: "1"}
+	})
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	defer func() { _ = unregister() }()
+
+	names := slices.Collect(maps.Keys(collect(t, reader)))
+	if len(names) == 0 {
+		t.Fatal("no metrics collected")
+	}
+	for _, outer := range names {
+		for _, inner := range names {
+			if outer != inner && strings.HasPrefix(inner, outer+".") {
+				t.Errorf("%q is a prefix of %q: Elasticsearch cannot map it as both a leaf and an object", outer, inner)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Predastore created no OpenTelemetry meter of its own. The only metrics it reported came from bluebottle's shared HTTP middleware, so consensus state and multipart uploads were observable only as log lines.

Adds `internal/telemetry`, mirroring `viperblock/telemetry`.

## Why

Two open P1 defects have no metric producer:

- **Meta-raft livelock.** `internal/meta/server.go` already assembles a full `MetaStatus` — state, observed leader, term, commit index, applied index — and serves it over `OpMetaStatus`. Nothing turned it into a metric. The Kibana storage-raft dashboard is built entirely on `FROM logs-apm*`, counting parsed hashicorp raft log messages, which cannot answer how far behind a replica is.
- **Multipart shard loss on large uploads** (`mulga-0yz1b`): 44 "shard not found" errors across three nodes in one attempt of a 4.97 GiB upload. No counter for uploads started, parts stored, part read-backs or shard errors.

Bytes transferred and real S3 error codes were already covered by the shared `otelsetup` middleware (`mulga.request.bytes` with a `direction` attribute, and `s3.error_code` set from both error-response paths), so they are not repeated here.

## What it adds

**Raft gauges**, registered by the meta server once raft exists and unregistered before teardown. One `RegisterCallback` takes one `MetaStatus` snapshot per collection, so the indexes stay mutually consistent and `applied_lag` is a real difference rather than two readings subtracted.

| Instrument | |
|---|---|
| `predastore.meta.raft.state` | constant 1 carrying `raft.state` as an attribute |
| `predastore.meta.raft.term` | climbing with no leader is an election storm |
| `predastore.meta.raft.commit_index` / `.applied_index` | |
| `predastore.meta.raft.applied_lag` | a lag that does not drain is a stalled FSM |
| `predastore.meta.raft.leader_known` | 0 on every replica past an election timeout is the livelock |

`raft.Stats()` renders term and indexes as strings. Parsing happens in the telemetry package so an unparseable value is skipped rather than reported as zero, which is a legitimate index. Several replicas in one process are separated by a `node` attribute.

**Multipart counters:** `uploads` by outcome (created/completed/aborted/rejected), `sessions` for uploads open right now, `part.count`, `part.bytes`, `part.fetches` by outcome and failure reason. `rejected` is the `ValidatePartsForCompletion` 400 — the client-visible "Part N does not exist" — and deliberately does not close a session, because the upload is still there.

**Shard errors:** `predastore.shard.errors` at the `readShard` seam, classified `not_found` (via `errors.Is(err, blob.ErrNotFound)`) or `transport`. `shardBytes` tolerates failed shards by design, so this is what separates routine parity reconstruction from a node losing data.

## Notes for review

- No attribute carries a bucket, key, upload id, part number or object hash.
- No metric name is a prefix of another. Elasticsearch maps a dotted name as a path, so such a name would have to be mapped as both a leaf and an object and the second to arrive is rejected, losing its series silently. A test exercises every recorder and asserts this holds.
- Nothing needs to change in spinifex: it calls `otelsetup.Init` for every service subcommand, which installs the global meter provider, and the lazy meter binds to it.
- Field pinning in the Elasticsearch metrics template and the Kibana panels are follow-up work in the mulga ansible roles.

## Testing

Ten tests over an SDK `ManualReader` covering every recorder, the raft callback, unparseable indexes, multi-replica separation, unregistration and the name-prefix rule. Full predastore suite passes.

`make preflight` reports six lint findings (3 `modernize`, 3 `staticcheck` SA4023) in `internal/config`, `internal/gate/model`, `internal/transport` and `internal/rpc`. All six are present on `dev` unchanged and none are in files this branch touches.