### PR TITLE
fix: verify the account of an attached policy ARN before resolving it

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/raft-boltdb/v2 v2.3.1
 	github.com/klauspost/reedsolomon v1.14.2
 	github.com/minio/crc64nvme v1.1.1
-	github.com/mulgadc/bluebottle v1.18.0
+	github.com/mulgadc/bluebottle v1.18.1-0.20260826044308-1a1e1242c217
 	github.com/nats-io/nats.go v1.53.1
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/quic-go/quic-go v0.61.0

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mulgadc/bluebottle v1.18.0 h1:aNrogJBz59gJAxCwpERGBC5bGXkSoUCCCBbNvnamuRU=
 github.com/mulgadc/bluebottle v1.18.0/go.mod h1:KkUyzqfKxyI8PvKR27EVqJnVm4BSbajl1Q/u+PQxAYw=
+github.com/mulgadc/bluebottle v1.18.1-0.20260826044308-1a1e1242c217 h1:zRKEFadLkUQxNCK2L3MYSQxRmu4VEEHWTxMwh04Qmeo=
+github.com/mulgadc/bluebottle v1.18.1-0.20260826044308-1a1e1242c217/go.mod h1:KkUyzqfKxyI8PvKR27EVqJnVm4BSbajl1Q/u+PQxAYw=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nats-io/nats.go v1.53.1 h1:Otsq3uLc/kLdjmkNHkXH0jBqwUquwdKFoe3fq6/3/Xo=

--- a/internal/gate/auth/auth.go
+++ b/internal/gate/auth/auth.go
@@ -24,6 +24,11 @@ import (
 // ErrKeyNotFound is returned when an access key does not exist in the provider.
 var ErrKeyNotFound = errors.New("access key not found")
 
+// ErrPrincipalConfig is returned when a principal's stored IAM records are
+// unusable — a malformed or foreign-account attached policy ARN. It is a
+// permanent config fault, so it denies (403) rather than inviting an SDK retry.
+var ErrPrincipalConfig = errors.New("principal IAM configuration is invalid")
+
 // CredentialResult is the result of a credential lookup.
 type CredentialResult struct {
 	SecretAccessKey string
@@ -701,7 +706,7 @@ func (p *NATSIAMProvider) resolveUserPolicies(ctx context.Context, accountID, us
 		return nil, fmt.Errorf("unmarshal user: %w", err)
 	}
 
-	docs, err := p.resolveManagedPolicies(ctx, accountID, user.AttachedPolicies)
+	docs, err := p.resolveManagedPolicies(ctx, accountID, "user "+userName, user.AttachedPolicies)
 	if err != nil {
 		return nil, err
 	}
@@ -775,7 +780,7 @@ func (p *NATSIAMProvider) resolveGroupPolicies(ctx context.Context, accountID, u
 			return nil, fmt.Errorf("unmarshal group %s: %w", groupName, err)
 		}
 
-		managed, err := p.resolveManagedPolicies(ctx, accountID, group.AttachedPolicies)
+		managed, err := p.resolveManagedPolicies(ctx, accountID, "group "+groupName, group.AttachedPolicies)
 		if err != nil {
 			return nil, err // fail closed (mirrors direct-policy handling)
 		}
@@ -805,7 +810,7 @@ func (p *NATSIAMProvider) resolveRolePolicies(ctx context.Context, accountID, ro
 		return nil, fmt.Errorf("unmarshal role: %w", err)
 	}
 
-	docs, err := p.resolveManagedPolicies(ctx, accountID, role.AttachedPolicies)
+	docs, err := p.resolveManagedPolicies(ctx, accountID, "role "+roleName, role.AttachedPolicies)
 	if err != nil {
 		return nil, err
 	}
@@ -833,26 +838,30 @@ func resolveInlinePolicies(inline map[string]string, label string) ([]iampolicy.
 }
 
 // resolveManagedPolicies resolves a list of managed-policy ARNs into parsed
-// policy documents from policiesBucket. Shared by the user and role resolvers;
-// the role resolver appends its inline-policy walk separately.
-func (p *NATSIAMProvider) resolveManagedPolicies(ctx context.Context, accountID string, arns []string) ([]iampolicy.PolicyDocument, error) {
+// policy documents from policiesBucket. label names the principal holding the
+// attachment ("group Admins") so a fault points at the record to fix.
+func (p *NATSIAMProvider) resolveManagedPolicies(ctx context.Context, accountID, label string, arns []string) ([]iampolicy.PolicyDocument, error) {
 	var docs []iampolicy.PolicyDocument
 	for _, arn := range arns {
 		// AWS-managed policies have no document in this stack: resolve them to no
 		// grant, matching spinifex's deny for an unmodeled managed policy.
 		if iamarn.IsAWSManagedPolicyARN(arn) {
-			slog.Debug("Skipping AWS-managed policy ARN", "arn", arn, "accountID", accountID)
+			slog.Debug("Skipping AWS-managed policy ARN", "arn", arn, "accountID", accountID, "principal", label)
 			continue
 		}
 
 		arnAccount, policyName, err := iamarn.ParsePolicyARN(arn)
 		if err != nil {
-			return nil, fmt.Errorf("parse attached policy ARN %q: %w", arn, err)
+			slog.Error("Attached policy ARN is unparseable — failing closed",
+				"accountID", accountID, "principal", label, "arn", arn, "err", err)
+			return nil, fmt.Errorf("%w: %s attached policy ARN %q: %w", ErrPrincipalConfig, label, arn, err)
 		}
 		// Scoping a foreign ARN's name to this account would load an unrelated
 		// same-named policy; there is no correct grant to return for it.
 		if arnAccount != accountID {
-			return nil, fmt.Errorf("attached policy ARN %q is not in account %s", arn, accountID)
+			slog.Error("Attached policy ARN names a foreign account — failing closed",
+				"accountID", accountID, "principal", label, "arn", arn, "arnAccountID", arnAccount)
+			return nil, fmt.Errorf("%w: %s attached policy ARN %q is not in account %s", ErrPrincipalConfig, label, arn, accountID)
 		}
 
 		policyKey := accountID + "." + policyName

--- a/internal/gate/auth/auth.go
+++ b/internal/gate/auth/auth.go
@@ -838,10 +838,21 @@ func resolveInlinePolicies(inline map[string]string, label string) ([]iampolicy.
 func (p *NATSIAMProvider) resolveManagedPolicies(ctx context.Context, accountID string, arns []string) ([]iampolicy.PolicyDocument, error) {
 	var docs []iampolicy.PolicyDocument
 	for _, arn := range arns {
-		policyName := iamarn.ExtractPolicyName(arn)
-		if policyName == "" {
-			slog.Warn("Skipping unparseable policy ARN", "arn", arn, "accountID", accountID)
+		// AWS-managed policies have no document in this stack: resolve them to no
+		// grant, matching spinifex's deny for an unmodeled managed policy.
+		if iamarn.IsAWSManagedPolicyARN(arn) {
+			slog.Debug("Skipping AWS-managed policy ARN", "arn", arn, "accountID", accountID)
 			continue
+		}
+
+		arnAccount, policyName, err := iamarn.ParsePolicyARN(arn)
+		if err != nil {
+			return nil, fmt.Errorf("parse attached policy ARN %q: %w", arn, err)
+		}
+		// Scoping a foreign ARN's name to this account would load an unrelated
+		// same-named policy; there is no correct grant to return for it.
+		if arnAccount != accountID {
+			return nil, fmt.Errorf("attached policy ARN %q is not in account %s", arn, accountID)
 		}
 
 		policyKey := accountID + "." + policyName

--- a/internal/gate/auth/auth_session_test.go
+++ b/internal/gate/auth/auth_session_test.go
@@ -399,6 +399,7 @@ func TestLookupSession_AttachedPolicyARNRejected(t *testing.T) {
 	}{
 		{"foreign account", []string{"arn:aws:iam::999999999999:policy/AdministratorAccess"}, "AdministratorAccess"},
 		{"policy-backup near miss", []string{local + ":policy-backup/AdministratorAccess"}, "AdministratorAccess"},
+		{"malformed AWS managed", []string{"arn:aws:iam::aws:policy/", local + ":policy/S3FullAccess"}, "S3FullAccess"},
 		{"malformed", []string{"not-an-arn", local + ":policy/S3FullAccess"}, "S3FullAccess"},
 		// A skipped ARN used to drop whatever it named — a Deny among them — and
 		// leave the sibling Allow standing. Fail rather than narrow the set.

--- a/internal/gate/auth/auth_session_test.go
+++ b/internal/gate/auth/auth_session_test.go
@@ -362,33 +362,128 @@ func TestLookupSession_AssumedRolePolicyKVError(t *testing.T) {
 	assert.Contains(t, err.Error(), "resolve session policies")
 }
 
-// TestLookupSession_AssumedRoleSkipsUnparseablePolicyARN: an unparseable entry in
-// the role's attached policies is skipped (logged), not treated as an error — the
-// remaining valid policies still resolve.
-func TestLookupSession_AssumedRoleSkipsUnparseablePolicyARN(t *testing.T) {
-	k := loadTestKey(t)
-	roles := map[string][]byte{
+// roleAttaching builds the roles KV record for testSessionRole attaching the
+// given verbatim policy ARNs, so a test can name a malformed or foreign one.
+func roleAttaching(t *testing.T, arns ...string) map[string][]byte {
+	t.Helper()
+	return map[string][]byte{
 		testSessionAccount + "." + testSessionRole: mustMarshal(t, iamRole{
-			RoleName:  testSessionRole,
-			AccountID: testSessionAccount,
-			AttachedPolicies: []string{
-				"not-an-arn",
-				"arn:aws:iam::" + testSessionAccount + ":policy/S3FullAccess",
-			},
+			RoleName:         testSessionRole,
+			AccountID:        testSessionAccount,
+			AttachedPolicies: arns,
 		}),
 	}
-	policies := map[string][]byte{
-		testSessionAccount + ".S3FullAccess": mustMarshal(t, iamPolicy{
-			PolicyName:     "S3FullAccess",
-			PolicyDocument: allowAllS3Policy,
+}
+
+// seededPolicy builds a policies KV record for a single same-account policy.
+func seededPolicy(t *testing.T, policyName, policyDoc string) map[string][]byte {
+	t.Helper()
+	return map[string][]byte{
+		testSessionAccount + "." + policyName: mustMarshal(t, iamPolicy{
+			PolicyName:     policyName,
+			PolicyDocument: policyDoc,
 		}),
 	}
+}
+
+// TestLookupSession_AttachedPolicyARNForeignAccount is the regression test: an
+// attached ARN naming another account's policy must fail the resolution, never
+// alias onto the same-named policy in the caller's own account.
+func TestLookupSession_AttachedPolicyARNForeignAccount(t *testing.T) {
+	k := loadTestKey(t)
+	roles := roleAttaching(t, "arn:aws:iam::999999999999:policy/AdministratorAccess")
+	policies := seededPolicy(t, "AdministratorAccess", allowAllS3Policy)
 	sessions := assumedRoleSession(t, k, "secret", testSessionRoleARN, time.Now().UTC().Add(time.Hour))
 	p := newSessionProvider(k, sessions, nil, roles, policies)
 
 	res, err := p.LookupCredentials(testSessionAKID)
-	require.NoError(t, err, "an unparseable ARN must be skipped, not error the whole lookup")
-	require.Len(t, res.PolicyDocuments, 1, "only the one valid attached policy resolves")
+	require.Error(t, err, "a foreign-account policy ARN must fail the resolution")
+	assert.Nil(t, res, "the same-named local policy must never be substituted")
+}
+
+// TestLookupSession_AttachedPolicyARNAWSManaged: an AWS-managed ARN has no
+// backing document here, so it resolves to no grant — skipped, not substituted
+// by a same-named local policy, and not an error.
+func TestLookupSession_AttachedPolicyARNAWSManaged(t *testing.T) {
+	k := loadTestKey(t)
+	roles := roleAttaching(t, "arn:aws:iam::aws:policy/AdministratorAccess")
+	policies := seededPolicy(t, "AdministratorAccess", allowAllS3Policy)
+	sessions := assumedRoleSession(t, k, "secret", testSessionRoleARN, time.Now().UTC().Add(time.Hour))
+	p := newSessionProvider(k, sessions, nil, roles, policies)
+
+	res, err := p.LookupCredentials(testSessionAKID)
+	require.NoError(t, err, "an AWS-managed ARN is expected in normal operation, not a fault")
+	assert.Empty(t, res.PolicyDocuments, "an AWS-managed ARN resolves to no grant")
+	assert.False(t, allowed("s3:ListBucket", "arn:aws:s3:::session-bucket", res.PolicyDocuments))
+}
+
+// TestLookupSession_AttachedPolicyARNNearMiss: a resource prefix that merely
+// starts with "policy" (":policy-backup/") is not a policy ARN and must not
+// resolve off its trailing segment.
+func TestLookupSession_AttachedPolicyARNNearMiss(t *testing.T) {
+	k := loadTestKey(t)
+	roles := roleAttaching(t, "arn:aws:iam::"+testSessionAccount+":policy-backup/AdministratorAccess")
+	policies := seededPolicy(t, "AdministratorAccess", allowAllS3Policy)
+	sessions := assumedRoleSession(t, k, "secret", testSessionRoleARN, time.Now().UTC().Add(time.Hour))
+	p := newSessionProvider(k, sessions, nil, roles, policies)
+
+	res, err := p.LookupCredentials(testSessionAKID)
+	require.Error(t, err, "a :policy-backup/ ARN must not parse as a policy ARN")
+	assert.Nil(t, res, "the same-named local policy must never be substituted")
+}
+
+// TestLookupSession_AttachedPolicyARNMalformed: an unparseable entry in a
+// principal's attachment list is a data-integrity fault, so it fails the whole
+// resolution rather than being skipped with a warning.
+func TestLookupSession_AttachedPolicyARNMalformed(t *testing.T) {
+	k := loadTestKey(t)
+	roles := roleAttaching(t,
+		"not-an-arn",
+		"arn:aws:iam::"+testSessionAccount+":policy/S3FullAccess",
+	)
+	policies := seededPolicy(t, "S3FullAccess", allowAllS3Policy)
+	sessions := assumedRoleSession(t, k, "secret", testSessionRoleARN, time.Now().UTC().Add(time.Hour))
+	p := newSessionProvider(k, sessions, nil, roles, policies)
+
+	res, err := p.LookupCredentials(testSessionAKID)
+	require.Error(t, err, "an unparseable attached ARN must fail the resolution")
+	assert.Nil(t, res)
+}
+
+// TestLookupSession_AttachedPolicyARNMalformedDenyNotDropped: skipping a
+// malformed ARN used to drop the Deny it named, leaving an inherited Allow
+// standing. The resolution must fail instead of returning the allow-only set.
+func TestLookupSession_AttachedPolicyARNMalformedDenyNotDropped(t *testing.T) {
+	k := loadTestKey(t)
+	roles := roleAttaching(t,
+		"arn:aws:iam::"+testSessionAccount+":policy/S3FullAccess",
+		"arn:aws:iam::"+testSessionAccount+":policy-backup/S3Deny",
+	)
+	policies := seededPolicy(t, "S3FullAccess", allowAllS3Policy)
+	policies[testSessionAccount+".S3Deny"] = mustMarshal(t, iamPolicy{
+		PolicyName:     "S3Deny",
+		PolicyDocument: denyAllS3Policy,
+	})
+	sessions := assumedRoleSession(t, k, "secret", testSessionRoleARN, time.Now().UTC().Add(time.Hour))
+	p := newSessionProvider(k, sessions, nil, roles, policies)
+
+	res, err := p.LookupCredentials(testSessionAKID)
+	require.Error(t, err, "a dropped Deny must fail the request, not resolve to the Allow alone")
+	assert.Nil(t, res, "the Allow must not be returned without the Deny that overrode it")
+}
+
+// TestLookupSession_AttachedPolicyARNWithPath: a path-bearing same-account ARN
+// resolves off its final segment.
+func TestLookupSession_AttachedPolicyARNWithPath(t *testing.T) {
+	k := loadTestKey(t)
+	roles := roleAttaching(t, "arn:aws:iam::"+testSessionAccount+":policy/team/S3FullAccess")
+	policies := seededPolicy(t, "S3FullAccess", allowAllS3Policy)
+	sessions := assumedRoleSession(t, k, "secret", testSessionRoleARN, time.Now().UTC().Add(time.Hour))
+	p := newSessionProvider(k, sessions, nil, roles, policies)
+
+	res, err := p.LookupCredentials(testSessionAKID)
+	require.NoError(t, err)
+	require.Len(t, res.PolicyDocuments, 1, "the path-bearing ARN must resolve off its final segment")
 	assert.True(t, allowed("s3:ListBucket", "arn:aws:s3:::session-bucket", res.PolicyDocuments))
 }
 

--- a/internal/gate/auth/auth_session_test.go
+++ b/internal/gate/auth/auth_session_test.go
@@ -386,19 +386,37 @@ func seededPolicy(t *testing.T, policyName, policyDoc string) map[string][]byte 
 	}
 }
 
-// TestLookupSession_AttachedPolicyARNForeignAccount is the regression test: an
-// attached ARN naming another account's policy must fail the resolution, never
-// alias onto the same-named policy in the caller's own account.
-func TestLookupSession_AttachedPolicyARNForeignAccount(t *testing.T) {
-	k := loadTestKey(t)
-	roles := roleAttaching(t, "arn:aws:iam::999999999999:policy/AdministratorAccess")
-	policies := seededPolicy(t, "AdministratorAccess", allowAllS3Policy)
-	sessions := assumedRoleSession(t, k, "secret", testSessionRoleARN, time.Now().UTC().Add(time.Hour))
-	p := newSessionProvider(k, sessions, nil, roles, policies)
+// TestLookupSession_AttachedPolicyARNRejected: an attached ARN that does not
+// name a policy in this account fails the resolution as a principal-config
+// fault. Each case seeds the allow-all policy the bad ARN would have aliased
+// onto, so a regression grants it instead of erroring.
+func TestLookupSession_AttachedPolicyARNRejected(t *testing.T) {
+	local := "arn:aws:iam::" + testSessionAccount
+	tests := []struct {
+		name string
+		arns []string
+		seed string
+	}{
+		{"foreign account", []string{"arn:aws:iam::999999999999:policy/AdministratorAccess"}, "AdministratorAccess"},
+		{"policy-backup near miss", []string{local + ":policy-backup/AdministratorAccess"}, "AdministratorAccess"},
+		{"malformed", []string{"not-an-arn", local + ":policy/S3FullAccess"}, "S3FullAccess"},
+		// A skipped ARN used to drop whatever it named — a Deny among them — and
+		// leave the sibling Allow standing. Fail rather than narrow the set.
+		{"malformed after a valid allow", []string{local + ":policy/S3FullAccess", "not-an-arn"}, "S3FullAccess"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := loadTestKey(t)
+			sessions := assumedRoleSession(t, k, "secret", testSessionRoleARN, time.Now().UTC().Add(time.Hour))
+			p := newSessionProvider(k, sessions, nil, roleAttaching(t, tt.arns...), seededPolicy(t, tt.seed, allowAllS3Policy))
 
-	res, err := p.LookupCredentials(testSessionAKID)
-	require.Error(t, err, "a foreign-account policy ARN must fail the resolution")
-	assert.Nil(t, res, "the same-named local policy must never be substituted")
+			res, err := p.LookupCredentials(testSessionAKID)
+			require.Error(t, err, "an unresolvable attached ARN must fail the resolution")
+			assert.ErrorIs(t, err, ErrPrincipalConfig, "a config fault must deny, not report a retriable infra error")
+			assert.NotErrorIs(t, err, ErrKeyNotFound)
+			assert.Nil(t, res, "no policy may be substituted for the ARN that failed")
+		})
+	}
 }
 
 // TestLookupSession_AttachedPolicyARNAWSManaged: an AWS-managed ARN has no
@@ -415,61 +433,6 @@ func TestLookupSession_AttachedPolicyARNAWSManaged(t *testing.T) {
 	require.NoError(t, err, "an AWS-managed ARN is expected in normal operation, not a fault")
 	assert.Empty(t, res.PolicyDocuments, "an AWS-managed ARN resolves to no grant")
 	assert.False(t, allowed("s3:ListBucket", "arn:aws:s3:::session-bucket", res.PolicyDocuments))
-}
-
-// TestLookupSession_AttachedPolicyARNNearMiss: a resource prefix that merely
-// starts with "policy" (":policy-backup/") is not a policy ARN and must not
-// resolve off its trailing segment.
-func TestLookupSession_AttachedPolicyARNNearMiss(t *testing.T) {
-	k := loadTestKey(t)
-	roles := roleAttaching(t, "arn:aws:iam::"+testSessionAccount+":policy-backup/AdministratorAccess")
-	policies := seededPolicy(t, "AdministratorAccess", allowAllS3Policy)
-	sessions := assumedRoleSession(t, k, "secret", testSessionRoleARN, time.Now().UTC().Add(time.Hour))
-	p := newSessionProvider(k, sessions, nil, roles, policies)
-
-	res, err := p.LookupCredentials(testSessionAKID)
-	require.Error(t, err, "a :policy-backup/ ARN must not parse as a policy ARN")
-	assert.Nil(t, res, "the same-named local policy must never be substituted")
-}
-
-// TestLookupSession_AttachedPolicyARNMalformed: an unparseable entry in a
-// principal's attachment list is a data-integrity fault, so it fails the whole
-// resolution rather than being skipped with a warning.
-func TestLookupSession_AttachedPolicyARNMalformed(t *testing.T) {
-	k := loadTestKey(t)
-	roles := roleAttaching(t,
-		"not-an-arn",
-		"arn:aws:iam::"+testSessionAccount+":policy/S3FullAccess",
-	)
-	policies := seededPolicy(t, "S3FullAccess", allowAllS3Policy)
-	sessions := assumedRoleSession(t, k, "secret", testSessionRoleARN, time.Now().UTC().Add(time.Hour))
-	p := newSessionProvider(k, sessions, nil, roles, policies)
-
-	res, err := p.LookupCredentials(testSessionAKID)
-	require.Error(t, err, "an unparseable attached ARN must fail the resolution")
-	assert.Nil(t, res)
-}
-
-// TestLookupSession_AttachedPolicyARNMalformedDenyNotDropped: skipping a
-// malformed ARN used to drop the Deny it named, leaving an inherited Allow
-// standing. The resolution must fail instead of returning the allow-only set.
-func TestLookupSession_AttachedPolicyARNMalformedDenyNotDropped(t *testing.T) {
-	k := loadTestKey(t)
-	roles := roleAttaching(t,
-		"arn:aws:iam::"+testSessionAccount+":policy/S3FullAccess",
-		"arn:aws:iam::"+testSessionAccount+":policy-backup/S3Deny",
-	)
-	policies := seededPolicy(t, "S3FullAccess", allowAllS3Policy)
-	policies[testSessionAccount+".S3Deny"] = mustMarshal(t, iamPolicy{
-		PolicyName:     "S3Deny",
-		PolicyDocument: denyAllS3Policy,
-	})
-	sessions := assumedRoleSession(t, k, "secret", testSessionRoleARN, time.Now().UTC().Add(time.Hour))
-	p := newSessionProvider(k, sessions, nil, roles, policies)
-
-	res, err := p.LookupCredentials(testSessionAKID)
-	require.Error(t, err, "a dropped Deny must fail the request, not resolve to the Allow alone")
-	assert.Nil(t, res, "the Allow must not be returned without the Deny that overrode it")
 }
 
 // TestLookupSession_AttachedPolicyARNWithPath: a path-bearing same-account ARN

--- a/internal/gate/handlers/respond.go
+++ b/internal/gate/handlers/respond.go
@@ -25,6 +25,15 @@ func RespondSigV4Error(w http.ResponseWriter, r *http.Request, claimedKey string
 				"The AWS Access Key Id you provided does not exist in our records")
 			return
 		}
+		// A permanent fault in the principal's IAM records: deny rather than
+		// return a 500 the SDK would retry against a record only an operator
+		// can fix. The offending ARN is logged, never returned to the client.
+		if errors.Is(lookupErr, auth.ErrPrincipalConfig) {
+			slog.ErrorContext(r.Context(), "Principal IAM configuration is invalid — denying",
+				"accessKeyID", claimedKey, "error", lookupErr, "remoteAddr", r.RemoteAddr)
+			WriteS3Error(w, r, http.StatusForbidden, "AccessDenied", "Access Denied")
+			return
+		}
 		slog.ErrorContext(r.Context(), "Credential lookup infrastructure error",
 			"accessKeyID", claimedKey, "error", lookupErr, "remoteAddr", r.RemoteAddr)
 		WriteS3Error(w, r, http.StatusInternalServerError, "InternalError",


### PR DESCRIPTION
## Summary

`resolveManagedPolicies` built its KV lookup key by pasting the bare policy name from an attached ARN onto the caller's own account, so a foreign-account or AWS-managed ARN silently aliased onto whatever same-account policy happened to share that name. It also skipped an unparseable ARN with a warning, which fails open when the skipped policy carries a `Deny`.

Depends on mulgadc/bluebottle#7 — needs the bluebottle `go.mod` pin bumped to the merge commit before CI is green here.

## Changes

`resolveManagedPolicies` now:

- skips AWS-managed ARNs (`arn:aws:iam::aws:policy/...`) explicitly, resolving them to no grant and no error. They have no backing document in this stack, which matches spinifex's fail-closed deny for an unmodeled managed policy; none of the policies in spinifex's builtin registry grant S3, so no grant is lost.
- parses every other ARN with `iamarn.ParsePolicyARN` and fails the request on a parse error.
- fails the request when the ARN's account is not the account being looked up.

Two deliberate behaviour changes: a malformed ARN and a foreign-account ARN now fail the whole resolution instead of being skipped or substituted. An unparseable entry in a principal's attachment list is a data-integrity fault, not a routine condition, and the function already fails the whole resolution on a KV miss.

## Testing

`TestLookupSession_AssumedRoleSkipsUnparseablePolicyARN` is replaced — the skip it asserted is the fail-open being closed. Six cases take its place: foreign-account (the regression test), AWS-managed, `:policy-backup/` near miss, malformed, Deny-not-dropped, and a path-bearing happy path. `make preflight` passes.

Part of mulga-8l8b4.