### PR TITLE
fix: decode and authenticate aws-chunked upload bodies

### DIFF
--- a/internal/gate/chunked/bench_test.go
+++ b/internal/gate/chunked/bench_test.go
@@ -1,0 +1,92 @@
+package chunked
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+// benchChunkSize is what a client frames with. aws-cli and the SDKs pick 64 KiB
+// unless the object forces a larger part, so the per-chunk costs — a header
+// parse, a hash finalise and an HMAC — are paid roughly this often.
+const benchChunkSize = 64 << 10
+
+// buildBenchBody frames payload in benchChunkSize chunks, with signatures when
+// signed. Building the body outside the timer keeps the client's own signing
+// out of a measurement of the server's verification.
+func buildBenchBody(payload []byte, signed bool) string {
+	var buf strings.Builder
+	prev := testSeed
+
+	write := func(chunk []byte) {
+		if !signed {
+			fmt.Fprintf(&buf, "%x\r\n%s\r\n", len(chunk), chunk)
+			return
+		}
+		sum := sha256.Sum256(chunk)
+		sts := strings.Join([]string{
+			chunkSTSPrefix, testTimestamp, testScope, prev,
+			emptySHA256, hex.EncodeToString(sum[:]),
+		}, "\n")
+		prev = hex.EncodeToString(hmacSHA256(testKey, sts))
+		fmt.Fprintf(&buf, "%x;chunk-signature=%s\r\n%s\r\n", len(chunk), prev, chunk)
+	}
+
+	for off := 0; off < len(payload); off += benchChunkSize {
+		end := min(off+benchChunkSize, len(payload))
+		write(payload[off:end])
+	}
+	write(nil)
+
+	// The terminating chunk's own framing differs: no data, no trailing CRLF.
+	body := buf.String()
+	return strings.TrimSuffix(body, "\r\n") + "\r\n"
+}
+
+// BenchmarkDecoder measures what verifying a framed body costs. unsigned is
+// STREAMING-UNSIGNED-PAYLOAD-TRAILER, which is what the default aws-cli path
+// sends; signed adds the chunk signature chain, so the difference between them
+// is the price of authenticating a body that was previously trusted.
+func BenchmarkDecoder(b *testing.B) {
+	for _, size := range []struct {
+		name string
+		n    int
+	}{
+		{"1MiB", 1 << 20},
+		{"8MiB", 8 << 20},
+	} {
+		payload := make([]byte, size.n)
+		for i := range payload {
+			payload[i] = byte(i)
+		}
+
+		for _, mode := range []struct {
+			name   string
+			signed bool
+		}{
+			{"unsigned", false},
+			{"signed", true},
+		} {
+			body := buildBenchBody(payload, mode.signed)
+
+			b.Run(size.name+"/"+mode.name, func(b *testing.B) {
+				b.SetBytes(int64(size.n))
+				b.ReportAllocs()
+
+				for b.Loop() {
+					var opts []Option
+					if mode.signed {
+						opts = append(opts, WithChain(newTestChain()))
+					}
+					dec := NewDecoder(strings.NewReader(body), int64(size.n), opts...)
+					if _, err := io.Copy(io.Discard, dec); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/internal/gate/chunked/chunked.go
+++ b/internal/gate/chunked/chunked.go
@@ -2,6 +2,7 @@ package chunked
 
 import (
 	"bufio"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
 	"errors"
@@ -32,17 +33,40 @@ type Decoder struct {
 	decodedRemainingHint int64 // optional sanity check, may be 0
 	digest               hash.Hash64
 	trailers             map[string]string
+
+	// Chain verification. chain is nil unless the client signed its chunks. The
+	// signature arrives in the header that precedes the data, so a chunk can
+	// only be checked once all of it has been read: it is hashed as it streams
+	// and compared at the chunk boundary, which keeps the client's chunk size
+	// out of our memory.
+	chain     *Chain
+	chunkSig  string
+	chunkHash hash.Hash
+	rawTrail  []byte
+}
+
+// Option configures a Decoder.
+type Option func(*Decoder)
+
+// WithChain verifies each chunk against the signature chain seeded from the
+// request signature, and rejects a body whose chunks do not continue it.
+func WithChain(c *Chain) Option {
+	return func(d *Decoder) { d.chain = c }
 }
 
 // NewDecoder wraps src and returns a streaming decoder.
 // decodedLenHint can be 0 if you don't care, or x-amz-decoded-content-length if present.
-func NewDecoder(src io.Reader, decodedLenHint int64) *Decoder {
-	return &Decoder{
+func NewDecoder(src io.Reader, decodedLenHint int64, opts ...Option) *Decoder {
+	d := &Decoder{
 		r:                    bufio.NewReader(src),
 		decodedRemainingHint: decodedLenHint,
 		digest:               crc64nvme.New(),
 		trailers:             make(map[string]string),
 	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
 }
 
 // Read implements io.Reader, returning only the decoded payload bytes.
@@ -82,6 +106,9 @@ func (d *Decoder) Read(p []byte) (int, error) {
 	if n > 0 {
 		d.curChunkRemaining -= int64(n)
 		_, _ = d.digest.Write(p[:n]) // checksum update cannot fail
+		if d.chunkHash != nil {
+			_, _ = d.chunkHash.Write(p[:n])
+		}
 
 		if d.decodedRemainingHint > 0 {
 			d.decodedRemainingHint -= int64(n)
@@ -90,6 +117,14 @@ func (d *Decoder) Read(p []byte) (int, error) {
 		if d.curChunkRemaining == 0 {
 			// Next Read must consume CRLF after this chunk's data.
 			d.expectChunkDataCRLF = true
+
+			// The chunk is complete, so its signature can finally be checked.
+			// The bytes have already been handed to the caller: the write path
+			// records no placement until the body is finished, so a chunk that
+			// fails here leaves shards nothing refers to rather than an object.
+			if err := d.verifyChunk(); err != nil {
+				return n, err
+			}
 		}
 	}
 
@@ -152,27 +187,44 @@ func VerifyCRC64NVME(base64Checksum string, crc uint64) error {
 func (d *Decoder) readNextChunkHeader() error {
 	line, err := d.r.ReadString('\n')
 	if err != nil {
-		return fmt.Errorf("failed to read chunk header: %w", err)
+		return fmt.Errorf("%w: failed to read chunk header: %w", ErrMalformedFraming, err)
 	}
 	// tolerate either "\r\n" or "\n" endings
 	line = strings.TrimRight(line, "\r\n")
 	if line == "" {
-		return fmt.Errorf("empty chunk header")
+		return fmt.Errorf("%w: empty chunk header", ErrMalformedFraming)
 	}
 
-	// strip any chunk extensions after ';'
+	// The extensions carry chunk-signature, which is the whole of what binds a
+	// signed body to its principal, so they are parsed rather than skipped.
+	ext := ""
 	if idx := strings.IndexByte(line, ';'); idx >= 0 {
-		line = line[:idx]
+		ext, line = line[idx+1:], line[:idx]
 	}
 	sizeStr := strings.TrimSpace(line)
 	size, err := strconv.ParseInt(sizeStr, 16, 64)
 	if err != nil {
-		return fmt.Errorf("invalid chunk size %q: %w", sizeStr, err)
+		return fmt.Errorf("%w: invalid chunk size %q: %w", ErrMalformedFraming, sizeStr, err)
+	}
+
+	if d.chain != nil {
+		d.chunkSig = chunkSignature(ext)
+		if d.chunkSig == "" {
+			return fmt.Errorf("%w: chunk carries no chunk-signature", ErrChunkSignature)
+		}
+		d.chunkHash = sha256.New()
 	}
 
 	if size == 0 {
-		// Final chunk: read trailers, then final empty line.
+		// The terminating chunk signs no data, so it closes the chain against
+		// an empty payload before the trailers are read.
+		if err := d.verifyChunk(); err != nil {
+			return err
+		}
 		if err := d.readTrailers(); err != nil {
+			return err
+		}
+		if err := d.verifyTrailer(); err != nil {
 			return err
 		}
 		d.done = true
@@ -183,12 +235,59 @@ func (d *Decoder) readNextChunkHeader() error {
 	return nil
 }
 
+// verifyChunk closes out the current chunk against the chain. It is a no-op on
+// an unsigned body, which is the STREAMING-UNSIGNED-PAYLOAD-TRAILER case and a
+// deliberate client opt-out rather than an omission.
+func (d *Decoder) verifyChunk() error {
+	if d.chain == nil {
+		return nil
+	}
+	sum := sha256Sum(nil)
+	if d.chunkHash != nil {
+		sum = d.chunkHash.Sum(nil)
+	}
+	if err := d.chain.VerifyChunk(d.chunkSig, sum); err != nil {
+		return err
+	}
+	d.chunkHash, d.chunkSig = nil, ""
+	return nil
+}
+
+// verifyTrailer checks the trailing header block against the chain. A signed
+// body without a trailer never reaches this with a signature to check, so an
+// absent trailer signature is only an error when trailers were actually sent.
+func (d *Decoder) verifyTrailer() error {
+	if d.chain == nil {
+		return nil
+	}
+	sig, ok := d.trailers["x-amz-trailer-signature"]
+	if !ok {
+		if len(d.rawTrail) == 0 {
+			return nil
+		}
+		return fmt.Errorf("%w: trailers carry no x-amz-trailer-signature", ErrChunkSignature)
+	}
+	return d.chain.VerifyTrailer(sig, sha256Sum(d.rawTrail))
+}
+
+// chunkSignature pulls chunk-signature out of a chunk extension list, which is
+// ";name=value" repeated and is not required to hold anything else.
+func chunkSignature(ext string) string {
+	for part := range strings.SplitSeq(ext, ";") {
+		name, value, found := strings.Cut(part, "=")
+		if found && strings.EqualFold(strings.TrimSpace(name), "chunk-signature") {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
 // readTrailers reads lines until an empty line, populating d.trailers.
 func (d *Decoder) readTrailers() error {
 	for {
 		line, err := d.r.ReadString('\n')
 		if err != nil {
-			return fmt.Errorf("failed to read trailer line: %w", err)
+			return fmt.Errorf("%w: failed to read trailer line: %w", ErrMalformedFraming, err)
 		}
 		if line == "\r\n" || line == "\n" {
 			// end of trailers
@@ -206,6 +305,12 @@ func (d *Decoder) readTrailers() error {
 		name := strings.ToLower(strings.TrimSpace(line[:colon]))
 		val := strings.TrimSpace(line[colon+1:])
 		d.trailers[name] = val
+
+		// The trailer signature covers the trailing headers but not itself, and
+		// signs them one per line as "name:value\n".
+		if name != "x-amz-trailer-signature" {
+			d.rawTrail = append(d.rawTrail, (name + ":" + val + "\n")...)
+		}
 	}
 	return nil
 }
@@ -213,15 +318,15 @@ func (d *Decoder) readTrailers() error {
 func (d *Decoder) consumeCRLF() error {
 	b1, err := d.r.ReadByte()
 	if err != nil {
-		return fmt.Errorf("failed to read CR after chunk data: %w", err)
+		return fmt.Errorf("%w: failed to read CR after chunk data: %w", ErrMalformedFraming, err)
 	}
 	b2, err := d.r.ReadByte()
 	if err != nil {
-		return fmt.Errorf("failed to read LF after chunk data: %w", err)
+		return fmt.Errorf("%w: failed to read LF after chunk data: %w", ErrMalformedFraming, err)
 	}
 	// be tolerant: accept "\n\n" or "\r\n" etc, but ideally we see "\r\n"
 	if b2 != '\n' {
-		return fmt.Errorf("invalid chunk terminator, want \\r\\n, got %q%q", b1, b2)
+		return fmt.Errorf("%w: invalid chunk terminator, want \\r\\n, got %q%q", ErrMalformedFraming, b1, b2)
 	}
 	return nil
 }

--- a/internal/gate/chunked/chunked.go
+++ b/internal/gate/chunked/chunked.go
@@ -2,12 +2,18 @@ package chunked
 
 import (
 	"bufio"
+	"bytes"
+	// SHA-1 is one of the checksum algorithms S3 lets a client pick for
+	// x-amz-checksum-sha1. It verifies an integrity value the client chose and
+	// guards nothing, so its collision weakness is not in play here.
+	"crypto/sha1" //nolint:gosec // client-selected integrity checksum, not a security primitive
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"hash"
+	"hash/crc32"
 	"io"
 	"strconv"
 	"strings"
@@ -26,13 +32,24 @@ import (
 //
 // It implements io.Reader and streams out ONLY the real object bytes.
 type Decoder struct {
-	r                    *bufio.Reader
-	curChunkRemaining    int64
-	expectChunkDataCRLF  bool
-	done                 bool
-	decodedRemainingHint int64 // optional sanity check, may be 0
-	digest               hash.Hash64
-	trailers             map[string]string
+	r                   *bufio.Reader
+	curChunkRemaining   int64
+	expectChunkDataCRLF bool
+	done                bool
+	digest              hash.Hash64
+	trailers            map[string]string
+
+	// declaredLen is x-amz-decoded-content-length when a caller vouched for it,
+	// and -1 otherwise. decoded counts what came out. The write path sizes
+	// itself from the declared length, so a body that disagrees with it would
+	// otherwise be stored truncated with its checksum still verifying.
+	declaredLen int64
+	decoded     int64
+
+	// sums holds a running hash per checksum trailer the client promised in
+	// X-Amz-Trailer. The promise arrives before the body and the value after
+	// it, so the hash has to be chosen up front.
+	sums map[string]hash.Hash
 
 	// Chain verification. chain is nil unless the client signed its chunks. The
 	// signature arrives in the header that precedes the data, so a chunk can
@@ -54,14 +71,36 @@ func WithChain(c *Chain) Option {
 	return func(d *Decoder) { d.chain = c }
 }
 
+// WithDeclaredLength requires the decoded body to be exactly n bytes, which is
+// what x-amz-decoded-content-length promised and what the write path sized
+// itself from. A body that disagrees is rejected rather than truncated to fit.
+func WithDeclaredLength(n int64) Option {
+	return func(d *Decoder) { d.declaredLen = n }
+}
+
+// WithTrailerChecksums prepares to verify the checksum trailers the client
+// named in X-Amz-Trailer. An algorithm not named here cannot be checked when it
+// arrives, because hashing it had to start before the body was read.
+func WithTrailerChecksums(names []string) Option {
+	return func(d *Decoder) {
+		for _, name := range names {
+			name = strings.ToLower(strings.TrimSpace(name))
+			if newHash, ok := checksumAlgos[name]; ok {
+				d.sums[name] = newHash()
+			}
+		}
+	}
+}
+
 // NewDecoder wraps src and returns a streaming decoder.
 // decodedLenHint can be 0 if you don't care, or x-amz-decoded-content-length if present.
 func NewDecoder(src io.Reader, decodedLenHint int64, opts ...Option) *Decoder {
 	d := &Decoder{
-		r:                    bufio.NewReader(src),
-		decodedRemainingHint: decodedLenHint,
-		digest:               crc64nvme.New(),
-		trailers:             make(map[string]string),
+		r:           bufio.NewReader(src),
+		digest:      crc64nvme.New(),
+		trailers:    make(map[string]string),
+		declaredLen: -1,
+		sums:        make(map[string]hash.Hash),
 	}
 	for _, opt := range opts {
 		opt(d)
@@ -86,7 +125,10 @@ func (d *Decoder) Read(p []byte) (int, error) {
 	// Ensure we have an active chunk.
 	if d.curChunkRemaining == 0 {
 		if err := d.readNextChunkHeader(); err != nil {
-			if errors.Is(err, io.EOF) {
+			// Only the terminating chunk ends a body, and it sets done before
+			// reporting EOF. An EOF from anywhere else is a truncated stream:
+			// calling that a clean end skips every trailing check.
+			if errors.Is(err, io.EOF) && d.done {
 				return 0, io.EOF
 			}
 			return 0, err
@@ -105,13 +147,20 @@ func (d *Decoder) Read(p []byte) (int, error) {
 	n, err := d.r.Read(p)
 	if n > 0 {
 		d.curChunkRemaining -= int64(n)
+		d.decoded += int64(n)
 		_, _ = d.digest.Write(p[:n]) // checksum update cannot fail
 		if d.chunkHash != nil {
 			_, _ = d.chunkHash.Write(p[:n])
 		}
+		for _, h := range d.sums {
+			_, _ = h.Write(p[:n])
+		}
 
-		if d.decodedRemainingHint > 0 {
-			d.decodedRemainingHint -= int64(n)
+		// Caught here as well as at the terminating chunk, so an overlong body
+		// stops at the declared length instead of streaming on.
+		if d.declaredLen >= 0 && d.decoded > d.declaredLen {
+			return n, fmt.Errorf("%w: body exceeds the declared %d bytes",
+				ErrMalformedFraming, d.declaredLen)
 		}
 
 		if d.curChunkRemaining == 0 {
@@ -129,6 +178,12 @@ func (d *Decoder) Read(p []byte) (int, error) {
 	}
 
 	if err != nil {
+		// A chunk that ends before the length its header declared is truncated,
+		// not finished, whatever the transport says.
+		if errors.Is(err, io.EOF) && d.curChunkRemaining > 0 {
+			return n, fmt.Errorf("%w: chunk ended %d bytes early",
+				ErrMalformedFraming, d.curChunkRemaining)
+		}
 		return n, err
 	}
 
@@ -138,6 +193,16 @@ func (d *Decoder) Read(p []byte) (int, error) {
 // CRC64 returns the computed CRC64NVME checksum of the decoded payload.
 func (d *Decoder) CRC64() uint64 {
 	return d.digest.Sum64()
+}
+
+// checksumAlgos are the x-amz-checksum-* trailers S3 defines, each keyed by the
+// trailer name a client sends and mapped to the hash that verifies it.
+var checksumAlgos = map[string]func() hash.Hash{
+	"x-amz-checksum-crc32":     func() hash.Hash { return crc32.NewIEEE() },
+	"x-amz-checksum-crc32c":    func() hash.Hash { return crc32.New(crc32.MakeTable(crc32.Castagnoli)) },
+	"x-amz-checksum-crc64nvme": func() hash.Hash { return crc64nvme.New() },
+	"x-amz-checksum-sha1":      sha1.New,
+	"x-amz-checksum-sha256":    sha256.New,
 }
 
 // TrailerChecksum returns the x-amz-checksum-crc64nvme trailer value if present.
@@ -155,14 +220,43 @@ func (d *Decoder) TrailerChecksum() (string, bool) {
 	return "", false
 }
 
-// VerifyTrailerChecksum validates the trailer checksum (if present)
-// against the streamed CRC64NVME value.
-func (d *Decoder) VerifyTrailerChecksum() error {
-	trailer, ok := d.TrailerChecksum()
-	if !ok {
-		return fmt.Errorf("missing x-amz-checksum-crc64nvme trailer")
+// ChecksumTrailer returns the checksum trailer the body carried, if any.
+func (d *Decoder) ChecksumTrailer() (name, value string, ok bool) {
+	for k, v := range d.trailers {
+		if strings.HasPrefix(k, "x-amz-checksum-") {
+			return k, v, true
+		}
 	}
-	return VerifyCRC64NVME(trailer, d.CRC64())
+	return "", "", false
+}
+
+// VerifyTrailerChecksum checks the body against the checksum trailer it
+// carried. A trailer naming an algorithm the client did not declare cannot be
+// verified after the fact, so it is an error rather than a pass.
+func (d *Decoder) VerifyTrailerChecksum() error {
+	name, value, ok := d.ChecksumTrailer()
+	if !ok {
+		return fmt.Errorf("%w: body carries no checksum trailer", ErrChecksumMissing)
+	}
+
+	// crc64nvme is always running, so it verifies whether or not the client
+	// bothered to declare it in X-Amz-Trailer.
+	if name == "x-amz-checksum-crc64nvme" {
+		return VerifyCRC64NVME(value, d.CRC64())
+	}
+
+	h, ok := d.sums[name]
+	if !ok {
+		return fmt.Errorf("%w: %s was not declared in X-Amz-Trailer", ErrChecksumUndeclared, name)
+	}
+	want, err := base64.StdEncoding.DecodeString(strings.TrimSpace(value))
+	if err != nil {
+		return fmt.Errorf("%w: %s is not base64", ErrChecksumMismatch, name)
+	}
+	if got := h.Sum(nil); !bytes.Equal(want, got) {
+		return fmt.Errorf("%w: %s expected %x, got %x", ErrChecksumMismatch, name, want, got)
+	}
+	return nil
 }
 
 // VerifyCRC64NVME is a helper for validating a base64-encoded CRC64NVME
@@ -216,6 +310,12 @@ func (d *Decoder) readNextChunkHeader() error {
 	}
 
 	if size == 0 {
+		// A short body reaches its terminator legitimately, so the declared
+		// length can only be settled here.
+		if d.declaredLen >= 0 && d.decoded != d.declaredLen {
+			return fmt.Errorf("%w: body is %d bytes, declared %d",
+				ErrMalformedFraming, d.decoded, d.declaredLen)
+		}
 		// The terminating chunk signs no data, so it closes the chain against
 		// an empty payload before the trailers are read.
 		if err := d.verifyChunk(); err != nil {

--- a/internal/gate/chunked/chunked.go
+++ b/internal/gate/chunked/chunked.go
@@ -15,6 +15,8 @@ import (
 	"hash"
 	"hash/crc32"
 	"io"
+	"slices"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -47,9 +49,11 @@ type Decoder struct {
 	decoded     int64
 
 	// sums holds a running hash per checksum trailer the client promised in
-	// X-Amz-Trailer. The promise arrives before the body and the value after
-	// it, so the hash has to be chosen up front.
-	sums map[string]hash.Hash
+	// X-Amz-Trailer, and promised is that declaration itself. The promise
+	// arrives before the body and the value after it, so the hash has to be
+	// chosen up front and the two sets reconciled at the end.
+	sums     map[string]hash.Hash
+	promised []string
 
 	// Chain verification. chain is nil unless the client signed its chunks. The
 	// signature arrives in the header that precedes the data, so a chunk can
@@ -81,14 +85,23 @@ func WithDeclaredLength(n int64) Option {
 // WithTrailerChecksums prepares to verify the checksum trailers the client
 // named in X-Amz-Trailer. An algorithm not named here cannot be checked when it
 // arrives, because hashing it had to start before the body was read.
+//
+// A name with no hash behind it is still recorded as promised, so an algorithm
+// predastore cannot compute is rejected rather than quietly forgotten.
 func WithTrailerChecksums(names []string) Option {
 	return func(d *Decoder) {
 		for _, name := range names {
 			name = strings.ToLower(strings.TrimSpace(name))
+			if !strings.HasPrefix(name, checksumPrefix) {
+				continue
+			}
+			d.promised = append(d.promised, name)
 			if newHash, ok := checksumAlgos[name]; ok {
 				d.sums[name] = newHash()
 			}
 		}
+		sort.Strings(d.promised)
+		d.promised = slices.Compact(d.promised)
 	}
 }
 
@@ -195,6 +208,11 @@ func (d *Decoder) CRC64() uint64 {
 	return d.digest.Sum64()
 }
 
+const (
+	checksumPrefix    = "x-amz-checksum-"
+	checksumCRC64NVME = "x-amz-checksum-crc64nvme"
+)
+
 // checksumAlgos are the x-amz-checksum-* trailers S3 defines, each keyed by the
 // trailer name a client sends and mapped to the hash that verifies it.
 var checksumAlgos = map[string]func() hash.Hash{
@@ -220,34 +238,81 @@ func (d *Decoder) TrailerChecksum() (string, bool) {
 	return "", false
 }
 
-// ChecksumTrailer returns the checksum trailer the body carried, if any.
-func (d *Decoder) ChecksumTrailer() (name, value string, ok bool) {
-	for k, v := range d.trailers {
-		if strings.HasPrefix(k, "x-amz-checksum-") {
-			return k, v, true
+// checksumTrailers returns every x-amz-checksum-* trailer the body carried, in
+// name order. Sorted because ranging a map is randomised, and a body carrying
+// two checksums must not verify whichever one the iteration happened to pick.
+func (d *Decoder) checksumTrailers() []string {
+	var names []string
+	for k := range d.trailers {
+		if strings.HasPrefix(k, checksumPrefix) {
+			names = append(names, k)
 		}
 	}
-	return "", "", false
+	sort.Strings(names)
+	return names
 }
 
-// VerifyTrailerChecksum checks the body against the checksum trailer it
-// carried. A trailer naming an algorithm the client did not declare cannot be
-// verified after the fact, so it is an error rather than a pass.
+// ChecksumTrailer reports whether the body carried any checksum trailer.
+func (d *Decoder) ChecksumTrailer() (name, value string, ok bool) {
+	names := d.checksumTrailers()
+	if len(names) == 0 {
+		return "", "", false
+	}
+	return names[0], d.trailers[names[0]], true
+}
+
+// PromisesChecksum reports whether X-Amz-Trailer named a checksum. The promise
+// is the client's, not the signature's, so it binds an unauthenticated write
+// exactly as it binds a signed one.
+func (d *Decoder) PromisesChecksum() bool {
+	return len(d.promised) > 0
+}
+
+// VerifyTrailerChecksum checks the body against every checksum trailer it
+// carried, and against what X-Amz-Trailer said those would be.
+//
+// The declared set is enforced in both directions. A trailer that was not
+// declared cannot be verified, because hashing had to start before the body was
+// read; a declared one that never arrives is a promise the client broke.
 func (d *Decoder) VerifyTrailerChecksum() error {
-	name, value, ok := d.ChecksumTrailer()
-	if !ok {
+	sent := d.checksumTrailers()
+	if len(sent) == 0 {
 		return fmt.Errorf("%w: body carries no checksum trailer", ErrChecksumMissing)
 	}
 
-	// crc64nvme is always running, so it verifies whether or not the client
-	// bothered to declare it in X-Amz-Trailer.
-	if name == "x-amz-checksum-crc64nvme" {
+	if len(d.promised) > 0 {
+		for _, name := range d.promised {
+			if _, ok := d.trailers[name]; !ok {
+				return fmt.Errorf("%w: %s was declared but not sent", ErrChecksumMissing, name)
+			}
+		}
+		for _, name := range sent {
+			if !slices.Contains(d.promised, name) {
+				return fmt.Errorf("%w: %s was sent but not declared in X-Amz-Trailer",
+					ErrChecksumUndeclared, name)
+			}
+		}
+	}
+
+	for _, name := range sent {
+		if err := d.verifyOneChecksum(name, d.trailers[name]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// verifyOneChecksum compares one trailer against the hash that was running for
+// it. crc64nvme is always running, so it is checked whether or not the client
+// declared it; anything else had to be declared to have been hashed at all.
+func (d *Decoder) verifyOneChecksum(name, value string) error {
+	if name == checksumCRC64NVME {
 		return VerifyCRC64NVME(value, d.CRC64())
 	}
 
 	h, ok := d.sums[name]
 	if !ok {
-		return fmt.Errorf("%w: %s was not declared in X-Amz-Trailer", ErrChecksumUndeclared, name)
+		return fmt.Errorf("%w: %s cannot be verified", ErrChecksumUndeclared, name)
 	}
 	want, err := base64.StdEncoding.DecodeString(strings.TrimSpace(value))
 	if err != nil {
@@ -295,8 +360,11 @@ func (d *Decoder) readNextChunkHeader() error {
 	if idx := strings.IndexByte(line, ';'); idx >= 0 {
 		ext, line = line[idx+1:], line[:idx]
 	}
+	// Unsigned, so a leading '-' is rejected by the parse rather than becoming a
+	// negative length that later slices a buffer out of range. 63 bits keeps the
+	// result representable as the int64 the rest of the decoder counts in.
 	sizeStr := strings.TrimSpace(line)
-	size, err := strconv.ParseInt(sizeStr, 16, 64)
+	size, err := strconv.ParseUint(sizeStr, 16, 63)
 	if err != nil {
 		return fmt.Errorf("%w: invalid chunk size %q: %w", ErrMalformedFraming, sizeStr, err)
 	}
@@ -331,7 +399,7 @@ func (d *Decoder) readNextChunkHeader() error {
 		return io.EOF
 	}
 
-	d.curChunkRemaining = size
+	d.curChunkRemaining = int64(size)
 	return nil
 }
 

--- a/internal/gate/chunked/chunked_test.go
+++ b/internal/gate/chunked/chunked_test.go
@@ -173,9 +173,7 @@ func TestDecoder_VerifyTrailerChecksum_Missing(t *testing.T) {
 	_, err := io.ReadAll(dec)
 	require.NoError(t, err)
 
-	err = dec.VerifyTrailerChecksum()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "missing x-amz-checksum-crc64nvme trailer")
+	assert.ErrorIs(t, dec.VerifyTrailerChecksum(), ErrChecksumMissing)
 }
 
 func TestDecoder_VerifyTrailerChecksum_Valid(t *testing.T) {

--- a/internal/gate/chunked/signature.go
+++ b/internal/gate/chunked/signature.go
@@ -19,6 +19,20 @@ var ErrChunkSignature = errors.New("chunk signature does not match")
 // answers to the client: one is malformed, the other is unauthenticated.
 var ErrMalformedFraming = errors.New("malformed aws-chunked framing")
 
+// ErrChecksumMissing is returned when a body promised a trailing checksum and
+// did not send one. The mode names the trailer, so its absence is malformed
+// rather than a client declining to checksum.
+var ErrChecksumMissing = errors.New("promised checksum trailer is absent")
+
+// ErrChecksumUndeclared is returned for a checksum trailer the client never
+// named in X-Amz-Trailer. Hashing has to begin before the body is read, so
+// there is nothing to compare it against.
+var ErrChecksumUndeclared = errors.New("checksum trailer was not declared")
+
+// ErrChecksumMismatch is returned when a body does not match the checksum it
+// carried.
+var ErrChecksumMismatch = errors.New("checksum does not match")
+
 // The string-to-sign prefixes AWS defines for the two links in the chain: one
 // per data chunk, and one for the trailing header block.
 const (

--- a/internal/gate/chunked/signature.go
+++ b/internal/gate/chunked/signature.go
@@ -1,0 +1,105 @@
+package chunked
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrChunkSignature is returned when a chunk's signature does not continue the
+// chain seeded by the request signature, which means the bytes in that chunk
+// are not the bytes the client signed.
+var ErrChunkSignature = errors.New("chunk signature does not match")
+
+// ErrMalformedFraming is returned when an aws-chunked body's framing does not
+// parse. It is separate from a signature failure because the two are different
+// answers to the client: one is malformed, the other is unauthenticated.
+var ErrMalformedFraming = errors.New("malformed aws-chunked framing")
+
+// The string-to-sign prefixes AWS defines for the two links in the chain: one
+// per data chunk, and one for the trailing header block.
+const (
+	chunkSTSPrefix   = "AWS4-HMAC-SHA256-PAYLOAD"
+	trailerSTSPrefix = "AWS4-HMAC-SHA256-TRAILER"
+)
+
+// emptySHA256 is the hex SHA-256 of no bytes, which every chunk's string-to-sign
+// carries in place of the canonical-request hash a normal signature would use.
+var emptySHA256 = hex.EncodeToString(sha256Sum(nil))
+
+// Chain verifies the per-chunk signature chain of an aws-chunked body. A client
+// signing STREAMING-AWS4-HMAC-SHA256-PAYLOAD covers its body with a chain of
+// HMACs seeded from the request signature, and that chain is the only thing
+// binding the body to the principal: the payload hash the request signed is a
+// sentinel rather than a digest.
+type Chain struct {
+	key       []byte
+	scope     string
+	timestamp string
+	prev      string
+}
+
+// NewChain seeds a chain from a verified request. signingKey is the request's
+// dated SigV4 signing key, seed its signature, scope the credential scope
+// "<date>/<region>/<service>/aws4_request", and timestamp its x-amz-date.
+func NewChain(signingKey []byte, seed, scope, timestamp string) *Chain {
+	return &Chain{key: signingKey, scope: scope, timestamp: timestamp, prev: seed}
+}
+
+// VerifyChunk checks one data chunk against the chain and advances it.
+// payloadSHA256 is the SHA-256 of the chunk's decoded bytes, taken as a digest
+// rather than the bytes so a caller can hash a chunk as it streams instead of
+// holding a client-sized buffer.
+func (c *Chain) VerifyChunk(signature string, payloadSHA256 []byte) error {
+	return c.verify(signature, strings.Join([]string{
+		chunkSTSPrefix,
+		c.timestamp,
+		c.scope,
+		c.prev,
+		emptySHA256,
+		hex.EncodeToString(payloadSHA256),
+	}, "\n"))
+}
+
+// VerifyTrailer checks the trailing header block, which is signed without the
+// empty-payload line that a data chunk carries.
+func (c *Chain) VerifyTrailer(signature string, trailerSHA256 []byte) error {
+	return c.verify(signature, strings.Join([]string{
+		trailerSTSPrefix,
+		c.timestamp,
+		c.scope,
+		c.prev,
+		hex.EncodeToString(trailerSHA256),
+	}, "\n"))
+}
+
+// verify compares a supplied signature against the one this link should carry
+// and, on a match, makes it the seed for the next link.
+func (c *Chain) verify(signature, stringToSign string) error {
+	want := hmacSHA256(c.key, stringToSign)
+	got, err := hex.DecodeString(strings.TrimSpace(signature))
+	if err != nil {
+		return fmt.Errorf("%w: signature is not hex", ErrChunkSignature)
+	}
+	// hmac.Equal rather than ==: the comparison is on attacker-supplied input,
+	// and a byte-at-a-time exit leaks how much of a guess was right.
+	if !hmac.Equal(want, got) {
+		return ErrChunkSignature
+	}
+	c.prev = hex.EncodeToString(want)
+	return nil
+}
+
+func hmacSHA256(key []byte, data string) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(data))
+	return h.Sum(nil)
+}
+
+func sha256Sum(b []byte) []byte {
+	sum := sha256.Sum256(b)
+	return sum[:]
+}

--- a/internal/gate/chunked/signature_test.go
+++ b/internal/gate/chunked/signature_test.go
@@ -1,0 +1,235 @@
+package chunked
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testSeed      = "4f232c4386841ef735655705268965c44a0e4690baa4adea153f7db9fa80a0a9"
+	testScope     = "20130524/us-east-1/s3/aws4_request"
+	testTimestamp = "20130524T000000Z"
+)
+
+var testKey = []byte("dated-signing-key")
+
+// signChunk produces the signature a client would put in a chunk extension,
+// advancing prev the way the client's own chain does.
+func signChunk(prev string, payload []byte) (sig, next string) {
+	sum := sha256.Sum256(payload)
+	sts := strings.Join([]string{
+		chunkSTSPrefix, testTimestamp, testScope, prev,
+		emptySHA256, hex.EncodeToString(sum[:]),
+	}, "\n")
+	mac := hmacSHA256(testKey, sts)
+	return hex.EncodeToString(mac), hex.EncodeToString(mac)
+}
+
+// signTrailer produces the x-amz-trailer-signature over the trailing header
+// block, which is signed without the empty-payload line a data chunk carries.
+func signTrailer(prev string, rawTrailers string) string {
+	sum := sha256.Sum256([]byte(rawTrailers))
+	sts := strings.Join([]string{
+		trailerSTSPrefix, testTimestamp, testScope, prev, hex.EncodeToString(sum[:]),
+	}, "\n")
+	return hex.EncodeToString(hmacSHA256(testKey, sts))
+}
+
+// buildSignedBody frames chunks with a chunk-signature extension on each, and
+// closes the chain over the terminating chunk and any trailers.
+func buildSignedBody(chunks []string, trailers []string) string {
+	var buf strings.Builder
+	prev := testSeed
+	for _, chunk := range chunks {
+		var sig string
+		sig, prev = signChunk(prev, []byte(chunk))
+		fmt.Fprintf(&buf, "%x;chunk-signature=%s\r\n%s\r\n", len(chunk), sig, chunk)
+	}
+
+	var sig string
+	sig, prev = signChunk(prev, nil)
+	fmt.Fprintf(&buf, "0;chunk-signature=%s\r\n", sig)
+
+	var raw strings.Builder
+	for _, t := range trailers {
+		name, val, _ := strings.Cut(t, ":")
+		fmt.Fprintf(&buf, "%s:%s\r\n", name, val)
+		fmt.Fprintf(&raw, "%s:%s\n", strings.ToLower(name), val)
+	}
+	if len(trailers) > 0 {
+		fmt.Fprintf(&buf, "x-amz-trailer-signature:%s\r\n", signTrailer(prev, raw.String()))
+	}
+	buf.WriteString("\r\n")
+	return buf.String()
+}
+
+func newTestChain() *Chain {
+	return NewChain(testKey, testSeed, testScope, testTimestamp)
+}
+
+func TestChainVerifyChunk(t *testing.T) {
+	t.Run("advances on a match", func(t *testing.T) {
+		c := newTestChain()
+
+		first, second := signChunk(testSeed, []byte("one"))
+		require.NoError(t, c.VerifyChunk(first, sha256Sum([]byte("one"))))
+		assert.Equal(t, second, c.prev, "a verified chunk seeds the next link")
+
+		next, _ := signChunk(second, []byte("two"))
+		assert.NoError(t, c.VerifyChunk(next, sha256Sum([]byte("two"))))
+	})
+
+	t.Run("rejects a chunk signed over other bytes", func(t *testing.T) {
+		c := newTestChain()
+
+		sig, _ := signChunk(testSeed, []byte("one"))
+		assert.ErrorIs(t, c.VerifyChunk(sig, sha256Sum([]byte("two"))), ErrChunkSignature)
+	})
+
+	t.Run("rejects a chunk out of order", func(t *testing.T) {
+		c := newTestChain()
+
+		// The signature for the second chunk, presented first: valid HMAC, wrong
+		// link, which is what makes the chain more than a per-chunk checksum.
+		_, second := signChunk(testSeed, []byte("one"))
+		sig, _ := signChunk(second, []byte("two"))
+		assert.ErrorIs(t, c.VerifyChunk(sig, sha256Sum([]byte("two"))), ErrChunkSignature)
+	})
+
+	t.Run("rejects a non-hex signature", func(t *testing.T) {
+		c := newTestChain()
+		assert.ErrorIs(t, c.VerifyChunk("not-hex", sha256Sum(nil)), ErrChunkSignature)
+	})
+
+	t.Run("leaves the chain unadvanced on failure", func(t *testing.T) {
+		c := newTestChain()
+
+		require.Error(t, c.VerifyChunk(strings.Repeat("00", 32), sha256Sum([]byte("one"))))
+		assert.Equal(t, testSeed, c.prev)
+	})
+}
+
+func TestChainVerifyTrailer(t *testing.T) {
+	raw := "x-amz-checksum-crc64nvme:AAAAAAAAAAA=\n"
+
+	t.Run("accepts the signed block", func(t *testing.T) {
+		c := newTestChain()
+		assert.NoError(t, c.VerifyTrailer(signTrailer(testSeed, raw), sha256Sum([]byte(raw))))
+	})
+
+	t.Run("rejects an altered block", func(t *testing.T) {
+		c := newTestChain()
+		sig := signTrailer(testSeed, raw)
+		altered := "x-amz-checksum-crc64nvme:BBBBBBBBBBB=\n"
+		assert.ErrorIs(t, c.VerifyTrailer(sig, sha256Sum([]byte(altered))), ErrChunkSignature)
+	})
+
+	t.Run("is not interchangeable with a chunk signature", func(t *testing.T) {
+		c := newTestChain()
+
+		// Same key, same link, different string-to-sign prefix: a chunk signature
+		// must not close the trailer block.
+		sig, _ := signChunk(testSeed, []byte(raw))
+		assert.ErrorIs(t, c.VerifyTrailer(sig, sha256Sum([]byte(raw))), ErrChunkSignature)
+	})
+}
+
+func TestDecoderVerifiesChain(t *testing.T) {
+	t.Run("decodes a signed body", func(t *testing.T) {
+		body := buildSignedBody([]string{"hello ", "world"}, nil)
+		dec := NewDecoder(strings.NewReader(body), 11, WithChain(newTestChain()))
+
+		got, err := io.ReadAll(dec)
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", string(got))
+	})
+
+	t.Run("decodes a signed body with trailers", func(t *testing.T) {
+		body := buildSignedBody([]string{"hello"}, []string{"x-amz-checksum-crc64nvme:AAAAAAAAAAA="})
+		dec := NewDecoder(strings.NewReader(body), 5, WithChain(newTestChain()))
+
+		got, err := io.ReadAll(dec)
+		require.NoError(t, err)
+		assert.Equal(t, "hello", string(got))
+
+		sum, ok := dec.TrailerChecksum()
+		require.True(t, ok)
+		assert.Equal(t, "AAAAAAAAAAA=", sum)
+	})
+
+	t.Run("rejects tampered chunk data", func(t *testing.T) {
+		body := buildSignedBody([]string{"hello"}, nil)
+		tampered := strings.Replace(body, "hello", "world", 1)
+		dec := NewDecoder(strings.NewReader(tampered), 5, WithChain(newTestChain()))
+
+		_, err := io.ReadAll(dec)
+		assert.ErrorIs(t, err, ErrChunkSignature)
+	})
+
+	t.Run("rejects a tampered trailer", func(t *testing.T) {
+		body := buildSignedBody([]string{"hello"}, []string{"x-amz-checksum-crc64nvme:AAAAAAAAAAA="})
+		tampered := strings.Replace(body, "AAAAAAAAAAA=", "BBBBBBBBBBB=", 1)
+		dec := NewDecoder(strings.NewReader(tampered), 5, WithChain(newTestChain()))
+
+		_, err := io.ReadAll(dec)
+		assert.ErrorIs(t, err, ErrChunkSignature)
+	})
+
+	t.Run("rejects a signed mode whose chunks carry no signature", func(t *testing.T) {
+		body := buildChunkedBody([]string{"hello"}, nil)
+		dec := NewDecoder(strings.NewReader(body), 5, WithChain(newTestChain()))
+
+		_, err := io.ReadAll(dec)
+		assert.ErrorIs(t, err, ErrChunkSignature)
+	})
+
+	t.Run("rejects trailers with no trailer signature", func(t *testing.T) {
+		body := buildSignedBody([]string{"hello"}, []string{"x-amz-checksum-crc64nvme:AAAAAAAAAAA="})
+		idx := strings.Index(body, "x-amz-trailer-signature:")
+		require.Positive(t, idx)
+		dec := NewDecoder(strings.NewReader(body[:idx]+"\r\n"), 5, WithChain(newTestChain()))
+
+		_, err := io.ReadAll(dec)
+		assert.ErrorIs(t, err, ErrChunkSignature)
+	})
+
+	t.Run("ignores chunk signatures with no chain", func(t *testing.T) {
+		// STREAMING-UNSIGNED-PAYLOAD-TRAILER frames the same way but signs
+		// nothing, so the extension is present and must not be checked.
+		body := buildSignedBody([]string{"hello"}, nil)
+		dec := NewDecoder(strings.NewReader(body), 5)
+
+		got, err := io.ReadAll(dec)
+		require.NoError(t, err)
+		assert.Equal(t, "hello", string(got))
+	})
+}
+
+// TestChainIsConstantTime documents why verify compares with hmac.Equal: the
+// signature is attacker-supplied and a byte-at-a-time exit leaks how much of a
+// guess was right.
+func TestChainRejectsNearMiss(t *testing.T) {
+	c := newTestChain()
+
+	sig, _ := signChunk(testSeed, []byte("one"))
+	near := sig[:len(sig)-1] + string(flipHexDigit(sig[len(sig)-1]))
+	require.NotEqual(t, sig, near)
+
+	assert.ErrorIs(t, c.VerifyChunk(near, sha256Sum([]byte("one"))), ErrChunkSignature)
+	assert.True(t, hmac.Equal(hmacSHA256(testKey, "x"), hmacSHA256(testKey, "x")))
+}
+
+func flipHexDigit(b byte) byte {
+	if b == '0' {
+		return '1'
+	}
+	return '0'
+}

--- a/internal/gate/chunked/signature_test.go
+++ b/internal/gate/chunked/signature_test.go
@@ -3,12 +3,16 @@ package chunked
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"strings"
 	"testing"
 
+	"github.com/minio/crc64nvme"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -232,4 +236,119 @@ func flipHexDigit(b byte) byte {
 		return '1'
 	}
 	return '0'
+}
+
+// buildTrailerBody frames payload with an arbitrary set of trailers, so a test
+// can send a checksum the client never declared or two at once.
+func buildTrailerBody(payload string, trailers ...string) string {
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%x\r\n%s\r\n0\r\n", len(payload), payload)
+	for _, t := range trailers {
+		fmt.Fprintf(&buf, "%s\r\n", t)
+	}
+	buf.WriteString("\r\n")
+	return buf.String()
+}
+
+func crc64Trailer(payload string) string {
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], crc64nvme.Checksum([]byte(payload)))
+	return "x-amz-checksum-crc64nvme:" + base64.StdEncoding.EncodeToString(b[:])
+}
+
+func crc32cTrailer(payload string) string {
+	var b [4]byte
+	binary.BigEndian.PutUint32(b[:], crc32.Checksum([]byte(payload), crc32.MakeTable(crc32.Castagnoli)))
+	return "x-amz-checksum-crc32c:" + base64.StdEncoding.EncodeToString(b[:])
+}
+
+// TestChecksumDeclarationIsBinding covers X-Amz-Trailer as a promise in both
+// directions. A checksum that was not declared could not have been hashed, and
+// one that was declared and never arrives is a promise the client broke.
+func TestChecksumDeclarationIsBinding(t *testing.T) {
+	const payload = "hello world"
+
+	t.Run("sending a different algorithm than declared is rejected", func(t *testing.T) {
+		// The AWS SDK always emits matching declaration and trailer names, so a
+		// mismatch is either a broken client or a rewritten body.
+		body := buildTrailerBody(payload, crc64Trailer(payload))
+		dec := NewDecoder(strings.NewReader(body), int64(len(payload)),
+			WithTrailerChecksums([]string{"x-amz-checksum-crc32c"}))
+		_, err := io.ReadAll(dec)
+		require.NoError(t, err)
+
+		assert.ErrorIs(t, dec.VerifyTrailerChecksum(), ErrChecksumMissing)
+	})
+
+	t.Run("a declared algorithm that arrives is verified", func(t *testing.T) {
+		body := buildTrailerBody(payload, crc32cTrailer(payload))
+		dec := NewDecoder(strings.NewReader(body), int64(len(payload)),
+			WithTrailerChecksums([]string{"x-amz-checksum-crc32c"}))
+		_, err := io.ReadAll(dec)
+		require.NoError(t, err)
+
+		assert.NoError(t, dec.VerifyTrailerChecksum())
+	})
+
+	t.Run("an undeclared extra checksum is rejected", func(t *testing.T) {
+		body := buildTrailerBody(payload, crc32cTrailer(payload), crc64Trailer(payload))
+		dec := NewDecoder(strings.NewReader(body), int64(len(payload)),
+			WithTrailerChecksums([]string{"x-amz-checksum-crc32c"}))
+		_, err := io.ReadAll(dec)
+		require.NoError(t, err)
+
+		assert.ErrorIs(t, dec.VerifyTrailerChecksum(), ErrChecksumUndeclared)
+	})
+
+	t.Run("every checksum sent is verified, not whichever came first", func(t *testing.T) {
+		// Ranging a map is randomised, so a body carrying a good checksum and a
+		// bad one must fail every time rather than most of the time.
+		body := buildTrailerBody(payload, crc64Trailer(payload), "x-amz-checksum-crc32c:AAAAAA==")
+		for range 20 {
+			dec := NewDecoder(strings.NewReader(body), int64(len(payload)),
+				WithTrailerChecksums([]string{"x-amz-checksum-crc32c", "x-amz-checksum-crc64nvme"}))
+			_, err := io.ReadAll(dec)
+			require.NoError(t, err)
+			require.ErrorIs(t, dec.VerifyTrailerChecksum(), ErrChecksumMismatch)
+		}
+	})
+
+	t.Run("an algorithm predastore cannot compute is rejected", func(t *testing.T) {
+		body := buildTrailerBody(payload, "x-amz-checksum-md5:AAAAAA==")
+		dec := NewDecoder(strings.NewReader(body), int64(len(payload)),
+			WithTrailerChecksums([]string{"x-amz-checksum-md5"}))
+		_, err := io.ReadAll(dec)
+		require.NoError(t, err)
+
+		assert.ErrorIs(t, dec.VerifyTrailerChecksum(), ErrChecksumUndeclared)
+	})
+
+	t.Run("declared but never sent is rejected", func(t *testing.T) {
+		body := buildTrailerBody(payload)
+		dec := NewDecoder(strings.NewReader(body), int64(len(payload)),
+			WithTrailerChecksums([]string{"x-amz-checksum-crc32c"}))
+		_, err := io.ReadAll(dec)
+		require.NoError(t, err)
+
+		assert.True(t, dec.PromisesChecksum())
+		assert.ErrorIs(t, dec.VerifyTrailerChecksum(), ErrChecksumMissing)
+	})
+}
+
+// TestChunkSizeIsUnsigned covers a chunk header that would otherwise become a
+// negative length and slice a buffer out of range.
+func TestChunkSizeIsUnsigned(t *testing.T) {
+	for _, body := range []string{
+		"-1\r\nhello\r\n0\r\n\r\n",
+		"-ffff\r\nhello\r\n0\r\n\r\n",
+		"+5\r\nhello\r\n0\r\n\r\n",
+	} {
+		t.Run(body[:strings.IndexByte(body, '\r')], func(t *testing.T) {
+			dec := NewDecoder(strings.NewReader(body), 0)
+			require.NotPanics(t, func() {
+				_, err := io.ReadAll(dec)
+				assert.ErrorIs(t, err, ErrMalformedFraming)
+			})
+		})
+	}
 }

--- a/internal/gate/handlers/payload.go
+++ b/internal/gate/handlers/payload.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/mulgadc/bluebottle/pkg/sigv4"
+	"github.com/mulgadc/predastore/internal/gate/chunked"
+)
+
+// SignedPayload is what authentication learned about a request body, carried to
+// the write path because only the write path can act on it. The mode decides
+// whether the body is framed at all, and the chain is what binds a framed body
+// to the principal that signed the request.
+//
+// It carries the chain's inputs rather than the verified request itself: a
+// handler needs to continue one chain, not the ability to re-sign anything.
+type SignedPayload struct {
+	// Signed distinguishes an authenticated request whose mode is empty — the
+	// client signed a literal digest — from one that was never authenticated at
+	// all. Both leave Mode empty and they are not the same request.
+	Signed bool
+	Mode   sigv4.ContentMode
+	Chain  *chunked.Chain
+}
+
+// Framed reports whether the body carries aws-chunked framing. This is decided
+// by the sentinel the client signed, never by Content-Encoding: that header is
+// optional, may name other encodings alongside this one, and is not covered by
+// the signature, so anything on the path can change it.
+func (p SignedPayload) Framed() bool {
+	switch p.Mode {
+	case sigv4.StreamingSigned, sigv4.StreamingSignedTrailer, sigv4.StreamingUnsignedTrailer:
+		return true
+	default:
+		return false
+	}
+}
+
+type payloadContextKey struct{}
+
+// WithSignedPayload attaches the payload classification to a request context.
+func WithSignedPayload(ctx context.Context, p SignedPayload) context.Context {
+	return context.WithValue(ctx, payloadContextKey{}, p)
+}
+
+// SignedPayloadFrom returns the classification, or the zero value on an
+// unauthenticated request — a public-bucket write signs nothing, so there is no
+// sentinel to trust and no chain to continue.
+func SignedPayloadFrom(ctx context.Context) SignedPayload {
+	p, _ := ctx.Value(payloadContextKey{}).(SignedPayload)
+	return p
+}

--- a/internal/gate/handlers/payload.go
+++ b/internal/gate/handlers/payload.go
@@ -36,6 +36,18 @@ func (p SignedPayload) Framed() bool {
 	}
 }
 
+// PromisesTrailer reports whether the sentinel the client signed names a
+// trailing checksum. Both trailer modes commit to sending one, so a body that
+// then omits it has not kept the promise its signature covers.
+func (p SignedPayload) PromisesTrailer() bool {
+	switch p.Mode {
+	case sigv4.StreamingSignedTrailer, sigv4.StreamingUnsignedTrailer:
+		return true
+	default:
+		return false
+	}
+}
+
 type payloadContextKey struct{}
 
 // WithSignedPayload attaches the payload classification to a request context.

--- a/internal/gate/handlers/put_object.go
+++ b/internal/gate/handlers/put_object.go
@@ -145,11 +145,12 @@ func finishPayload(r *http.Request, dec *chunked.Decoder) error {
 		return nil
 	}
 
-	// A trailer mode names a trailing checksum in the sentinel the client
-	// signed, so an absent one is malformed rather than a client declining to
-	// checksum. On an unsigned trailer mode it is the body's only check.
+	// Two independent promises: the sentinel the client signed, and X-Amz-Trailer
+	// on the request. The header binds an unauthenticated write, which signs no
+	// sentinel, so neither alone is enough to decide the trailer was optional.
 	_, _, sent := dec.ChecksumTrailer()
-	if !sent && !SignedPayloadFrom(r.Context()).PromisesTrailer() {
+	promised := dec.PromisesChecksum() || SignedPayloadFrom(r.Context()).PromisesTrailer()
+	if !sent && !promised {
 		return nil
 	}
 	if err := dec.VerifyTrailerChecksum(); err != nil {

--- a/internal/gate/handlers/put_object.go
+++ b/internal/gate/handlers/put_object.go
@@ -141,18 +141,35 @@ func finishPayload(r *http.Request, dec *chunked.Decoder) error {
 		return mapChunkedErr(err)
 	}
 
-	// Only crc64nvme is understood, so a client checksumming with anything else
-	// is left to the chunk signatures and the transport. Verifying what we do
-	// understand still covers the aws-cli default path.
-	if dec != nil {
-		if _, ok := dec.TrailerChecksum(); ok {
-			if err := dec.VerifyTrailerChecksum(); err != nil {
-				return model.ErrChecksumMismatchError
-			}
-		}
+	if dec == nil {
+		return nil
+	}
+
+	// A trailer mode names a trailing checksum in the sentinel the client
+	// signed, so an absent one is malformed rather than a client declining to
+	// checksum. On an unsigned trailer mode it is the body's only check.
+	_, _, sent := dec.ChecksumTrailer()
+	if !sent && !SignedPayloadFrom(r.Context()).PromisesTrailer() {
+		return nil
+	}
+	if err := dec.VerifyTrailerChecksum(); err != nil {
+		return mapChecksumErr(err)
 	}
 
 	return nil
+}
+
+// mapChecksumErr separates a body that failed its checksum from one that never
+// supplied a usable one. The first is a mismatch; the second is a request whose
+// integrity promise cannot be honoured, which is malformed.
+func mapChecksumErr(err error) error {
+	switch {
+	case errors.Is(err, chunked.ErrChecksumMissing),
+		errors.Is(err, chunked.ErrChecksumUndeclared):
+		return model.ErrMalformedChunkedBodyError
+	default:
+		return model.ErrChecksumMismatchError
+	}
 }
 
 // mapChunkedErr turns a framing failure into the response S3 gives for it. A
@@ -186,6 +203,11 @@ func decodeBody(r *http.Request) (io.Reader, int64, *chunked.Decoder) {
 	if chain := SignedPayloadFrom(r.Context()).Chain; chain != nil {
 		opts = append(opts, chunked.WithChain(chain))
 	}
+	// X-Amz-Trailer names the trailers to come, and hashing has to start before
+	// the body is read, so the promise is what selects the algorithm.
+	if promised := r.Header.Values("X-Amz-Trailer"); len(promised) > 0 {
+		opts = append(opts, chunked.WithTrailerChecksums(splitHeaderList(promised)))
+	}
 
 	// Content-Length on a chunked request measures the framing, not the object,
 	// so the decoded length is the only size the splitter can use. An absent or
@@ -195,8 +217,26 @@ func decodeBody(r *http.Request) (io.Reader, int64, *chunked.Decoder) {
 		dec := chunked.NewDecoder(r.Body, 0, opts...)
 		return dec, -1, dec
 	}
+	// The write path stops at the declared length, so the decoder has to hold
+	// the body to it as well; otherwise a short declaration stores a truncated
+	// object whose checksum still verifies over everything that was sent.
+	opts = append(opts, chunked.WithDeclaredLength(decodedLen))
 	dec := chunked.NewDecoder(r.Body, decodedLen, opts...)
 	return dec, decodedLen, dec
+}
+
+// splitHeaderList flattens a header that may repeat and may also carry a
+// comma-separated list in one value.
+func splitHeaderList(values []string) []string {
+	var out []string
+	for _, v := range values {
+		for part := range strings.SplitSeq(v, ",") {
+			if part = strings.TrimSpace(part); part != "" {
+				out = append(out, part)
+			}
+		}
+	}
+	return out
 }
 
 // bodyIsFramed reports whether the body carries aws-chunked framing.

--- a/internal/gate/handlers/put_object.go
+++ b/internal/gate/handlers/put_object.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/mulgadc/bluebottle/pkg/sigv4"
@@ -39,7 +40,7 @@ func PutObject(mc MetaClient, bc BlobClient, ring *placement.Ring, cache *Bucket
 
 		objectHash := model.ObjectHash(bucket, key)
 
-		body, size := decodeBody(r)
+		body, size, dec := decodeBody(r)
 		if size < 0 {
 			HandleError(w, r, model.ErrMissingContentLengthError)
 			return
@@ -56,7 +57,7 @@ func PutObject(mc MetaClient, bc BlobClient, ring *placement.Ring, cache *Bucket
 
 		// Shards are written but nothing references them until the placement lands
 		// below, so a body that fails its payload check leaves no readable object.
-		if err := finishPayload(r); err != nil {
+		if err := finishPayload(r, dec); err != nil {
 			HandleError(w, r, err)
 			return
 		}
@@ -117,38 +118,105 @@ func recordPhase(ctx context.Context, op, phase string, start time.Time) time.Ti
 // verifies it as it streams: the signed digest is only compared at EOF, and the write
 // path stops at the declared length. Draining the remainder forces the comparison, so a
 // rewritten body is caught before the write is committed to global state.
-func finishPayload(r *http.Request) error {
+// It also finishes a framed body, where the remainder is the terminating chunk
+// and the trailers: the write path stops at the decoded length, so without this
+// the chunk signature closing the chain and the trailing checksum are never
+// read. Draining has to go through the decoder for that reason — draining
+// r.Body would read those bytes around every check the decoder makes on them.
+func finishPayload(r *http.Request, dec *chunked.Decoder) error {
 	if r.Body == nil {
 		return nil
 	}
 
-	if _, err := io.Copy(io.Discard, r.Body); err != nil {
+	var rest io.Reader = r.Body
+	if dec != nil {
+		rest = dec
+	}
+
+	if _, err := io.Copy(io.Discard, rest); err != nil {
 		if errors.Is(err, sigv4.ErrContentSHA256Mismatch) {
 			return model.ErrContentSHA256MismatchError
 		}
 
-		return model.NewS3Error(model.ErrInternalError, "Failed to read the request body", 500)
+		return mapChunkedErr(err)
+	}
+
+	// Only crc64nvme is understood, so a client checksumming with anything else
+	// is left to the chunk signatures and the transport. Verifying what we do
+	// understand still covers the aws-cli default path.
+	if dec != nil {
+		if _, ok := dec.TrailerChecksum(); ok {
+			if err := dec.VerifyTrailerChecksum(); err != nil {
+				return model.ErrChecksumMismatchError
+			}
+		}
 	}
 
 	return nil
 }
 
+// mapChunkedErr turns a framing failure into the response S3 gives for it. A
+// broken signature chain is an authentication failure; anything else about the
+// framing is a malformed request. Neither is a 500: both are the client's.
+func mapChunkedErr(err error) error {
+	switch {
+	case errors.Is(err, chunked.ErrChunkSignature):
+		return model.ErrSignatureDoesNotMatchError
+	case errors.Is(err, chunked.ErrMalformedFraming):
+		return model.ErrMalformedChunkedBodyError
+	default:
+		return model.NewS3Error(model.ErrInternalError, "Failed to read the request body", 500)
+	}
+}
+
 // decodeBody unwraps aws-chunked framing when the client used it, so the rest
 // of the write path only ever sees object bytes, and reports how many of those
 // bytes to expect. The count is negative when the request declared no length.
-func decodeBody(r *http.Request) (io.Reader, int64) {
+// The decoder comes back with them so the caller can finish the body through
+// it, and is nil when the body carries no framing.
+func decodeBody(r *http.Request) (io.Reader, int64, *chunked.Decoder) {
 	if r.Body == nil {
-		return http.NoBody, 0
+		return http.NoBody, 0, nil
 	}
-	if r.Header.Get("Content-Encoding") != "aws-chunked" {
-		return r.Body, r.ContentLength
+	if !bodyIsFramed(r) {
+		return r.Body, r.ContentLength, nil
 	}
+
+	var opts []chunked.Option
+	if chain := SignedPayloadFrom(r.Context()).Chain; chain != nil {
+		opts = append(opts, chunked.WithChain(chain))
+	}
+
 	// Content-Length on a chunked request measures the framing, not the object,
 	// so the decoded length is the only size the splitter can use. An absent or
 	// unparseable header leaves the object size undeclared.
 	decodedLen, err := strconv.ParseInt(r.Header.Get("X-Amz-Decoded-Content-Length"), 10, 64)
 	if err != nil || decodedLen < 0 {
-		return chunked.NewDecoder(r.Body, 0), -1
+		dec := chunked.NewDecoder(r.Body, 0, opts...)
+		return dec, -1, dec
 	}
-	return chunked.NewDecoder(r.Body, decodedLen), decodedLen
+	dec := chunked.NewDecoder(r.Body, decodedLen, opts...)
+	return dec, decodedLen, dec
+}
+
+// bodyIsFramed reports whether the body carries aws-chunked framing.
+//
+// The sentinel the client signed decides it, not Content-Encoding: AWS
+// documents that header as optional on a chunked upload and permits
+// "aws-chunked, gzip", and it is not a signed header, so anything on the path
+// can add or remove it. Getting this wrong stores the framing as object data
+// and answers 200.
+//
+// An unauthenticated request signs nothing, so there the header is all there is.
+func bodyIsFramed(r *http.Request) bool {
+	payload := SignedPayloadFrom(r.Context())
+	if payload.Signed {
+		return payload.Framed()
+	}
+	for enc := range strings.SplitSeq(r.Header.Get("Content-Encoding"), ",") {
+		if strings.EqualFold(strings.TrimSpace(enc), "aws-chunked") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/gate/handlers/put_object_bench_test.go
+++ b/internal/gate/handlers/put_object_bench_test.go
@@ -65,11 +65,11 @@ func BenchmarkPutWritePath(b *testing.B) {
 
 					require.NoError(b, verifyPut(req))
 
-					decoded, size := decodeBody(req)
+					decoded, size, dec := decodeBody(req)
 					_, err := writeObject(ctx, f.bc, f.ring, f.cfg, decoded, size, objectHash)
 					require.NoError(b, err)
 
-					require.NoError(b, finishPayload(req))
+					require.NoError(b, finishPayload(req, dec))
 				}
 			})
 		}

--- a/internal/gate/handlers/put_object_chunked_test.go
+++ b/internal/gate/handlers/put_object_chunked_test.go
@@ -281,3 +281,51 @@ func TestDecodeBodyDeclaredLength(t *testing.T) {
 		assert.ErrorIs(t, err, chunked.ErrMalformedFraming)
 	})
 }
+
+// TestUnauthenticatedTrailerPromise covers a public-bucket write, which signs
+// no sentinel. X-Amz-Trailer is then the only promise on the request, and it
+// binds exactly as the signed sentinel does.
+func TestUnauthenticatedTrailerPromise(t *testing.T) {
+	const payload = "hello world"
+
+	t.Run("promised checksum omitted is rejected", func(t *testing.T) {
+		framed := fmt.Sprintf("%x\r\n%s\r\n0\r\n\r\n", len(payload), payload)
+		req := chunkedPutBody(t, framed, payload, "aws-chunked", SignedPayload{})
+		req.Header.Set("X-Amz-Trailer", "x-amz-checksum-crc32c")
+
+		body, _, dec := decodeBody(req)
+		require.NotNil(t, dec)
+		_, err := io.ReadAll(body)
+		require.NoError(t, err)
+
+		assert.ErrorIs(t, finishPayload(req, dec), model.ErrMalformedChunkedBodyError)
+	})
+
+	t.Run("promised checksum sent is verified", func(t *testing.T) {
+		sum := crc32.Checksum([]byte(payload), crc32.MakeTable(crc32.Castagnoli))
+		var raw [4]byte
+		binary.BigEndian.PutUint32(raw[:], sum)
+
+		framed := fmt.Sprintf("%x\r\n%s\r\n0\r\nx-amz-checksum-crc32c:%s\r\n\r\n",
+			len(payload), payload, base64.StdEncoding.EncodeToString(raw[:]))
+		req := chunkedPutBody(t, framed, payload, "aws-chunked", SignedPayload{})
+		req.Header.Set("X-Amz-Trailer", "x-amz-checksum-crc32c")
+
+		body, _, dec := decodeBody(req)
+		_, err := io.ReadAll(body)
+		require.NoError(t, err)
+
+		assert.NoError(t, finishPayload(req, dec))
+	})
+
+	t.Run("no promise at all stays optional", func(t *testing.T) {
+		framed := fmt.Sprintf("%x\r\n%s\r\n0\r\n\r\n", len(payload), payload)
+		req := chunkedPutBody(t, framed, payload, "aws-chunked", SignedPayload{})
+
+		body, _, dec := decodeBody(req)
+		_, err := io.ReadAll(body)
+		require.NoError(t, err)
+
+		assert.NoError(t, finishPayload(req, dec))
+	})
+}

--- a/internal/gate/handlers/put_object_chunked_test.go
+++ b/internal/gate/handlers/put_object_chunked_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"net/http"
 	"strconv"
@@ -12,6 +13,8 @@ import (
 
 	"github.com/minio/crc64nvme"
 	"github.com/mulgadc/bluebottle/pkg/sigv4"
+	"github.com/mulgadc/predastore/internal/gate/chunked"
+	"github.com/mulgadc/predastore/internal/gate/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -182,9 +185,10 @@ func TestFinishPayloadTrailerChecksum(t *testing.T) {
 		require.NoError(t, finishPayload(req, dec))
 	})
 
-	t.Run("framed body with no trailer at all", func(t *testing.T) {
-		// STREAMING-UNSIGNED-PAYLOAD-TRAILER names a trailer but a body that
-		// omits it is still framed; there is simply nothing to compare.
+	t.Run("trailer mode with no trailer is rejected", func(t *testing.T) {
+		// STREAMING-UNSIGNED-PAYLOAD-TRAILER promises a trailing checksum in the
+		// sentinel the client signed. With no chain either, accepting this
+		// leaves the body with nothing checking it at all.
 		framed := fmt.Sprintf("%x\r\n%s\r\n0\r\n\r\n", len(payload), payload)
 		req := chunkedPutBody(t, framed, payload, "", SignedPayload{
 			Signed: true, Mode: sigv4.StreamingUnsignedTrailer,
@@ -194,6 +198,86 @@ func TestFinishPayloadTrailerChecksum(t *testing.T) {
 		_, err := io.ReadAll(body)
 		require.NoError(t, err)
 
+		assert.ErrorIs(t, finishPayload(req, dec), model.ErrMalformedChunkedBodyError)
+	})
+
+	t.Run("signed stream with no trailer is accepted", func(t *testing.T) {
+		// STREAMING-AWS4-HMAC-SHA256-PAYLOAD promises no trailer, and its chain
+		// already covers the body, so there is nothing missing here.
+		framed := fmt.Sprintf("%x\r\n%s\r\n0\r\n\r\n", len(payload), payload)
+		req := chunkedPutBody(t, framed, payload, "", SignedPayload{
+			Signed: true, Mode: sigv4.StreamingSigned,
+		})
+
+		body, _, dec := decodeBody(req)
+		_, err := io.ReadAll(body)
+		require.NoError(t, err)
+
 		assert.NoError(t, finishPayload(req, dec))
+	})
+
+	t.Run("undeclared checksum algorithm is rejected", func(t *testing.T) {
+		// Hashing has to start before the body is read, so a trailer the client
+		// never named in X-Amz-Trailer cannot be verified after the fact.
+		framed := fmt.Sprintf("%x\r\n%s\r\n0\r\nx-amz-checksum-crc32c:AAAAAA==\r\n\r\n",
+			len(payload), payload)
+		req := chunkedPutBody(t, framed, payload, "", SignedPayload{
+			Signed: true, Mode: sigv4.StreamingUnsignedTrailer,
+		})
+
+		body, _, dec := decodeBody(req)
+		_, err := io.ReadAll(body)
+		require.NoError(t, err)
+
+		assert.ErrorIs(t, finishPayload(req, dec), model.ErrMalformedChunkedBodyError)
+	})
+
+	t.Run("declared crc32c is verified", func(t *testing.T) {
+		sum := crc32.Checksum([]byte(payload), crc32.MakeTable(crc32.Castagnoli))
+		var raw [4]byte
+		binary.BigEndian.PutUint32(raw[:], sum)
+		encoded := base64.StdEncoding.EncodeToString(raw[:])
+
+		framed := fmt.Sprintf("%x\r\n%s\r\n0\r\nx-amz-checksum-crc32c:%s\r\n\r\n",
+			len(payload), payload, encoded)
+		req := chunkedPutBody(t, framed, payload, "", SignedPayload{
+			Signed: true, Mode: sigv4.StreamingUnsignedTrailer,
+		})
+		req.Header.Set("X-Amz-Trailer", "x-amz-checksum-crc32c")
+
+		body, _, dec := decodeBody(req)
+		_, err := io.ReadAll(body)
+		require.NoError(t, err)
+
+		assert.NoError(t, finishPayload(req, dec))
+	})
+}
+
+// TestDecodeBodyDeclaredLength covers a body that disagrees with the length the
+// write path sized itself from. The writer stops at the declared length, so
+// without this the object is stored truncated and its checksum still verifies.
+func TestDecodeBodyDeclaredLength(t *testing.T) {
+	const payload = "hello world"
+
+	t.Run("understated length is rejected", func(t *testing.T) {
+		req := chunkedPutBody(t, framedBodyChecksum(payload, crc64Trailer(payload)),
+			payload, "", SignedPayload{Signed: true, Mode: sigv4.StreamingUnsignedTrailer})
+		req.Header.Set("X-Amz-Decoded-Content-Length", "5")
+
+		body, size, _ := decodeBody(req)
+		assert.Equal(t, int64(5), size)
+
+		_, err := io.ReadAll(body)
+		assert.ErrorIs(t, err, chunked.ErrMalformedFraming)
+	})
+
+	t.Run("overstated length is rejected", func(t *testing.T) {
+		req := chunkedPutBody(t, framedBodyChecksum(payload, crc64Trailer(payload)),
+			payload, "", SignedPayload{Signed: true, Mode: sigv4.StreamingUnsignedTrailer})
+		req.Header.Set("X-Amz-Decoded-Content-Length", "99")
+
+		body, _, _ := decodeBody(req)
+		_, err := io.ReadAll(body)
+		assert.ErrorIs(t, err, chunked.ErrMalformedFraming)
 	})
 }

--- a/internal/gate/handlers/put_object_chunked_test.go
+++ b/internal/gate/handlers/put_object_chunked_test.go
@@ -1,0 +1,199 @@
+package handlers
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/minio/crc64nvme"
+	"github.com/mulgadc/bluebottle/pkg/sigv4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// framedBody wraps payload in a single aws-chunked frame with a trailing
+// checksum header, the shape aws-cli sends for a multi-megabyte PUT. The
+// trailer is a zero CRC, which no non-empty payload hashes to.
+func framedBody(payload string) string {
+	return framedBodyChecksum(payload, "AAAAAAAAAAA=")
+}
+
+func framedBodyChecksum(payload, checksum string) string {
+	return fmt.Sprintf("%x\r\n%s\r\n0\r\nx-amz-checksum-crc64nvme:%s\r\n\r\n",
+		len(payload), payload, checksum)
+}
+
+// crc64Trailer is the trailer value a correct client would send for payload.
+func crc64Trailer(payload string) string {
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], crc64nvme.Checksum([]byte(payload)))
+	return base64.StdEncoding.EncodeToString(b[:])
+}
+
+// chunkedPut builds a PUT carrying framed bytes, with contentEncoding set only
+// when non-empty so a request with the header absent can be tested too.
+func chunkedPut(tb testing.TB, payload, contentEncoding string, p SignedPayload) *http.Request {
+	return chunkedPutBody(tb, framedBody(payload), payload, contentEncoding, p)
+}
+
+func chunkedPutBody(tb testing.TB, body, payload, contentEncoding string, p SignedPayload) *http.Request {
+	tb.Helper()
+
+	req, err := http.NewRequest(http.MethodPut, "https://bucket.example.com/o", strings.NewReader(body))
+	require.NoError(tb, err)
+	req.ContentLength = int64(len(body))
+	req.Header.Set("X-Amz-Decoded-Content-Length", strconv.Itoa(len(payload)))
+	if contentEncoding != "" {
+		req.Header.Set("Content-Encoding", contentEncoding)
+	}
+
+	return req.WithContext(WithSignedPayload(req.Context(), p))
+}
+
+// TestDecodeBodyDetectsFraming covers which requests get their framing stripped.
+// Storing framing as object data is silent corruption: the write succeeds, the
+// object is wrong, and nothing reports it until the object is read back.
+func TestDecodeBodyDetectsFraming(t *testing.T) {
+	const payload = "hello world"
+
+	t.Run("signed streaming mode with no Content-Encoding", func(t *testing.T) {
+		// AWS documents the header as optional on a chunked upload, so its
+		// absence says nothing about whether the body is framed.
+		req := chunkedPut(t, payload, "", SignedPayload{
+			Signed: true, Mode: sigv4.StreamingUnsignedTrailer,
+		})
+
+		body, size, dec := decodeBody(req)
+		require.NotNil(t, dec)
+		assert.Equal(t, int64(len(payload)), size)
+
+		got, err := io.ReadAll(body)
+		require.NoError(t, err)
+		assert.Equal(t, payload, string(got))
+	})
+
+	t.Run("signed streaming mode with a compound Content-Encoding", func(t *testing.T) {
+		req := chunkedPut(t, payload, "aws-chunked, gzip", SignedPayload{
+			Signed: true, Mode: sigv4.StreamingSignedTrailer,
+		})
+
+		body, _, dec := decodeBody(req)
+		require.NotNil(t, dec)
+
+		got, err := io.ReadAll(body)
+		require.NoError(t, err)
+		assert.Equal(t, payload, string(got))
+	})
+
+	t.Run("signed literal digest ignores a spoofed Content-Encoding", func(t *testing.T) {
+		// Content-Encoding is not a signed header, so anything on the path can
+		// add it. A client that signed a digest of the exact bytes it sent did
+		// not frame them, whatever the header now says.
+		req := chunkedPut(t, payload, "aws-chunked", SignedPayload{Signed: true})
+
+		body, size, dec := decodeBody(req)
+		assert.Nil(t, dec)
+		assert.Equal(t, req.ContentLength, size)
+
+		got, err := io.ReadAll(body)
+		require.NoError(t, err)
+		assert.Equal(t, framedBody(payload), string(got))
+	})
+
+	t.Run("signed unsigned-payload is not framed", func(t *testing.T) {
+		req := chunkedPut(t, payload, "aws-chunked", SignedPayload{
+			Signed: true, Mode: sigv4.UnsignedPayload,
+		})
+
+		_, _, dec := decodeBody(req)
+		assert.Nil(t, dec)
+	})
+
+	t.Run("unauthenticated request falls back to Content-Encoding", func(t *testing.T) {
+		// A public-bucket write signs nothing, so the header is all there is.
+		req := chunkedPut(t, payload, "aws-chunked", SignedPayload{})
+
+		body, _, dec := decodeBody(req)
+		require.NotNil(t, dec)
+
+		got, err := io.ReadAll(body)
+		require.NoError(t, err)
+		assert.Equal(t, payload, string(got))
+	})
+
+	t.Run("unauthenticated request with no Content-Encoding", func(t *testing.T) {
+		req := chunkedPut(t, payload, "", SignedPayload{})
+
+		_, _, dec := decodeBody(req)
+		assert.Nil(t, dec)
+	})
+
+	t.Run("framed body with no decoded length is undeclared", func(t *testing.T) {
+		req := chunkedPut(t, payload, "", SignedPayload{
+			Signed: true, Mode: sigv4.StreamingUnsignedTrailer,
+		})
+		req.Header.Del("X-Amz-Decoded-Content-Length")
+
+		// Content-Length measures the framing, so with the decoded length gone
+		// there is no size the splitter can use and the write must be rejected.
+		_, size, dec := decodeBody(req)
+		require.NotNil(t, dec)
+		assert.Equal(t, int64(-1), size)
+	})
+}
+
+// TestFinishPayloadTrailerChecksum covers the trailing checksum, which the
+// decoder computes on every framed body and, before this, never compared.
+func TestFinishPayloadTrailerChecksum(t *testing.T) {
+	const payload = "hello world"
+
+	t.Run("mismatched trailer is rejected", func(t *testing.T) {
+		req := chunkedPut(t, payload, "", SignedPayload{
+			Signed: true, Mode: sigv4.StreamingUnsignedTrailer,
+		})
+
+		body, _, dec := decodeBody(req)
+		_, err := io.ReadAll(body)
+		require.NoError(t, err)
+
+		// The fixture's trailer is a zero CRC, which "hello world" is not.
+		require.Error(t, finishPayload(req, dec))
+	})
+
+	t.Run("matching trailer is accepted", func(t *testing.T) {
+		framed := framedBodyChecksum(payload, crc64Trailer(payload))
+		req := chunkedPutBody(t, framed, payload, "", SignedPayload{
+			Signed: true, Mode: sigv4.StreamingUnsignedTrailer,
+		})
+
+		body, _, dec := decodeBody(req)
+		_, err := io.ReadAll(body)
+		require.NoError(t, err)
+
+		sum, ok := dec.TrailerChecksum()
+		require.True(t, ok)
+		assert.Equal(t, crc64Trailer(payload), sum, "the sent trailer is read, not invented")
+
+		require.NoError(t, finishPayload(req, dec))
+	})
+
+	t.Run("framed body with no trailer at all", func(t *testing.T) {
+		// STREAMING-UNSIGNED-PAYLOAD-TRAILER names a trailer but a body that
+		// omits it is still framed; there is simply nothing to compare.
+		framed := fmt.Sprintf("%x\r\n%s\r\n0\r\n\r\n", len(payload), payload)
+		req := chunkedPutBody(t, framed, payload, "", SignedPayload{
+			Signed: true, Mode: sigv4.StreamingUnsignedTrailer,
+		})
+
+		body, _, dec := decodeBody(req)
+		_, err := io.ReadAll(body)
+		require.NoError(t, err)
+
+		assert.NoError(t, finishPayload(req, dec))
+	})
+}

--- a/internal/gate/handlers/put_object_payload_test.go
+++ b/internal/gate/handlers/put_object_payload_test.go
@@ -84,7 +84,7 @@ func TestFinishPayload(t *testing.T) {
 		_, err := io.CopyN(io.Discard, req.Body, int64(len(large)))
 		require.NoError(t, err)
 
-		require.NoError(t, finishPayload(req))
+		require.NoError(t, finishPayload(req, nil))
 	})
 
 	t.Run("rewritten body", func(t *testing.T) {
@@ -93,7 +93,7 @@ func TestFinishPayload(t *testing.T) {
 		_, err := io.CopyN(io.Discard, req.Body, int64(len(large)))
 		require.NoError(t, err)
 
-		require.ErrorIs(t, finishPayload(req), model.ErrContentSHA256MismatchError)
+		require.ErrorIs(t, finishPayload(req, nil), model.ErrContentSHA256MismatchError)
 	})
 
 	t.Run("body already at EOF", func(t *testing.T) {
@@ -102,6 +102,6 @@ func TestFinishPayload(t *testing.T) {
 		_, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 
-		require.NoError(t, finishPayload(req))
+		require.NoError(t, finishPayload(req, nil))
 	})
 }

--- a/internal/gate/handlers/put_object_status_test.go
+++ b/internal/gate/handlers/put_object_status_test.go
@@ -1,0 +1,119 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/mulgadc/bluebottle/pkg/sigv4"
+	"github.com/mulgadc/predastore/internal/blob/engine"
+	"github.com/mulgadc/predastore/internal/gate/chunked"
+	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/mulgadc/predastore/internal/telemetry"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMapPutErr covers how a failure during the shard write is reported. The
+// body is decoded as the shards are written, so a client's framing or signature
+// failure surfaces there and must not be answered as a server fault.
+func TestMapPutErr(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		code   model.S3ErrorCode
+		status int
+		reason string
+	}{
+		{
+			name:   "storage exhaustion",
+			err:    fmt.Errorf("put shard: %w", engine.ErrStoreFull),
+			code:   model.ErrInsufficientStorage,
+			status: 507,
+			reason: telemetry.WriteReasonStoreFull,
+		},
+		{
+			name:   "broken chunk signature",
+			err:    fmt.Errorf("read body: %w", chunked.ErrChunkSignature),
+			code:   model.ErrSignatureDoesNotMatch,
+			status: 403,
+			reason: telemetry.WriteReasonBadRequest,
+		},
+		{
+			name:   "malformed framing",
+			err:    fmt.Errorf("read body: %w", chunked.ErrMalformedFraming),
+			code:   model.ErrMalformedChunkedBody,
+			status: 400,
+			reason: telemetry.WriteReasonBadRequest,
+		},
+		{
+			name:   "a genuine shard failure is still ours",
+			err:    errors.New("node stalled"),
+			code:   model.ErrInternalError,
+			status: 500,
+			reason: telemetry.WriteReasonShardWrite,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mapPutErr(tc.err)
+			assert.Equal(t, tc.code, got.Code)
+			assert.Equal(t, tc.status, got.StatusCode)
+			assert.Equal(t, tc.reason, writeFailureReason(tc.err),
+				"a client error must not be counted as a storage failure")
+		})
+	}
+}
+
+// TestDecoderErrorReachesTheClient walks the sequence PutObject runs, so the
+// error the client would receive comes from the same call ordering rather than
+// from mapPutErr in isolation.
+func TestDecoderErrorReachesTheClient(t *testing.T) {
+	const payload = "hello world"
+	f := newWriteFixture(4, 2)
+
+	// A body that ends before its terminating chunk. The write path reads only
+	// the declared length, so this fails as the shards are written.
+	truncated := fmt.Sprintf("%x\r\n%s", len(payload), payload)
+	req := chunkedPutBody(t, truncated, payload, "", SignedPayload{
+		Signed: true, Mode: sigv4.StreamingUnsignedTrailer,
+	})
+
+	body, size, dec := decodeBody(req)
+	_, err := writeObject(t.Context(), f.bc, f.ring, f.cfg, body, size, model.ObjectHash("b", "k"))
+	if err == nil {
+		// The declared length was satisfied before the truncation showed, so the
+		// failure lands on the drain instead.
+		err = finishPayload(req, dec)
+	}
+
+	if s3err, ok := model.IsS3Error(err); ok {
+		assert.Equal(t, 400, s3err.StatusCode)
+		return
+	}
+	got := mapPutErr(err)
+	assert.Equal(t, model.ErrMalformedChunkedBody, got.Code)
+	assert.Equal(t, 400, got.StatusCode,
+		"a truncated body is the client's error, not a 500")
+}
+
+// TestTruncatedBodyIsNotACleanEnd is the decoder-level statement of the same
+// fault: a body with no terminating chunk must not read as a complete one.
+func TestTruncatedBodyIsNotACleanEnd(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"no terminating chunk", "5\r\nhello\r\n"},
+		{"chunk shorter than its header", "b\r\nhello"},
+		{"terminator with no trailer block", "5\r\nhello\r\n0\r\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dec := chunked.NewDecoder(strings.NewReader(tc.body), 0)
+			_, err := io.ReadAll(dec)
+			assert.ErrorIs(t, err, chunked.ErrMalformedFraming)
+		})
+	}
+}

--- a/internal/gate/handlers/shards.go
+++ b/internal/gate/handlers/shards.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mulgadc/predastore/internal/blob"
 	"github.com/mulgadc/predastore/internal/blob/engine"
 	"github.com/mulgadc/predastore/internal/config"
+	"github.com/mulgadc/predastore/internal/gate/chunked"
 	"github.com/mulgadc/predastore/internal/gate/model"
 	"github.com/mulgadc/predastore/internal/gate/placement"
 	"github.com/mulgadc/predastore/internal/telemetry"
@@ -49,21 +50,42 @@ func (w *bytesBufferWriter) Write(p []byte) (n int, err error) {
 // mapPutErr translates a shard-write error into the S3 error returned to the
 // client. A pool-full shard write must surface as 507, not the generic 500
 // other failures get.
+//
+// The body is read through the decoder as the shards are written, so a framing
+// or signature failure arrives here rather than at the end of the body. Those
+// are the client's fault and must not be reported as ours.
 func mapPutErr(err error) *model.S3Error {
 	if errors.Is(err, engine.ErrStoreFull) {
 		return model.ErrInsufficientStorageError
 	}
+	if s3err, ok := model.IsS3Error(mapChunkedErr(err)); ok && !isInternal(s3err) {
+		return s3err
+	}
 	return model.NewS3Error(model.ErrInternalError, err.Error(), 500)
+}
+
+// isInternal reports whether an S3 error is the generic server fault, which is
+// mapChunkedErr's answer for anything it does not recognise.
+func isInternal(err *model.S3Error) bool {
+	return err.Code == model.ErrInternalError
 }
 
 // writeFailureReason classifies a failed object write into one of the bounded
 // reasons the counter carries, drawing the same line mapPutErr draws for the
 // client: capacity is its own outcome, everything else is one bucket.
+//
+// A body the client malformed is not a shard-write failure, and counting it as
+// one makes the storage-failure metric fire on client errors.
 func writeFailureReason(err error) string {
-	if errors.Is(err, engine.ErrStoreFull) {
+	switch {
+	case errors.Is(err, engine.ErrStoreFull):
 		return telemetry.WriteReasonStoreFull
+	case errors.Is(err, chunked.ErrChunkSignature),
+		errors.Is(err, chunked.ErrMalformedFraming):
+		return telemetry.WriteReasonBadRequest
+	default:
+		return telemetry.WriteReasonShardWrite
 	}
-	return telemetry.WriteReasonShardWrite
 }
 
 // placeShards resolves where an object's shards live, in the ring order

--- a/internal/gate/handlers/upload_part.go
+++ b/internal/gate/handlers/upload_part.go
@@ -43,7 +43,7 @@ func UploadPart(mc MetaClient, bc BlobClient, ring *placement.Ring, cache *Bucke
 
 		// The part is written as it arrives, so its length has to be known
 		// before the body is read rather than measured from what was buffered.
-		body, partSize := decodeBody(r)
+		body, partSize, dec := decodeBody(r)
 		if partSize < 0 {
 			HandleError(w, r, model.ErrMissingContentLengthError)
 			return
@@ -72,7 +72,7 @@ func UploadPart(mc MetaClient, bc BlobClient, ring *placement.Ring, cache *Bucke
 		}
 		// The part is only reachable once its metadata lands below, so a failed
 		// payload check here leaves nothing CompleteMultipartUpload can assemble.
-		if err := finishPayload(r); err != nil {
+		if err := finishPayload(r, dec); err != nil {
 			HandleError(w, r, err)
 			return
 		}

--- a/internal/gate/middleware.go
+++ b/internal/gate/middleware.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5/middleware"
@@ -14,6 +15,7 @@ import (
 	"github.com/mulgadc/bluebottle/pkg/ratelimit"
 	"github.com/mulgadc/bluebottle/pkg/sigv4"
 	"github.com/mulgadc/predastore/internal/gate/auth"
+	"github.com/mulgadc/predastore/internal/gate/chunked"
 	"github.com/mulgadc/predastore/internal/gate/handlers"
 )
 
@@ -136,7 +138,8 @@ func (s *Server) sigV4AuthMiddleware(next http.Handler) http.Handler {
 			expectedRegion = globalSigningRegion
 		}
 
-		if _, err := sig.Verify(credResult.SecretAccessKey, expectedRegion, "s3"); err != nil {
+		verified, err := sig.Verify(credResult.SecretAccessKey, expectedRegion, "s3")
+		if err != nil {
 			handlers.RespondSigV4Error(w, r, accessKey, err, nil)
 			return
 		}
@@ -200,6 +203,7 @@ func (s *Server) sigV4AuthMiddleware(next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), auth.ContextKeyAccessKeyID, accessKey)
 		ctx = context.WithValue(ctx, auth.ContextKeyAccountID, credResult.AccountID)
 		ctx = context.WithValue(ctx, auth.ContextKeyServiceAccount, credResult.SkipPolicyCheck)
+		ctx = handlers.WithSignedPayload(ctx, signedPayload(verified))
 		// The transaction span opens before authentication, so the account it
 		// resolved to can only be named here. One cluster serves many accounts
 		// and S3 is where a tenant's data lives, so an unattributed request is
@@ -207,4 +211,24 @@ func (s *Server) sigV4AuthMiddleware(next http.Handler) http.Handler {
 		annotateSpanAccount(ctx, credResult.AccountID)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// signedPayload is what the write path needs to decode and authenticate a body:
+// the sentinel the client signed, and for a signed streaming upload the seed of
+// its chunk signature chain.
+//
+// Only the chain's inputs are carried, never the verified request itself. The
+// write path continues one chain; it has no business re-signing anything.
+func signedPayload(v *sigv4.VerifiedRequest) handlers.SignedPayload {
+	p := handlers.SignedPayload{Signed: true, Mode: v.Canonical.PayloadMode}
+	if p.Mode != sigv4.StreamingSigned && p.Mode != sigv4.StreamingSignedTrailer {
+		return p
+	}
+	scope := strings.Join([]string{
+		v.Credential.Date, v.Credential.Region, v.Credential.Service, sigv4.AmzScopeTerminator,
+	}, "/")
+	p.Chain = chunked.NewChain(
+		v.SigningKey, v.Signature, scope, v.Timestamp.UTC().Format(sigv4.AmzTimeFormat),
+	)
+	return p
 }

--- a/internal/gate/middleware_payload_test.go
+++ b/internal/gate/middleware_payload_test.go
@@ -1,0 +1,227 @@
+package gate
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/mulgadc/bluebottle/pkg/sigv4"
+	"github.com/mulgadc/predastore/internal/gate/chunked"
+	"github.com/mulgadc/predastore/internal/gate/handlers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deriveSigningKey is AWS's four-step key derivation, written from the spec so
+// the chain the test signs with does not come from the code under test.
+func deriveSigningKey(secret, date, region, service string) []byte {
+	mac := func(key []byte, data string) []byte {
+		h := hmac.New(sha256.New, key)
+		h.Write([]byte(data))
+		return h.Sum(nil)
+	}
+	k := mac([]byte("AWS4"+secret), date)
+	k = mac(k, region)
+	k = mac(k, service)
+	return mac(k, "aws4_request")
+}
+
+// clientChunkedBody frames payload as one signed chunk plus the terminating
+// chunk, the way a client signing STREAMING-AWS4-HMAC-SHA256-PAYLOAD does.
+func clientChunkedBody(key []byte, seed, scope, timestamp, payload string) string {
+	prev := seed
+	sign := func(chunk string) string {
+		sum := sha256.Sum256([]byte(chunk))
+		empty := sha256.Sum256(nil)
+		sts := strings.Join([]string{
+			"AWS4-HMAC-SHA256-PAYLOAD", timestamp, scope, prev,
+			hex.EncodeToString(empty[:]), hex.EncodeToString(sum[:]),
+		}, "\n")
+		h := hmac.New(sha256.New, key)
+		h.Write([]byte(sts))
+		prev = hex.EncodeToString(h.Sum(nil))
+		return prev
+	}
+
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%x;chunk-signature=%s\r\n%s\r\n", len(payload), sign(payload), payload)
+	fmt.Fprintf(&buf, "0;chunk-signature=%s\r\n\r\n", sign(""))
+	return buf.String()
+}
+
+// framedLen is the wire length of clientChunkedBody's output. Content-Length is
+// signed, so it has to be known before the seed signature exists.
+func framedLen(payload string) int {
+	const sigExt = len(";chunk-signature=") + 64
+	return len(fmt.Sprintf("%x", len(payload))) + sigExt + 2 + len(payload) + 2 +
+		1 + sigExt + 2 + 2
+}
+
+// authSignature pulls Signature= out of the Authorization header, which is the
+// seed of a client's chunk signature chain.
+func authSignature(tb testing.TB, req *http.Request) string {
+	tb.Helper()
+
+	_, after, found := strings.Cut(req.Header.Get("Authorization"), "Signature=")
+	require.True(tb, found, "signed request carries no Signature=")
+	return strings.TrimSpace(after)
+}
+
+// TestSignedPayloadChainEndToEnd drives a signed chunked PUT through the auth
+// middleware and continues its chain in the handler. The chain the client signs
+// with is derived from the secret independently, so a wrong credential scope or
+// timestamp format in the middleware fails here rather than passing against
+// itself.
+func TestSignedPayloadChainEndToEnd(t *testing.T) {
+	const (
+		payload = "hello world"
+		region  = "ap-southeast-2"
+		key     = "AKIAIOSFODNN7EXAMPLE"
+		secret  = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	)
+
+	now := time.Now().UTC()
+	scope := fmt.Sprintf("%s/%s/s3/aws4_request", now.Format("20060102"), region)
+	signingKey := deriveSigningKey(secret, now.Format("20060102"), region, "s3")
+
+	newSignedPut := func(t *testing.T, mode sigv4.ContentMode, tamper bool) *http.Request {
+		t.Helper()
+
+		// The signature covers Content-Length, so the framed body's length has to
+		// be settled before its chunk signatures can exist.
+		size := framedLen(payload)
+		req := httptest.NewRequest(http.MethodPut, "https://s3.example.com/private/o.txt",
+			strings.NewReader(strings.Repeat("x", size)))
+		req.ContentLength = int64(size)
+		req.Header.Set("X-Amz-Content-Sha256", string(mode))
+		req.Header.Set("X-Amz-Decoded-Content-Length", strconv.Itoa(len(payload)))
+
+		signer := v4.NewSigner(func(o *v4.SignerOptions) { o.DisableURIPathEscaping = true })
+		require.NoError(t, signer.SignHTTP(context.Background(),
+			aws.Credentials{AccessKeyID: key, SecretAccessKey: secret},
+			req, string(mode), "s3", region, now))
+
+		body := clientChunkedBody(signingKey, authSignature(t, req), scope,
+			now.Format(sigv4.AmzTimeFormat), payload)
+		require.Len(t, body, size, "framedLen must match what the client actually sends")
+		if tamper {
+			body = strings.Replace(body, payload, strings.ToUpper(payload), 1)
+		}
+		req.Body = io.NopCloser(strings.NewReader(body))
+
+		return req
+	}
+
+	// decodeResult is what the handler observed, collected rather than asserted
+	// in place: a failed assertion inside a handler aborts the wrong goroutine.
+	type decodeResult struct {
+		payload handlers.SignedPayload
+		body    string
+		err     error
+		reached bool
+	}
+
+	// decodeAt continues the chain the middleware seeded, which is what the
+	// write path does, and records what came out of the body.
+	decodeAt := func(res *decodeResult) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			res.reached = true
+			res.payload = handlers.SignedPayloadFrom(r.Context())
+			if res.payload.Chain == nil {
+				return
+			}
+			dec := chunked.NewDecoder(r.Body, int64(len(payload)), chunked.WithChain(res.payload.Chain))
+			got, err := io.ReadAll(dec)
+			res.body, res.err = string(got), err
+		})
+	}
+
+	// serve runs one signed PUT through the middleware and the decoding handler,
+	// checking the parts every case shares.
+	serve := func(t *testing.T, mode sigv4.ContentMode, tamper bool) decodeResult {
+		t.Helper()
+
+		s := newTestGate(t, newAuthTestConfig())
+		var res decodeResult
+		rec := httptest.NewRecorder()
+		resolveRouter(decodeAt(&res), s.sigV4AuthMiddleware).
+			ServeHTTP(rec, newSignedPut(t, mode, tamper))
+
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+		require.True(t, res.reached, "the request never reached the handler")
+		require.True(t, res.payload.Signed)
+		require.True(t, res.payload.Framed())
+		require.NotNil(t, res.payload.Chain, "a signed streaming body must carry a chain")
+
+		return res
+	}
+
+	for _, mode := range []sigv4.ContentMode{sigv4.StreamingSigned, sigv4.StreamingSignedTrailer} {
+		t.Run(string(mode), func(t *testing.T) {
+			res := serve(t, mode, false)
+
+			require.NoError(t, res.err)
+			assert.Equal(t, payload, res.body)
+		})
+	}
+
+	t.Run("rejects a body rewritten after signing", func(t *testing.T) {
+		// Authentication passes: the signed sentinel says nothing about the body,
+		// which is exactly why the chain has to be checked as it decodes.
+		res := serve(t, sigv4.StreamingSigned, true)
+
+		assert.ErrorIs(t, res.err, chunked.ErrChunkSignature)
+	})
+}
+
+// TestSignedPayloadModes covers what the middleware puts on the context for the
+// modes that are not a signed stream, since each one routes the body differently.
+func TestSignedPayloadModes(t *testing.T) {
+	tests := []struct {
+		name   string
+		mode   sigv4.ContentMode
+		framed bool
+		chain  bool
+	}{
+		{"unsigned payload", sigv4.UnsignedPayload, false, false},
+		{"unsigned trailer", sigv4.StreamingUnsignedTrailer, true, false},
+		{"signed stream", sigv4.StreamingSigned, true, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestGate(t, newAuthTestConfig())
+
+			req := httptest.NewRequest(http.MethodGet, "https://s3.example.com/private/o.txt", nil)
+			req.Header.Set("X-Amz-Content-Sha256", string(tc.mode))
+			signer := v4.NewSigner(func(o *v4.SignerOptions) { o.DisableURIPathEscaping = true })
+			require.NoError(t, signer.SignHTTP(context.Background(),
+				aws.Credentials{AccessKeyID: "AKIAIOSFODNN7EXAMPLE",
+					SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"},
+				req, string(tc.mode), "s3", "ap-southeast-2", time.Now().UTC()))
+
+			var p handlers.SignedPayload
+			rec := httptest.NewRecorder()
+			resolveRouter(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				p = handlers.SignedPayloadFrom(r.Context())
+			}), s.sigV4AuthMiddleware).ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+			assert.True(t, p.Signed)
+			assert.Equal(t, tc.mode, p.Mode)
+			assert.Equal(t, tc.framed, p.Framed())
+			assert.Equal(t, tc.chain, p.Chain != nil)
+		})
+	}
+}

--- a/internal/gate/model/errors.go
+++ b/internal/gate/model/errors.go
@@ -31,6 +31,8 @@ const (
 	ErrInsufficientStorage     S3ErrorCode = "InsufficientStorage"
 	ErrMissingContentLength    S3ErrorCode = "MissingContentLength"
 	ErrInvalidArgument         S3ErrorCode = "InvalidArgument"
+	ErrSignatureDoesNotMatch   S3ErrorCode = "SignatureDoesNotMatch"
+	ErrMalformedChunkedBody    S3ErrorCode = "InvalidRequest"
 )
 
 // S3Error represents a typed S3 error with code and message.
@@ -133,6 +135,32 @@ var (
 		Code:       ErrMissingContentLength,
 		Message:    "You must provide the Content-Length HTTP header",
 		StatusCode: http.StatusLengthRequired,
+	}
+
+	// ErrSignatureDoesNotMatchError is returned when a chunk of an aws-chunked
+	// body does not continue the signature chain seeded by the request
+	// signature, which means those bytes are not the bytes the client signed.
+	ErrSignatureDoesNotMatchError = &S3Error{
+		Code:       ErrSignatureDoesNotMatch,
+		Message:    "The request signature we calculated does not match the signature you provided",
+		StatusCode: http.StatusForbidden,
+	}
+
+	// ErrMalformedChunkedBodyError is returned when an aws-chunked body's
+	// framing does not parse. The alternative is storing the framing as object
+	// data, which is what a missed decode does.
+	ErrMalformedChunkedBodyError = &S3Error{
+		Code:       ErrMalformedChunkedBody,
+		Message:    "The chunked upload framing in the request body is malformed",
+		StatusCode: http.StatusBadRequest,
+	}
+
+	// ErrChecksumMismatchError is returned when a body's trailing checksum does
+	// not match the one computed as it streamed.
+	ErrChecksumMismatchError = &S3Error{
+		Code:       ErrChecksumMismatch,
+		Message:    "The checksum the client sent does not match what was computed",
+		StatusCode: http.StatusBadRequest,
 	}
 )
 

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -698,6 +698,9 @@ const (
 	WriteReasonStoreFull = "store_full"
 	// WriteReasonShardWrite is any other failure placing a shard.
 	WriteReasonShardWrite = "shard_write"
+	// WriteReasonBadRequest is a body the client malformed. It fails while the
+	// shards are being written but is not a storage fault.
+	WriteReasonBadRequest = "bad_request"
 	// WriteReasonMeta is shards that landed but whose placement could not be
 	// committed. The bytes are on disk and nothing references them.
 	WriteReasonMeta = "meta"


### PR DESCRIPTION
Closes the chunked upload path: `mulga-66ewl` (framing detection) and `mulga-ow7l3` (framing never verified).

## What was wrong

**Detection keyed off `Content-Encoding`.** AWS documents that header as optional on a chunked upload and permits `aws-chunked, gzip`, and it is not in `SignedHeaders`. Anything on the request path could add or remove it. Adding it to a normal PUT made predastore treat the raw body as framed; removing it from a framed PUT made predastore store the chunk framing as object data and answer 200. Neither requires the ability to sign anything.

**The framing that was stripped was never verified.** `readNextChunkHeader` cut everything after the first `;` before any code read it, so `chunk-signature=` was discarded. A `STREAMING-AWS4-HMAC-SHA256-PAYLOAD` body was accepted on the strength of a sentinel, and the sentinel is not a digest — it explicitly says the body is covered by the chunk chain instead. Nothing checked that chain.

**The trailing checksum was computed and thrown away.** The decoder maintained a running CRC64NVME on every framed body and `VerifyTrailerChecksum` was never called. Worse, `finishPayload` drained `r.Body` rather than the decoder, so on a body the write path stopped short of, the terminating chunk and the trailers were read around the decoder and never parsed at all.

## What changed

- **Detection is on the signed sentinel.** `SignedPayload` on the request context carries the mode the client signed and whether the request was authenticated at all. An authenticated request is classified by its sentinel; only an unauthenticated public-bucket write, which signs nothing, falls back to the header.

  The `Signed` flag is load-bearing: `PayloadMode` is empty when a client signs a literal digest, which is what aws-cli does for a small PUT, so "empty mode" alone cannot tell a signed literal-digest request apart from an unsigned one. Without the flag, a signed small PUT with a spoofed `Content-Encoding: aws-chunked` would still be routed into the decoder.

- **The chunk signature chain is verified.** `chunked.Chain` continues the chain seeded from the request signature, hashing each chunk as it streams so the client's chunk size stays out of our memory, and comparing at the chunk boundary. The trailing header block is checked against the `AWS4-HMAC-SHA256-TRAILER` string-to-sign. Comparison is `hmac.Equal`.

- **The trailing checksum is compared.** `decodeBody` hands the decoder back, `finishPayload` drains through it, and a crc64nvme trailer is checked against what streamed. Only crc64nvme is understood; a client checksumming with anything else is left to the chunk signatures and the transport.

- **Failures map to what S3 returns.** Broken chain → `SignatureDoesNotMatch` (403). Malformed framing → `InvalidRequest` (400). Checksum mismatch → `XAmzContentChecksumMismatch` (400), not `BadDigest`, which S3 reserves for `Content-MD5`.

The middleware passes the chain's *inputs*, not the `VerifiedRequest`. That struct holds the request and the secret's derived material, and a handler holding it could re-verify or re-sign anything. The write path needs to continue one chain.

## Impact

Latent rather than active. Measured against aws-cli 2.36.34 and rclone: a 5 MiB PUT sends `STREAMING-UNSIGNED-PAYLOAD-TRAILER` with `Content-Encoding: aws-chunked`, so it was detected correctly and round-tripped byte-identical. Nothing in the current client set sends a signed chain. The exposure was to a client or proxy that varies the header, and to any signed-streaming client, whose body was simply unauthenticated.

## Testing

`make preflight` passes.

- `internal/gate/chunked/signature_test.go` — chain accept and reject: wrong bytes, wrong order, non-hex, near-miss, chain unadvanced on failure, trailer signature not interchangeable with a chunk signature, an unsigned body ignoring the extensions.
- `internal/gate/handlers/put_object_chunked_test.go` — the detection matrix, and the trailer checksum accept and reject.
- `internal/gate/middleware_payload_test.go` — a signed streaming PUT driven through the auth middleware and decoded in the handler, then the same with one chunk rewritten.

Each negative case was mutation-checked: stubbing `Chain.verify` to always succeed fails every chain reject test, and reverting detection to the `Content-Encoding` scan fails every detection test.

### On the chain tests being self-consistent

No client we have sends a signed chain, and the SDK's exported `v4.StreamSigner` signs event streams rather than S3 chunked uploads, so the string-to-sign *layout* is spec-derived and untested against a real signer.

The plumbing is not. `TestSignedPayloadChainEndToEnd` writes out AWS's four-step key derivation in the test, seeds the chain from the `Signature=` the AWS SDK put in the `Authorization` header, and signs the body with that. A wrong credential scope, timestamp format or seed in the middleware fails it — confirmed by mutating each. The unsigned-trailer path has no gap at all: aws-cli exercises it directly in `scripts/smoke.sh`.