### PR TITLE
ci: fail the e2e suites on any failing check, and run the performance job

### DIFF
--- a/.github/workflows/predastore-e2e.yml
+++ b/.github/workflows/predastore-e2e.yml
@@ -77,10 +77,12 @@ jobs:
           docker compose -f deploy/compose.cluster.yml logs --tail 50
           exit 1
 
-      # Predastore fails several checks today, so this gates on regressions
-      # against scripts/smoke-baseline.txt rather than on a clean run.
+      # Every failing check fails this job. The suite exists to say whether
+      # predastore is S3 compatible, and it is not yet, so this stays red until
+      # the remaining gaps close. The baseline is still read, to mark each
+      # failure as a known gap or a new one in the job summary.
       - name: Smoke Suite
-        run: make docker-smoke SMOKE_SUITES="${{ inputs.smoke_suites }}"
+        run: make docker-smoke-strict SMOKE_SUITES="${{ inputs.smoke_suites }}"
 
       - name: Cluster Logs
         if: failure()
@@ -111,12 +113,13 @@ jobs:
           cache-dependency-path: "go.sum"
           go-version-file: "go.mod"
 
-      # torn-overwrite and the leader freeze fail against predastore today, so
-      # this gates on a regression against scripts/stress-baseline.txt. A job
-      # that is red from its first run is a job nobody reads.
+      # A failing scenario fails this job. torn-overwrite is red today and it
+      # should look red: an overwrite with no commit point across its shards
+      # leaves the object part new and part old, served as a 200 with the right
+      # length and ETag. The baseline marks it as known rather than excusing it.
       - name: Run Scenario
         if: inputs.stress_scenarios == '' || contains(inputs.stress_scenarios, matrix.scenario)
-        run: make e2e-stress-gate STRESS_SCENARIOS=${{ matrix.scenario }}
+        run: make e2e-stress-strict STRESS_SCENARIOS=${{ matrix.scenario }}
 
       - name: Upload Results
         if: always()
@@ -134,7 +137,10 @@ jobs:
     # compared across hosts reports a difference in machines as a regression.
     runs-on: [self-hosted, ci-predastore]
     timeout-minutes: 45
-    if: inputs.run_performance != false
+    # inputs is null on a push, and GitHub coerces both sides of != to a number,
+    # so `inputs.run_performance != false` is `0 != 0` there and the job never
+    # runs. The event has to be checked first.
+    if: github.event_name != 'workflow_dispatch' || inputs.run_performance
 
     # A fixed group with no ref in it, so every performance run across every
     # branch queues behind the one in flight. Killing a benchmark part way

--- a/.github/workflows/predastore.yml
+++ b/.github/workflows/predastore.yml
@@ -116,6 +116,26 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # This job asks whether the change broke something, which a baseline can
+      # be made to answer wrongly: re-recording it turns a fresh regression into
+      # an expected failure and the gate goes quiet. Growing the expected-failure
+      # count is therefore its own failure, reviewable as a number.
+      - name: Guard the Baselines
+        if: github.event_name == 'pull_request'
+        run: |
+          status=0
+          for f in scripts/smoke-baseline.txt scripts/stress-baseline.txt; do
+            base=$(git show "origin/${{ github.base_ref }}:$f" 2>/dev/null | grep -c '^FAIL|' || true)
+            head=$(grep -c '^FAIL|' "$f" || true)
+            if [ "$head" -gt "$base" ]; then
+              echo "::error file=$f::$f gained $((head - base)) expected failure(s); a regression is fixed, not recorded"
+              status=1
+            fi
+          done
+          exit $status
 
       # Builds the image the same way an operator would, which is also the
       # only place the FIPS build guard runs: a binary built without GOFIPS140

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,14 @@ docker-smoke:
 	@PREDA_IMAGE=$(DOCKER_IMAGE) PREDA_BASELINE=$(SMOKE_BASELINE) \
 		./scripts/smoke.sh $(SMOKE_SUITES)
 
+# Fails on any failing check. This is the honest question — is predastore S3
+# compatible — and it is red until the remaining gaps are closed. The
+# regression form above is what a pull request runs, so a branch is not red
+# for defects it did not introduce.
+docker-smoke-strict:
+	@PREDA_IMAGE=$(DOCKER_IMAGE) PREDA_BASELINE=$(SMOKE_BASELINE) PREDA_STRICT=1 \
+		./scripts/smoke.sh $(SMOKE_SUITES)
+
 # Re-record the baseline. Run it when a fix lands, in the same change.
 docker-smoke-baseline:
 	@PREDA_IMAGE=$(DOCKER_IMAGE) PREDA_WRITE_BASELINE=$(SMOKE_BASELINE) \
@@ -187,6 +195,15 @@ e2e-stress-gate: build certs warp-install
 		WARP="$(WARP)" \
 		./scripts/bench/stress-gate.sh $(STRESS_SCENARIOS)
 
+# Fails on any failing scenario. Red until torn-overwrite is fixed, which is
+# the point: an overwrite that leaves an object part new and part old is data
+# loss on the ordinary write path.
+e2e-stress-strict: build certs warp-install
+	@STRESS_CONFIG="$(STRESS_CONFIG)" STRESS_FREEZE="$(STRESS_FREEZE)" \
+		STRESS_HOST="$(STRESS_HOST)" STRESS_BASELINE="$(STRESS_BASELINE)" \
+		STRESS_STRICT=1 WARP="$(WARP)" \
+		./scripts/bench/stress-gate.sh $(STRESS_SCENARIOS)
+
 # Re-record the baseline. Run it when a fix lands, in the same change.
 e2e-stress-baseline: build certs warp-install
 	@STRESS_CONFIG="$(STRESS_CONFIG)" STRESS_FREEZE="$(STRESS_FREEZE)" \
@@ -201,5 +218,6 @@ nilaway:
 
 .PHONY: certs build go_build preflight test test-cover test-race test-integration diff-coverage \
 	clean lint fix govulncheck nilaway warp-install e2e-performance e2e-performance-compare \
-	e2e-stress e2e-stress-gate e2e-stress-baseline \
-	docker-build docker-smoke docker-smoke-baseline compose-up compose-down
+	e2e-stress e2e-stress-gate e2e-stress-strict e2e-stress-baseline \
+	docker-build docker-smoke docker-smoke-strict docker-smoke-baseline \
+	compose-up compose-down

--- a/scripts/bench/stress-gate.sh
+++ b/scripts/bench/stress-gate.sh
@@ -19,6 +19,9 @@
 # Environment:
 #   STRESS_BASELINE        Baseline file (default: scripts/stress-baseline.txt)
 #   STRESS_WRITE_BASELINE  Record outcomes here instead of gating
+#   STRESS_STRICT          1 to fail on any failing scenario, not just a
+#                          regression. The baseline is still read, to separate
+#                          a known gap from a new one in the report.
 #   Everything e2e-stress.sh reads is passed through untouched.
 #
 set -uo pipefail
@@ -81,21 +84,32 @@ if [ -n "$WRITE_BASELINE" ]; then
     exit 0
 fi
 
+note() {
+    [ -n "${GITHUB_ACTIONS:-}" ] || return 0
+    printf '::%s::%s\n' "${2:-warning}" "$1"
+}
+
 regressions=0
 fixed=0
+failed=0
 printf '\n=== gate ===\n'
 for r in "${RESULTS[@]}"; do
     IFS='|' read -r status scenario <<< "$r"
+    [ "$status" = FAIL ] && failed=$((failed + 1))
     want=$(grep -F "|$scenario" "$BASELINE" | cut -d'|' -f1 | head -1)
     if [ -z "$want" ]; then
         printf '  ? %s is not in the baseline\n' "$scenario"
+        note "$scenario is not in the baseline"
         continue
     fi
     if [ "$want" = PASS ] && [ "$status" = FAIL ]; then
         printf '  REGRESSION %s survived in the baseline and fails now\n' "$scenario"
+        note "REGRESSION: $scenario survived in the baseline and fails now" error
         regressions=$((regressions + 1))
     elif [ "$want" = FAIL ] && [ "$status" = PASS ]; then
         fixed=$((fixed + 1))
+    elif [ "$status" = FAIL ]; then
+        note "known gap: $scenario"
     fi
 done
 
@@ -104,5 +118,26 @@ if [ "$fixed" -gt 0 ]; then
         "$fixed" "$BASELINE"
 fi
 
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+        printf '## Stress\n\n| Scenario | Result | Baseline |\n|---|---|---|\n'
+        for r in "${RESULTS[@]}"; do
+            IFS='|' read -r status scenario <<< "$r"
+            want=$(grep -F "|$scenario" "$BASELINE" | cut -d'|' -f1 | head -1)
+            # Backticks are markdown for the summary, not a substitution.
+            # shellcheck disable=SC2016
+            printf '| `%s` | %s | %s |\n' "$scenario" "$status" "${want:-not baselined}"
+        done
+        printf '\n%d regression(s), %d newly passing.\n\n' "$regressions" "$fixed"
+    } >> "$GITHUB_STEP_SUMMARY"
+fi
+
 printf '\n'
+
+# Strict asks whether the cluster survives the fault; the default asks whether
+# this change made it survive less well than it used to.
+if [ "${STRESS_STRICT:-}" = 1 ]; then
+    [ "$failed" -eq 0 ]
+    exit $?
+fi
 [ "$regressions" -eq 0 ]

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -24,6 +24,9 @@
 #                    if present, else it is taken from the endpoint itself.
 #   PREDA_BASELINE   Compare against this baseline and fail only on
 #                    regressions. See scripts/smoke-baseline.txt.
+#   PREDA_STRICT     1 to fail on any failing check, not just a regression.
+#                    The baseline is still read, to separate a known gap from
+#                    a new one in the report.
 #   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_DEFAULT_REGION
 
 set -uo pipefail
@@ -98,6 +101,40 @@ check() {
 }
 
 section() { printf '\n%s%s%s\n' "$BOLD" "$1" "$NC"; }
+
+# note <message> [warning|error] — a GitHub annotation, so a run that is green
+# still lists what is broken instead of showing a bare tick. Silent off CI.
+note() {
+    [ -n "${GITHUB_ACTIONS:-}" ] || return 0
+    printf '::%s::%s\n' "${2:-warning}" "$1"
+}
+
+# summary <regressions> <known> <fixed> — the run's job summary. A checks list
+# says only pass or fail, and "no regressions against seven known gaps" is not
+# something a tick can express.
+summary() {
+    [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+    {
+        printf '## S3 compatibility\n\n'
+        printf '%d of %d checks pass.\n\n' "$PASSED" "$((PASSED + FAILED))"
+        printf '| Result | Count |\n|---|---|\n'
+        printf '| Passing | %d |\n' "$PASSED"
+        printf '| Known gaps | %d |\n' "$2"
+        printf '| **Regressions** | **%d** |\n' "$1"
+        printf '| Newly passing | %d |\n\n' "$3"
+        if [ "$FAILED" -gt 0 ]; then
+            printf '### Failing\n\n'
+            for r in "${RESULTS[@]}"; do
+                IFS='|' read -r status label code <<< "$r"
+                [ "$status" = FAIL ] || continue
+                # Backticks are markdown for the summary, not a substitution.
+                # shellcheck disable=SC2016
+                printf -- '- `%s`%s\n' "$label" "${code:+ — $code}"
+            done
+            printf '\n'
+        fi
+    } >> "$GITHUB_STEP_SUMMARY"
+}
 
 # Clients run on the host network so they reach the published gate the same way
 # an operator would, rather than through a compose-internal address.
@@ -401,18 +438,24 @@ if [ -n "${PREDA_BASELINE:-}" ]; then
 
     regressions=0
     fixed=0
+    known=0
     for r in "${RESULTS[@]}"; do
         IFS='|' read -r status label _ <<< "$r"
         want=$(grep -F "|$label" "$PREDA_BASELINE" | cut -d'|' -f1 | head -1)
         if [ -z "$want" ]; then
             printf '  %s?%s %s is not in the baseline\n' "$YELLOW" "$NC" "$label"
+            note "$label is not in the baseline" warning
             continue
         fi
         if [ "$want" = "PASS" ] && [ "$status" = "FAIL" ]; then
             printf '  %sREGRESSION%s %s passed in the baseline and fails now\n' "$RED" "$NC" "$label"
+            note "REGRESSION: $label passed in the baseline and fails now" error
             regressions=$((regressions + 1))
         elif [ "$want" = "FAIL" ] && [ "$status" = "PASS" ]; then
             fixed=$((fixed + 1))
+        elif [ "$status" = "FAIL" ]; then
+            note "known gap: $label" warning
+            known=$((known + 1))
         fi
     done
 
@@ -420,7 +463,17 @@ if [ -n "${PREDA_BASELINE:-}" ]; then
         printf '\n  %s%d check(s) now pass that the baseline expects to fail.%s Update %s.\n' \
             "$GREEN" "$fixed" "$NC" "$PREDA_BASELINE"
     fi
+
+    summary "$regressions" "$known" "$fixed"
     printf '\n'
+
+    # Strict asks whether predastore is correct; the default asks whether this
+    # change broke something that worked. A pull request answers the second —
+    # the first would leave every branch red on defects it did not introduce.
+    if [ "${PREDA_STRICT:-}" = 1 ]; then
+        [ "$FAILED" -eq 0 ]
+        exit $?
+    fi
     [ "$regressions" -eq 0 ]
     exit $?
 fi


### PR DESCRIPTION
Bead: `mulga-0f5wr`
Follows #115. Three faults, all visible in the first e2e run on `dev` ([run 33359863169](https://github.com/mulgadc/predastore/actions/runs/33359863169)).

## The performance job never ran

It reported `skipped`, not queued. The condition was:

```yaml
if: inputs.run_performance != false
```

`inputs` is null on a `push`, and GitHub coerces both sides of `!=` to a number, so this reads `0 != 0` and the job was skipped on every push. It could only ever have run on `workflow_dispatch`. Now:

```yaml
if: github.event_name != 'workflow_dispatch' || inputs.run_performance
```

## Green while failing

`S3 Compatibility (cluster)` passed with **7 of 35 checks failing**. `Stress (torn-overwrite)` passed while failing **3 of its 5 assertions** — that scenario is an overwrite with no commit point across its shards, leaving the object part new and part old and serving it as a 200 with the right length and ETag.

Regression-gating was the right call for adoption and the wrong signal. A tick cannot express "no regressions against seven known gaps", and nobody reading a checks list infers it.

The e2e workflow now fails on any failing check and stays red until the gaps close.

**The pull-request job keeps gating on regressions.** Flipping both would leave every branch red for defects it did not introduce, including the branches fixing them. The two jobs answer different questions: the PR job asks whether this change broke something, e2e asks whether predastore is correct.

## The gaps this makes visible

7 failing checks, 4 root causes:

| Root cause | Checks | Bead |
|---|---|---|
| ETag is not the body MD5 | `ETag is the body MD5`, `rclone copy (up)`, `rclone check` | `mulga-1xeqi` (P1) |
| CopyObject writes zero bytes | `CopyObject (server-side)` | `mulga-l29gl` (P0) |
| DeleteObjects returns 405 | `DeleteObjects (bulk)` | — |
| Registry resumable upload | `docker push`, `docker pull` | `mulga-agyde` (P2) |

Plus `torn-overwrite` on stress.

## Reporting

The baseline is still read in strict mode, to mark each failure as a known gap or a new one. Both scripts now write a job summary and emit annotations:

```
::warning::known gap: ETag is the body MD5
::error::REGRESSION: <check> passed in the baseline and fails now
```

## Baselines can be made to lie

Re-recording a baseline turns a fresh regression into an expected failure and the gate goes quiet. Growing the expected-failure count is now its own failure on a pull request, for both baseline files.

## Testing

Run locally against `2d80d9f`, with `GITHUB_ACTIONS` and `GITHUB_STEP_SUMMARY` set.

| Suite | Lenient | Strict |
|---|---|---|
| smoke, `image aws` | exit 0 | exit 2, 3 warning annotations |
| stress, `torn-overwrite` | exit 0 | exit 2, 1 warning annotation |

Job summaries render correctly for both. `shellcheck` clean on both scripts, `actionlint` clean on both workflows, `make preflight` passes.

Not verified locally: the `Guard the Baselines` step, which only runs on `pull_request` — this PR is its first execution.