### PR TITLE
feat: paginate ListObjectsV2

### DIFF
--- a/internal/gate/handlers/list_objects.go
+++ b/internal/gate/handlers/list_objects.go
@@ -2,17 +2,35 @@ package handlers
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/gob"
 	"log/slog"
 	"net/http"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/mulgadc/predastore/internal/meta"
 )
 
-// defaultMaxKeys is the page size S3 reports when the client asks for none.
+// defaultMaxKeys is the page size S3 reports when the client asks for none, and
+// the ceiling it clamps a larger request down to.
 const defaultMaxKeys = 1000
+
+// listEntry is one row of a listing: an object, or a common prefix standing in
+// for every key collapsed beneath it. Paging works on entries rather than on
+// raw keys because a delimiter turns many keys into one row.
+type listEntry struct {
+	// sortKey orders the listing and is what a continuation token names. It is
+	// the object key, or the common prefix including its trailing delimiter.
+	sortKey string
+	dir     bool
+	// hash keys the shard placement holding the object's size. Empty for a
+	// common prefix.
+	hash []byte
+}
 
 // ListObjects serves GET /{bucket} (ListObjectsV2). Objects are listed by
 // scanning their ARN keys in global state.
@@ -54,6 +72,28 @@ func ListObjects(mc MetaClient, cache *BucketCache) http.Handler {
 
 		prefix := query.Get("prefix")
 		delimiter := query.Get("delimiter")
+		startAfter := query.Get("start-after")
+		token := query.Get("continuation-token")
+
+		maxKeys, ok := parseMaxKeys(query.Get("max-keys"))
+		if !ok {
+			WriteS3Error(w, r, http.StatusBadRequest, string(model.ErrInvalidArgument),
+				"max-keys must be a non-negative integer")
+			return
+		}
+
+		// A continuation token supersedes start-after, and both resolve to the
+		// same thing: the last entry the client has already seen.
+		cursor := startAfter
+		if token != "" {
+			decoded, err := base64.StdEncoding.DecodeString(token)
+			if err != nil {
+				WriteS3Error(w, r, http.StatusBadRequest, string(model.ErrInvalidArgument),
+					"The continuation token provided is incorrect")
+				return
+			}
+			cursor = string(decoded)
+		}
 
 		items, err := metaScan(ctx, mc, model.TableObjects, objectARN(bucket, prefix), 0)
 		if err != nil {
@@ -61,45 +101,50 @@ func ListObjects(mc MetaClient, cache *BucketCache) http.Handler {
 			return
 		}
 
-		contents := make([]ListObjectsV2_Contents, 0, len(items))
+		entries := collapse(items, objectARN(bucket, ""), prefix, delimiter)
+
+		// The scan arrives in key order, but MetaClient promises nothing about
+		// ordering, and a cursor into an unordered listing drops and repeats
+		// keys without saying so.
+		sort.Slice(entries, func(i, j int) bool { return entries[i].sortKey < entries[j].sortKey })
+
+		if cursor != "" {
+			entries = entries[sort.Search(len(entries), func(i int) bool {
+				return entries[i].sortKey > cursor
+			}):]
+		}
+
+		// max-keys of zero is an empty listing, not a truncated one: there is no
+		// entry to name in a token, so a client told it was truncated would
+		// either stall or re-request the same empty page forever.
+		truncated := maxKeys > 0 && len(entries) > maxKeys
+		if len(entries) > maxKeys {
+			entries = entries[:maxKeys]
+		}
+
+		contents := make([]ListObjectsV2_Contents, 0, len(entries))
 		prefixes := make([]ListObjectsV2_Dir, 0)
-		seenPrefix := make(map[string]bool)
-
-		keyPrefix := objectARN(bucket, "")
-		for _, item := range items {
-			if !strings.HasPrefix(item.Key, keyPrefix) {
+		for _, entry := range entries {
+			if entry.dir {
+				prefixes = append(prefixes, ListObjectsV2_Dir{Prefix: entry.sortKey})
 				continue
-			}
-			objectKey := strings.TrimPrefix(item.Key, keyPrefix)
-
-			// A delimiter collapses everything below it into a common prefix, which
-			// is how S3 presents a flat keyspace as directories.
-			if delimiter != "" {
-				afterPrefix := strings.TrimPrefix(objectKey, prefix)
-				if idx := strings.Index(afterPrefix, delimiter); idx >= 0 {
-					dir := objectKey[:len(prefix)+idx+len(delimiter)]
-					if !seenPrefix[dir] {
-						seenPrefix[dir] = true
-						prefixes = append(prefixes, ListObjectsV2_Dir{Prefix: dir})
-					}
-					continue
-				}
 			}
 
 			// The listing row holds the object hash; the size lives with the shard
-			// placement it keys.
+			// placement it keys. Only the page is resolved, so the cost of a
+			// listing follows the page size rather than the bucket size.
 			var objectSize int64
-			if len(item.Value) == 32 {
-				if meta, err := metaGet(ctx, mc, model.TableObjects, string(item.Value)); err == nil && len(meta) > 0 {
+			if len(entry.hash) == 32 {
+				if row, err := metaGet(ctx, mc, model.TableObjects, string(entry.hash)); err == nil && len(row) > 0 {
 					var placement ObjectToShardNodes
-					if err := gob.NewDecoder(bytes.NewReader(meta)).Decode(&placement); err == nil {
+					if err := gob.NewDecoder(bytes.NewReader(row)).Decode(&placement); err == nil {
 						objectSize = placement.Size
 					}
 				}
 			}
 
 			contents = append(contents, ListObjectsV2_Contents{
-				Key:          objectKey,
+				Key:          entry.sortKey,
 				LastModified: time.Now(), // TODO: Store actual modification time
 				Size:         objectSize,
 				StorageClass: "STANDARD",
@@ -107,17 +152,69 @@ func ListObjects(mc MetaClient, cache *BucketCache) http.Handler {
 		}
 
 		result := ListObjectsV2{
-			Name:           bucket,
-			Prefix:         prefix,
-			KeyCount:       len(contents),
-			MaxKeys:        defaultMaxKeys,
-			IsTruncated:    false, // TODO: Implement pagination
-			Contents:       &contents,
-			CommonPrefixes: &prefixes,
+			Name:              bucket,
+			Prefix:            prefix,
+			Delimiter:         delimiter,
+			KeyCount:          len(contents) + len(prefixes),
+			MaxKeys:           maxKeys,
+			IsTruncated:       truncated,
+			ContinuationToken: token,
+			StartAfter:        startAfter,
+			Contents:          &contents,
+			CommonPrefixes:    &prefixes,
+		}
+		if truncated {
+			last := entries[len(entries)-1].sortKey
+			result.NextContinuationToken = base64.StdEncoding.EncodeToString([]byte(last))
 		}
 
 		if err := writeXML(w, http.StatusOK, result); err != nil {
 			slog.DebugContext(ctx, "failed to write XML response", "error", err)
 		}
 	})
+}
+
+// collapse turns scanned rows into listing entries, folding everything below a
+// delimiter into a single common prefix the way S3 presents a flat keyspace as
+// directories.
+func collapse(items []meta.Item, keyPrefix, prefix, delimiter string) []listEntry {
+	entries := make([]listEntry, 0, len(items))
+	seenPrefix := make(map[string]bool)
+
+	for _, item := range items {
+		if !strings.HasPrefix(item.Key, keyPrefix) {
+			continue
+		}
+		objectKey := strings.TrimPrefix(item.Key, keyPrefix)
+
+		if delimiter != "" {
+			afterPrefix := strings.TrimPrefix(objectKey, prefix)
+			if idx := strings.Index(afterPrefix, delimiter); idx >= 0 {
+				dir := objectKey[:len(prefix)+idx+len(delimiter)]
+				if !seenPrefix[dir] {
+					seenPrefix[dir] = true
+					entries = append(entries, listEntry{sortKey: dir, dir: true})
+				}
+				continue
+			}
+		}
+
+		entries = append(entries, listEntry{sortKey: objectKey, hash: item.Value})
+	}
+	return entries
+}
+
+// parseMaxKeys reads the client's page size. S3 clamps a request above 1000
+// rather than rejecting it, but a negative or non-numeric value is an error:
+// treating it as unlimited is how an unpaginated listing gets served to a
+// client that asked for a page.
+func parseMaxKeys(raw string) (int, bool) {
+	if raw == "" {
+		return defaultMaxKeys, true
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return min(n, defaultMaxKeys), true
 }

--- a/internal/gate/handlers/list_objects_test.go
+++ b/internal/gate/handlers/list_objects_test.go
@@ -1,0 +1,291 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const listTestBucket = "b"
+
+// listFixture is a bucket whose contents are listing rows in global state. The
+// rows carry no object hash, so sizes read back as zero; paging does not depend
+// on them.
+type listFixture struct {
+	mc      *fakeMeta
+	handler http.Handler
+}
+
+func newListFixture(t *testing.T, keys ...string) listFixture {
+	t.Helper()
+	mc := newFakeMeta()
+	for _, key := range keys {
+		require.NoError(t, metaPut(context.Background(), mc, model.TableObjects,
+			objectARN(listTestBucket, key), []byte("row")))
+	}
+	cache := NewBucketCache([]BucketConfig{{Name: listTestBucket, Region: "ap-southeast-2"}})
+	return listFixture{mc: mc, handler: ListObjects(mc, cache)}
+}
+
+// list issues one ListObjectsV2 request and decodes the answer.
+func (f listFixture) list(t *testing.T, query url.Values) ListObjectsV2 {
+	t.Helper()
+	rr := f.do(t, query)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var result ListObjectsV2
+	require.NoError(t, xml.NewDecoder(rr.Body).Decode(&result))
+	return result
+}
+
+func (f listFixture) do(t *testing.T, query url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/"+listTestBucket+"?"+query.Encode(), nil)
+	req = req.WithContext(WithBucket(req.Context(), model.Bucket{Name: listTestBucket}))
+	rr := httptest.NewRecorder()
+	f.handler.ServeHTTP(rr, req)
+	return rr
+}
+
+// walk pages the bucket to exhaustion the way an SDK paginator does, returning
+// every entry in the order the server produced it.
+func (f listFixture) walk(t *testing.T, query url.Values, pageSize int) []string {
+	t.Helper()
+	var got []string
+	page := url.Values{}
+	maps.Copy(page, query)
+	page.Set("max-keys", strconv.Itoa(pageSize))
+
+	for i := 0; ; i++ {
+		require.Less(t, i, 100, "paginator did not terminate")
+		result := f.list(t, page)
+
+		require.LessOrEqual(t, result.KeyCount, pageSize)
+
+		// The document carries objects and common prefixes as two lists, so
+		// their interleaving is not on the wire and a client reassembles it.
+		// Every entry on a page still sorts before every entry on the next.
+		var batch []string
+		for _, c := range contentsOf(result) {
+			batch = append(batch, c.Key)
+		}
+		for _, p := range prefixesOf(result) {
+			batch = append(batch, p.Prefix)
+		}
+		sort.Strings(batch)
+		got = append(got, batch...)
+
+		if !result.IsTruncated {
+			require.Empty(t, result.NextContinuationToken,
+				"a complete listing must not offer a token to follow")
+			return got
+		}
+		require.NotEmpty(t, result.NextContinuationToken,
+			"a truncated listing the client cannot resume is a silent short read")
+		page.Set("continuation-token", result.NextContinuationToken)
+	}
+}
+
+// An empty slice encodes to no elements at all, so the decoder leaves the
+// pointer nil rather than pointing at an empty slice.
+func contentsOf(r ListObjectsV2) []ListObjectsV2_Contents {
+	if r.Contents == nil {
+		return nil
+	}
+	return *r.Contents
+}
+
+func prefixesOf(r ListObjectsV2) []ListObjectsV2_Dir {
+	if r.CommonPrefixes == nil {
+		return nil
+	}
+	return *r.CommonPrefixes
+}
+
+func listKeys(n int) []string {
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("key-%03d", i)
+	}
+	return keys
+}
+
+// The defect this work exists for: a client paging a bucket larger than one
+// page either saw the whole bucket at once or stopped after the first page.
+func TestListObjectsPagesEveryKeyExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	want := listKeys(25)
+	f := newListFixture(t, want...)
+
+	assert.Equal(t, want, f.walk(t, url.Values{}, 4))
+}
+
+func TestListObjectsHonoursMaxKeys(t *testing.T) {
+	t.Parallel()
+
+	f := newListFixture(t, listKeys(10)...)
+	result := f.list(t, url.Values{"max-keys": {"3"}})
+
+	assert.True(t, result.IsTruncated)
+	assert.Equal(t, 3, result.KeyCount)
+	assert.Equal(t, 3, result.MaxKeys)
+	assert.Len(t, contentsOf(result), 3)
+}
+
+// MaxKeys used to report 1000 whatever the client asked for, which contradicts
+// the body it sits beside.
+func TestListObjectsMaxKeysClampsAndRejects(t *testing.T) {
+	t.Parallel()
+
+	f := newListFixture(t, listKeys(3)...)
+
+	t.Run("above the ceiling clamps", func(t *testing.T) {
+		t.Parallel()
+		result := f.list(t, url.Values{"max-keys": {"5000"}})
+		assert.Equal(t, defaultMaxKeys, result.MaxKeys)
+		assert.False(t, result.IsTruncated)
+	})
+
+	t.Run("absent is the default", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, defaultMaxKeys, f.list(t, url.Values{}).MaxKeys)
+	})
+
+	// Not truncated: a truncation flag with no token to follow either stalls
+	// the client or loops it on the same empty page.
+	t.Run("zero is an empty page", func(t *testing.T) {
+		t.Parallel()
+		result := f.list(t, url.Values{"max-keys": {"0"}})
+		assert.Equal(t, 0, result.KeyCount)
+		assert.False(t, result.IsTruncated)
+		assert.Empty(t, result.NextContinuationToken)
+	})
+
+	for _, bad := range []string{"-1", "not-a-number", "1.5"} {
+		t.Run("rejects "+bad, func(t *testing.T) {
+			t.Parallel()
+			rr := f.do(t, url.Values{"max-keys": {bad}})
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+			var s3err S3Error
+			require.NoError(t, xml.NewDecoder(rr.Body).Decode(&s3err))
+			assert.Equal(t, string(model.ErrInvalidArgument), s3err.Code)
+		})
+	}
+}
+
+func TestListObjectsStartAfter(t *testing.T) {
+	t.Parallel()
+
+	f := newListFixture(t, "a", "b", "c", "d")
+	result := f.list(t, url.Values{"start-after": {"b"}})
+
+	assert.Equal(t, 2, result.KeyCount)
+	assert.Equal(t, "c", (contentsOf(result))[0].Key)
+	assert.Equal(t, "b", result.StartAfter, "S3 echoes the parameter back")
+}
+
+func TestListObjectsStartAfterComposesWithPrefix(t *testing.T) {
+	t.Parallel()
+
+	f := newListFixture(t, "logs/1", "logs/2", "logs/3", "other/1")
+	result := f.list(t, url.Values{"prefix": {"logs/"}, "start-after": {"logs/1"}})
+
+	require.Len(t, contentsOf(result), 2)
+	assert.Equal(t, "logs/2", (contentsOf(result))[0].Key)
+	assert.Equal(t, "logs/3", (contentsOf(result))[1].Key)
+}
+
+// A continuation token is opaque, so a client sending one back must not have to
+// know it is a key. It also wins over start-after, which is what S3 does.
+func TestListObjectsContinuationTokenSupersedesStartAfter(t *testing.T) {
+	t.Parallel()
+
+	f := newListFixture(t, "a", "b", "c", "d")
+	token := base64.StdEncoding.EncodeToString([]byte("c"))
+
+	result := f.list(t, url.Values{
+		"continuation-token": {token},
+		"start-after":        {"a"},
+	})
+
+	require.Len(t, contentsOf(result), 1)
+	assert.Equal(t, "d", (contentsOf(result))[0].Key)
+	assert.Equal(t, token, result.ContinuationToken)
+}
+
+func TestListObjectsRejectsUndecodableToken(t *testing.T) {
+	t.Parallel()
+
+	f := newListFixture(t, "a")
+	rr := f.do(t, url.Values{"continuation-token": {"not!base64"}})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+// A delimiter collapses many keys into one row, so a page boundary can land on
+// a common prefix. Resuming from one has to skip everything underneath it
+// rather than re-listing the keys it stands for.
+func TestListObjectsPagesCommonPrefixes(t *testing.T) {
+	t.Parallel()
+
+	f := newListFixture(t,
+		"a/1", "a/2", "a/3",
+		"b/1", "b/2",
+		"c/1",
+		"top",
+	)
+
+	got := f.walk(t, url.Values{"delimiter": {"/"}}, 2)
+	assert.Equal(t, []string{"a/", "b/", "c/", "top"}, got)
+}
+
+// Common prefixes count against max-keys the same as keys do. Counting only
+// objects lets a listing of nothing but directories never terminate.
+func TestListObjectsCountsCommonPrefixesTowardsTheLimit(t *testing.T) {
+	t.Parallel()
+
+	f := newListFixture(t, "a/1", "b/1", "c/1")
+	result := f.list(t, url.Values{"delimiter": {"/"}, "max-keys": {"2"}})
+
+	assert.Equal(t, 2, result.KeyCount)
+	assert.Len(t, prefixesOf(result), 2)
+	assert.Empty(t, contentsOf(result))
+	assert.True(t, result.IsTruncated)
+}
+
+func TestListObjectsEchoesDelimiter(t *testing.T) {
+	t.Parallel()
+
+	f := newListFixture(t, "a/1")
+	assert.Equal(t, "/", f.list(t, url.Values{"delimiter": {"/"}}).Delimiter)
+}
+
+// Every page size must produce the same listing, or the cursor is losing or
+// repeating entries at some boundary a single page size would not reveal.
+func TestListObjectsPagingIsIndependentOfPageSize(t *testing.T) {
+	t.Parallel()
+
+	keys := listKeys(17)
+	f := newListFixture(t, keys...)
+
+	for _, size := range []int{1, 2, 3, 5, 16, 17, 18, 100} {
+		t.Run(strconv.Itoa(size), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, keys, f.walk(t, url.Values{}, size))
+		})
+	}
+}

--- a/internal/gate/handlers/xmltypes.go
+++ b/internal/gate/handlers/xmltypes.go
@@ -22,15 +22,22 @@ type ListObjectsV2_Contents struct {
 	StorageClass string    `xml:"StorageClass"`
 }
 
+// ListObjectsV2 answers GET /{bucket}. The cursor fields are omitted when
+// empty: a client that sees an empty NextContinuationToken on a truncated
+// listing has no way to tell it apart from one it can follow.
 type ListObjectsV2 struct {
-	XMLName        xml.Name                  `xml:"ListBucketResult"`
-	Name           string                    `xml:"Name"`
-	Prefix         string                    `xml:"Prefix"`
-	KeyCount       int                       `xml:"KeyCount"`
-	MaxKeys        int                       `xml:"MaxKeys"`
-	IsTruncated    bool                      `xml:"IsTruncated"`
-	Contents       *[]ListObjectsV2_Contents `xml:"Contents"`
-	CommonPrefixes *[]ListObjectsV2_Dir      `xml:"CommonPrefixes"`
+	XMLName               xml.Name                  `xml:"ListBucketResult"`
+	Name                  string                    `xml:"Name"`
+	Prefix                string                    `xml:"Prefix"`
+	Delimiter             string                    `xml:"Delimiter,omitempty"`
+	KeyCount              int                       `xml:"KeyCount"`
+	MaxKeys               int                       `xml:"MaxKeys"`
+	IsTruncated           bool                      `xml:"IsTruncated"`
+	ContinuationToken     string                    `xml:"ContinuationToken,omitempty"`
+	NextContinuationToken string                    `xml:"NextContinuationToken,omitempty"`
+	StartAfter            string                    `xml:"StartAfter,omitempty"`
+	Contents              *[]ListObjectsV2_Contents `xml:"Contents"`
+	CommonPrefixes        *[]ListObjectsV2_Dir      `xml:"CommonPrefixes"`
 }
 
 /*

--- a/scripts/smoke-baseline.txt
+++ b/scripts/smoke-baseline.txt
@@ -11,6 +11,7 @@ PASS|HeadObject
 PASS|GetObject
 PASS|GetObject (range)
 PASS|Multipart upload (16 MiB)
+PASS|ListObjectsV2 pagination
 FAIL|ETag is the body MD5
 FAIL|CopyObject (server-side)
 FAIL|DeleteObjects (bulk)

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -253,6 +253,39 @@ if run_suite aws; then
     head -c 16777216 /dev/urandom > "$WORK/multi.bin"
     check "Multipart upload (16 MiB)" aws_cli s3 cp /work/multi.bin "s3://$B/multi.bin"
 
+    # Two assertions, because either one alone passes against a server with no
+    # pagination at all. A paginator sent the whole prefix on page one stops
+    # happy, and a single unfollowed page proves nothing about resuming.
+    paginator_walks_every_key() {
+        local want=7 count truncated keys total unique
+        for i in 1 2 3 4 5 6 7; do
+            aws_cli s3 cp /work/hello.txt "s3://$B/page/$i" >/dev/null || return 1
+        done
+
+        # One page, not followed: the server has to bound it and say so.
+        count=$(aws_cli s3api list-objects-v2 --bucket "$B" --prefix "page/" \
+            --max-keys 2 --no-paginate --query 'length(Contents)' --output text 2>/dev/null)
+        truncated=$(aws_cli s3api list-objects-v2 --bucket "$B" --prefix "page/" \
+            --max-keys 2 --no-paginate --query 'IsTruncated' --output text 2>/dev/null)
+        if [ "$count" != "2" ] || [ "$truncated" != "True" ]; then
+            echo "max-keys=2 returned $count keys with IsTruncated=$truncated, want 2 and True"
+            return 1
+        fi
+
+        # Then the whole walk, following NextContinuationToken to exhaustion.
+        keys=$(aws_cli s3api list-objects-v2 --bucket "$B" --prefix "page/" \
+            --page-size 2 --query 'Contents[].Key' --output text 2>/dev/null \
+            | tr '\t' '\n' | grep '^page/')
+        total=$(printf '%s\n' "$keys" | grep -c .)
+        unique=$(printf '%s\n' "$keys" | sort -u | grep -c .)
+        if [ "$total" != "$want" ] || [ "$unique" != "$want" ]; then
+            echo "paged listing returned $total keys ($unique unique), want $want"
+            return 1
+        fi
+        return 0
+    }
+    check "ListObjectsV2 pagination"  paginator_walks_every_key
+
     # Content assertions. Each of these currently fails, and each is asserted
     # on what came back rather than on a status code, because that is the
     # difference between naming the defect and recording a pass.


### PR DESCRIPTION
## Summary

`GET /{bucket}` read only `prefix` and `delimiter`. It scanned every matching key and returned the whole set, reported `MaxKeys` as 1000 whatever the client asked for, and always sent `IsTruncated: false` under a `// TODO: Implement pagination`.

That gives a caller one of two wrong answers depending on its SDK. A paginator asking for 100 keys receives the entire bucket, in a response whose `MaxKeys` contradicts the request. A caller that pages by cursor gets one page and a flag saying the listing is complete, so it stops — every key past the first page is invisible and nothing errors. `spinifex`'s `ebsmetadata` `listDocuments` is the second shape, which is `mulga-1d8kt` and could not be fixed while the server was unable to truncate.

The handler now reads `continuation-token`, `start-after` and `max-keys`, and answers a truncated listing with a `NextContinuationToken` that resumes exactly where the page ended.

Closes `mulga-756`.

## How it works

**Paging is over listing entries, not raw keys.** A delimiter collapses many keys into one common prefix, so the number of keys that fills a page is not knowable before the collapse. The handler builds an ordered list of entries — each an object or a common prefix — and pages that. Common prefixes count against `max-keys` the same as keys do, which is what S3 does and what makes a listing of nothing but directories terminate.

**The token is base64 of the last entry emitted.** Resumption drops every entry sorting at or below the decoded cursor, which is the same comparison `start-after` performs, so both go through one path. Base64 keeps it opaque and lets object keys hold bytes that would not survive a URL round trip. A `continuation-token` supersedes `start-after` when both arrive, matching S3.

**Sizes are resolved for the page.** Previously every key in the bucket cost a metadata read whether or not it was returned. Now a listing costs one read per key it actually answers with.

**Entries are sorted in the handler.** Badger already iterates a prefix in key order, but `MetaClient` promises nothing about ordering and a cursor into an unordered listing drops and repeats keys silently. The sort puts the guarantee next to the code depending on it.

**`max-keys=0` is an empty listing, not a truncated one.** There is no entry to name in a token, so a client told it was truncated would either stall or re-request the same empty page forever.

Negative or non-numeric `max-keys` and an undecodable token are both `InvalidArgument`. Values above 1000 clamp rather than fail.

## Testing

Eleven unit tests against the `fakeMeta` stub. The load-bearing one walks a 17-key bucket at page sizes 1, 2, 3, 5, 16, 17, 18 and 100 and asserts every size produces the identical listing — a cursor that loses or repeats an entry at some boundary will not survive all eight. Others cover `max-keys` honoured, clamped and rejected, `start-after` composing with `prefix`, the token superseding `start-after`, a page boundary landing on a common prefix, and common prefixes counting toward the limit.

The smoke suite gains `ListObjectsV2 pagination`, which asserts both halves. First that an unfollowed `--max-keys 2` page comes back bounded and says it is truncated, then that following the token walks all seven keys exactly once. Either assertion alone passes against a server with no pagination at all — the paginator half was written first and passed against unmodified `dev`, because a server that hands over the whole prefix on page one looks identical to a complete listing.

Verified both ways on a single-node cluster. Against `dev`'s handler:

```
✗ ListObjectsV2 pagination
    max-keys=2 returned 7 keys with IsTruncated=False, want 2 and True
REGRESSION ListObjectsV2 pagination passed in the baseline and fails now
```

Against this branch it passes, and the full `image aws` suite is otherwise unchanged: 3 failures, the same three the baseline already records (`ETag is the body MD5`, `CopyObject (server-side)`, `DeleteObjects (bulk)`). `make preflight` is green and `shellcheck` is clean on `smoke.sh`.

## Note on #112

#112 rewrites the size-lookup block this change also touches, to read a real `LastModified` off the placement. The conflict is about ten lines in one function and resolves either way. This branch leaves `LastModified: time.Now()` alone rather than fixing it here, to keep that conflict as small as possible.

## Out of scope

- `LastModified` is still `time.Now()`, fixed on #112.
- Pushing the page limit into the meta scan. `meta.Client.Scan` starts at a prefix and cannot start at a cursor, so every page still rebuilds the full listing. Memory per request is unchanged from today; the response is what got bounded.
- `ListMultipartUploads`, separately unpaginated and documented as such in its type.