### PR TITLE
fix: bound a shard commit by the disk rather than the round trip

### DIFF
--- a/internal/blob/client.go
+++ b/internal/blob/client.go
@@ -26,6 +26,13 @@ var (
 	// one repair is responsible for clearing.
 	ErrEpochMismatch = errors.New("shard held under a different write epoch")
 
+	// ErrCommitUnknown is returned by puts whose body was delivered in full
+	// but whose result never came back within the commit bound. The shard may
+	// be prepared on the node or may not: we gave up, the node did not refuse.
+	// Treating it as a shard that never arrived is what makes a slow drive
+	// look like a lost write.
+	ErrCommitUnknown = errors.New("put outcome unknown: no result within the commit bound")
+
 	// ErrNotPrepared is returned by commits when the node has nothing prepared
 	// under that epoch. The answer is to rewrite the shard, not to retry.
 	ErrNotPrepared = errors.New("no prepared shard under that epoch")
@@ -101,6 +108,10 @@ type DeleteResponse struct {
 const (
 	DefaultEnvelopeTimeout = 10 * time.Second
 	DefaultIdleTimeout     = 30 * time.Second
+	// DefaultCommitTimeout sits above the kernel's 30s NVMe io_timeout so a
+	// device that stalls and then completes is waited out. Below it, a drive
+	// whose completion interrupts are late fails every write it does land.
+	DefaultCommitTimeout = 45 * time.Second
 )
 
 // Client performs value operations against blob nodes over rpc streams,
@@ -109,6 +120,7 @@ type Client struct {
 	rpc             *rpc.Client
 	envelopeTimeout time.Duration
 	idleTimeout     time.Duration
+	commitTimeout   time.Duration
 }
 
 type ClientConfig struct {
@@ -124,6 +136,11 @@ type ClientConfig struct {
 	// deliberately not a total duration: a large value transferring steadily
 	// must not be cut off, while one that stalls must not block forever.
 	IdleTimeout time.Duration
+	// CommitTimeout bounds the envelopes a node cannot send until it has
+	// fsynced: a put's response, and commit and abort. Their size is fixed
+	// but their timing is the disk's, so they do not belong under
+	// EnvelopeTimeout however small they are on the wire.
+	CommitTimeout time.Duration
 }
 
 func NewClient(cfg ClientConfig) (*Client, error) {
@@ -136,10 +153,14 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 	if cfg.IdleTimeout <= 0 {
 		cfg.IdleTimeout = DefaultIdleTimeout
 	}
+	if cfg.CommitTimeout <= 0 {
+		cfg.CommitTimeout = DefaultCommitTimeout
+	}
 	return &Client{
 		rpc:             cfg.Client,
 		envelopeTimeout: cfg.EnvelopeTimeout,
 		idleTimeout:     cfg.IdleTimeout,
+		commitTimeout:   cfg.CommitTimeout,
 	}, nil
 }
 
@@ -199,11 +220,23 @@ func (c *Client) openBounded(ctx context.Context, nodeID config.NodeID, op rpc.O
 	return c.open(openCtx, nodeID, op, h)
 }
 
-// awaitEnvelope reads the response envelope under a total cap, aborting the
-// read side if the peer goes quiet. This is where an unbounded client blocks
-// forever against a node that accepts a stream and never answers.
+// awaitEnvelope reads the response envelope under the envelope bound, for the
+// exchanges whose timing is the network's alone.
 func (c *Client) awaitEnvelope(ctx context.Context, stream transport.Stream, br *bufio.Reader) (*Response, error) {
-	respCtx, cancel := context.WithTimeout(ctx, c.envelopeTimeout)
+	return c.awaitEnvelopeWithin(ctx, stream, br, c.envelopeTimeout)
+}
+
+// awaitEnvelopeWithin reads the response envelope under a total cap, aborting
+// the read side if the peer goes quiet. This is where an unbounded client
+// blocks forever against a node that accepts a stream and never answers.
+//
+// The bound is the caller's because the same envelope means different things:
+// after a put it is not sent until the shard is fsynced, so capping it at a
+// round trip caps the disk.
+func (c *Client) awaitEnvelopeWithin(
+	ctx context.Context, stream transport.Stream, br *bufio.Reader, within time.Duration,
+) (*Response, error) {
+	respCtx, cancel := context.WithTimeout(ctx, within)
 	defer cancel()
 	stop := context.AfterFunc(respCtx, func() { stream.CancelRead(0) })
 	defer stop()
@@ -254,9 +287,17 @@ func (c *Client) Put(ctx context.Context, nodeID config.NodeID, req PutRequest, 
 	}
 	stopCaller()
 
-	resp, err := c.awaitEnvelope(ctx, stream, bufio.NewReader(stream))
+	// The node does not answer until the shard is durable, so this waits on
+	// the disk and is bounded as such.
+	resp, err := c.awaitEnvelopeWithin(ctx, stream, bufio.NewReader(stream), c.commitTimeout)
 	if err != nil {
 		stream.CancelRead(0)
+		// The body is already delivered and half-closed, so a node that has
+		// not answered may still be committing. Say so, rather than reporting
+		// a refusal we never received.
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("put to node %d: %w: %w", nodeID, ErrCommitUnknown, err)
+		}
 		return nil, fmt.Errorf("put to node %d: %w", nodeID, err)
 	}
 	switch resp.Err {
@@ -372,7 +413,9 @@ func (c *Client) finish(ctx context.Context, nodeID config.NodeID, op rpc.Opcode
 		abortStream(stream)
 		return nil, fmt.Errorf("half-close %s stream: %w", name, err)
 	}
-	resp, err := c.awaitEnvelope(ctx, stream, bufio.NewReader(stream))
+	// Publishing and discarding both reach the disk, so they are bounded by it
+	// rather than by the round trip that carries them.
+	resp, err := c.awaitEnvelopeWithin(ctx, stream, bufio.NewReader(stream), c.commitTimeout)
 	if err != nil {
 		stream.CancelRead(0)
 		return nil, fmt.Errorf("%s on node %d: %w", name, nodeID, err)

--- a/internal/blob/slow_commit_test.go
+++ b/internal/blob/slow_commit_test.go
@@ -1,0 +1,335 @@
+package blob_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore/internal/blob"
+	"github.com/mulgadc/predastore/internal/blob/engine"
+	"github.com/mulgadc/predastore/internal/config"
+	"github.com/mulgadc/predastore/internal/rpc"
+	"github.com/mulgadc/predastore/internal/transport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// slowCommitStore is a healthy store on a drive whose completion interrupts
+// are late. Every write lands; only the fsync in Close is delayed, which is
+// what "I/O tag N QID nn timeout, completion polled" describes.
+type slowCommitStore struct {
+	commitDelay time.Duration
+	// readDelay stalls the server before it drains the body, which is what a
+	// mid-transfer device stall looks like from the other end of the stream.
+	readDelay time.Duration
+
+	mu        sync.Mutex
+	prepared  map[uint32]preparedValue
+	published map[uint32]preparedValue
+}
+
+type preparedValue struct {
+	data  []byte
+	epoch uint64
+}
+
+func newSlowCommitStore(commitDelay, readDelay time.Duration) *slowCommitStore {
+	return &slowCommitStore{
+		commitDelay: commitDelay,
+		readDelay:   readDelay,
+		prepared:    map[uint32]preparedValue{},
+		published:   map[uint32]preparedValue{},
+	}
+}
+
+func (s *slowCommitStore) Append(_ [32]byte, index uint32, _ int64, epoch uint64) (engine.Writer, error) {
+	return &slowCommitWriter{store: s, index: index, epoch: epoch}, nil
+}
+
+func (s *slowCommitStore) Lookup(_ [32]byte, index uint32) (engine.Reader, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.published[index]
+	if !ok {
+		return nil, engine.ErrKeyNotFound
+	}
+
+	return &sectionReader{Reader: bytes.NewReader(v.data), size: int64(len(v.data)), epoch: v.epoch}, nil
+}
+
+// Commit publishes a prepared value. It is idempotent against the epoch so a
+// retry of one already applied succeeds rather than reporting a lost write,
+// and publishing is forward-only: losing to a higher epoch reports
+// published=false rather than an error, which is last-write-wins.
+func (s *slowCommitStore) Commit(_ [32]byte, index uint32, epoch uint64) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if v, ok := s.published[index]; ok {
+		if v.epoch == epoch {
+			return true, nil
+		}
+		if v.epoch > epoch {
+			return false, nil
+		}
+	}
+	v, ok := s.prepared[index]
+	if !ok || v.epoch != epoch {
+		return false, engine.ErrNotPrepared
+	}
+	s.published[index] = v
+	delete(s.prepared, index)
+
+	return true, nil
+}
+
+// LookupAt serves a named generation, which the read path uses to reach a
+// shard the placement record still points at.
+func (s *slowCommitStore) LookupAt(_ [32]byte, index uint32, epoch uint64) (engine.Reader, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, set := range []map[uint32]preparedValue{s.published, s.prepared} {
+		if v, ok := set[index]; ok && v.epoch == epoch {
+			return &sectionReader{Reader: bytes.NewReader(v.data), size: int64(len(v.data)), epoch: v.epoch}, nil
+		}
+	}
+
+	return nil, engine.ErrKeyNotFound
+}
+
+func (s *slowCommitStore) Abort(_ [32]byte, index uint32, epoch uint64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if v, ok := s.prepared[index]; ok && v.epoch == epoch {
+		delete(s.prepared, index)
+	}
+
+	return nil
+}
+
+func (s *slowCommitStore) Delete(_ [32]byte, _ uint32) (bool, error) { return false, nil }
+func (s *slowCommitStore) NearFull() bool                            { return false }
+func (s *slowCommitStore) Close() error                              { return nil }
+
+// Prepared is what reached the platter, whatever the caller was told.
+func (s *slowCommitStore) Prepared(index uint32) (preparedValue, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.prepared[index]
+
+	return v, ok
+}
+
+type sectionReader struct {
+	*bytes.Reader
+
+	size  int64
+	epoch uint64
+}
+
+func (r *sectionReader) Size() int64   { return r.size }
+func (r *sectionReader) Epoch() uint64 { return r.epoch }
+func (r *sectionReader) Close() error  { return nil }
+
+type slowCommitWriter struct {
+	store *slowCommitStore
+	index uint32
+	epoch uint64
+	buf   bytes.Buffer
+}
+
+func (w *slowCommitWriter) Write(p []byte) (int, error) { return w.buf.Write(p) }
+
+func (w *slowCommitWriter) ReadFrom(r io.Reader) (int64, error) {
+	time.Sleep(w.store.readDelay)
+
+	return w.buf.ReadFrom(r)
+}
+
+// Close is the prepare: two fsyncs in the real engine, and the only thing the
+// stalling drive delays. It still succeeds.
+func (w *slowCommitWriter) Close() error {
+	time.Sleep(w.store.commitDelay)
+	w.store.mu.Lock()
+	defer w.store.mu.Unlock()
+	w.store.prepared[w.index] = preparedValue{
+		data:  append([]byte(nil), w.buf.Bytes()...),
+		epoch: w.epoch,
+	}
+
+	return nil
+}
+
+const (
+	slowServerPort = 6311
+	slowClientPort = 6312
+	slowEpoch      = uint64(0x1234)
+)
+
+// startSlowCommitNode runs a real blob.Server over a store whose commit is
+// slow, and returns a client pointed at it plus the store to inspect.
+// envelopeTimeout is deliberately separate from commitTimeout in every case
+// here: setting it short is what proves which bound the put is actually under.
+func startSlowCommitNode(
+	t *testing.T, commitDelay, readDelay, envelopeTimeout, commitTimeout, idleTimeout time.Duration,
+) (*blob.Client, *slowCommitStore) {
+	t.Helper()
+
+	clusterCfg := &config.Config{
+		Hosts: []config.Host{{
+			ID:   1,
+			Addr: hostileHost,
+			Nodes: []config.Node{
+				{ID: 1, Role: config.RoleBlob, Port: slowServerPort},
+				{ID: 2, Role: config.RoleBlob, Port: slowClientPort},
+			},
+		}},
+	}
+
+	serverTr := transport.NewPipeTransport(hostileHost, slowServerPort)
+	t.Cleanup(func() { serverTr.Close() })
+	ln, err := serverTr.Listen()
+	require.NoError(t, err)
+
+	store := newSlowCommitStore(commitDelay, readDelay)
+	srv, err := blob.New(blob.Config{
+		NodeID:    1,
+		DataDir:   t.TempDir(),
+		Store:     store,
+		Listeners: []transport.Listener{ln},
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+
+	clientTr := transport.NewPipeTransport(hostileHost, slowClientPort)
+	t.Cleanup(func() { clientTr.Close() })
+	clientRes, err := rpc.NewResolver(clusterCfg, 2, clientTr)
+	require.NoError(t, err)
+
+	client, err := blob.NewClient(blob.ClientConfig{
+		Client:          rpc.NewClient(rpc.NewConnPool(2, clientRes)),
+		EnvelopeTimeout: envelopeTimeout,
+		CommitTimeout:   commitTimeout,
+		IdleTimeout:     idleTimeout,
+	})
+	require.NoError(t, err)
+
+	return client, store
+}
+
+// A blob node on a drive that stalls its commit used to fail every put,
+// because the response envelope was capped at EnvelopeTimeout and handlePut
+// does not send it until the shard is fsynced. The cap was on the disk.
+// CommitTimeout is the bound that belongs there, and it is set above the
+// kernel's 30s io_timeout for that reason.
+func TestPutWaitsOutASlowCommit(t *testing.T) {
+	const (
+		// Shorter than the commit it has to survive: if the put is bounded by
+		// this, as it was, the write fails on a drive that is merely slow.
+		envelopeTimeout = 300 * time.Millisecond
+		commitTimeout   = 5 * time.Second
+		idleTimeout     = 30 * time.Second
+		commitDelay     = 750 * time.Millisecond
+	)
+
+	client, store := startSlowCommitNode(t, commitDelay, 0, envelopeTimeout, commitTimeout, idleTimeout)
+	payload := bytes.Repeat([]byte("x"), 4096)
+
+	start := time.Now()
+	resp, err := client.Put(context.Background(), serverNode,
+		blob.PutRequest{Key: [32]byte{1}, Index: 0, Size: int64(len(payload)), Epoch: slowEpoch},
+		bytes.NewReader(payload))
+	elapsed := time.Since(start)
+
+	require.NoError(t, err, "a commit slower than a round trip is not a failed write")
+	assert.Equal(t, int64(len(payload)), resp.Size)
+	assert.GreaterOrEqual(t, elapsed, commitDelay,
+		"the put should have waited for the commit rather than racing it")
+
+	// What the caller was told matches what is on the platter.
+	prepared, ok := store.Prepared(0)
+	require.True(t, ok, "the shard should be prepared")
+	assert.Equal(t, payload, prepared.data)
+	assert.Equal(t, slowEpoch, prepared.epoch)
+}
+
+// TestPutReportsAnAbandonedCommitAsUnknown covers the residual case: a commit
+// slower than even the commit bound. The shard may still land, so the put says
+// the outcome is unknown rather than reporting a refusal it never received.
+// The gate settles it by committing, which is what stops a slow drive being
+// scored as lost redundancy.
+func TestPutReportsAnAbandonedCommitAsUnknown(t *testing.T) {
+	const (
+		envelopeTimeout = 10 * time.Second
+		commitTimeout   = 300 * time.Millisecond
+		idleTimeout     = 30 * time.Second
+		commitDelay     = 900 * time.Millisecond
+	)
+
+	client, store := startSlowCommitNode(t, commitDelay, 0, envelopeTimeout, commitTimeout, idleTimeout)
+	payload := bytes.Repeat([]byte("x"), 4096)
+
+	_, err := client.Put(context.Background(), serverNode,
+		blob.PutRequest{Key: [32]byte{2}, Index: 1, Size: int64(len(payload)), Epoch: slowEpoch},
+		bytes.NewReader(payload))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, blob.ErrCommitUnknown,
+		"a node that took the body and went quiet has not refused the write")
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+
+	// The write the caller was told nothing about lands anyway, and the commit
+	// the gate issues after publishing the record finds it there.
+	assert.Eventually(t, func() bool {
+		_, ok := store.Prepared(1)
+
+		return ok
+	}, 5*time.Second, 20*time.Millisecond, "the abandoned put should still have landed")
+
+	overtaken, err := client.Commit(context.Background(), serverNode,
+		blob.CommitRequest{Key: [32]byte{2}, Index: 1, Epoch: slowEpoch})
+	require.NoError(t, err,
+		"committing an abandoned put is how the gate learns it was only slow")
+	assert.False(t, overtaken, "nothing newer raced it, so this epoch is the live one")
+}
+
+// TestPutBodyStallTripsTheIdleGuard is the other half of the same fault: when
+// the drive stalls while the body is still arriving, the server stops reading
+// the stream and the write guard aborts it. That is a transfer making no
+// progress rather than a slow commit, so it must stay bounded by the idle
+// timeout and must not be waited out.
+func TestPutBodyStallTripsTheIdleGuard(t *testing.T) {
+	const (
+		envelopeTimeout = 10 * time.Second
+		commitTimeout   = 45 * time.Second
+		idleTimeout     = 300 * time.Millisecond
+		readDelay       = 3 * time.Second
+	)
+
+	client, _ := startSlowCommitNode(t, 0, readDelay, envelopeTimeout, commitTimeout, idleTimeout)
+
+	// Larger than the stream's flow-control window, so a server that is not
+	// draining blocks the client's writes rather than absorbing them.
+	payload := bytes.Repeat([]byte("x"), 8<<20)
+
+	start := time.Now()
+	_, err := client.Put(context.Background(), serverNode,
+		blob.PutRequest{Key: [32]byte{3}, Index: 2, Size: int64(len(payload)), Epoch: slowEpoch},
+		bytes.NewReader(payload))
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, transport.ErrIdleTimeout)
+	assert.NotErrorIs(t, err, blob.ErrCommitUnknown,
+		"a body that never arrived cannot have prepared a shard")
+	assert.Less(t, elapsed, readDelay, "the guard should fire at the idle timeout")
+}

--- a/internal/gate/handlers/abandoned_put_test.go
+++ b/internal/gate/handlers/abandoned_put_test.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// abandonedFixture is a write fixture with one shard position on a node that
+// prepares the shard and then does not report in time, which is what a drive
+// with late completion interrupts looks like to the write path.
+func abandonedFixture(t *testing.T, data, parity int, slow uint32) writeFixture {
+	t.Helper()
+
+	f := newWriteFixture(data, parity)
+	f.cfg.DegradedWrites = true
+	f.bc.abandonPutOn = func(index uint32) bool { return index == slow }
+
+	return f
+}
+
+// A node that takes the body and goes quiet has not refused the write.
+// Counting it missing is what made a drive that was only slow look like a
+// cluster losing redundancy on every object.
+func TestAnAbandonedPutIsNotCountedMissing(t *testing.T) {
+	t.Parallel()
+
+	f := abandonedFixture(t, 2, 1, 1)
+	want := randomBytes(t, 1<<16)
+
+	ctx := context.Background()
+	objectHash := model.ObjectHash("b", "k")
+	place, written, err := f.write(ctx, objectHash, bytes.NewReader(want), int64(len(want)))
+
+	require.NoError(t, err)
+	assert.Equal(t, []int{1}, written.ambiguous, "the position has to be recorded as unsettled")
+	assert.Empty(t, written.missing, "nothing was refused, so nothing is missing")
+	assert.False(t, written.degraded(), "a shard that is present is not lost redundancy")
+
+	// The commit the fixture issues after the record settles it, so the object
+	// reads back at full width rather than being reconstructed from parity.
+	got, _, err := readObject(ctx, f.bc, f.cfg, "b", "k", place, place.Size, 0)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+// The record keeps naming the node the shard was aimed at, which is what lets
+// a read find it there and complete the commit itself.
+func TestAnAbandonedPutKeepsItsHolderInTheRecord(t *testing.T) {
+	t.Parallel()
+
+	f := abandonedFixture(t, 2, 1, 2)
+	body := randomBytes(t, 1<<15)
+
+	objectHash := model.ObjectHash("b", "k")
+	place, written, err := f.write(context.Background(), objectHash,
+		bytes.NewReader(body), int64(len(body)))
+
+	require.NoError(t, err)
+	require.Equal(t, []int{2}, written.ambiguous)
+	assert.Equal(t, place.AllNodes()[2], written.holders[2],
+		"an unsettled position must still point at the node that has the shard")
+}
+
+// The commit that settles an ambiguous position has to actually be sent, or
+// the shard stays prepared and invisible until some later read stumbles on it.
+func TestAnAbandonedPutIsCommittedNotSkipped(t *testing.T) {
+	t.Parallel()
+
+	f := abandonedFixture(t, 2, 1, 0)
+	body := randomBytes(t, 1<<15)
+
+	_, written, err := f.write(context.Background(), model.ObjectHash("b", "k"),
+		bytes.NewReader(body), int64(len(body)))
+
+	require.NoError(t, err)
+	require.Equal(t, []int{0}, written.ambiguous)
+	assert.Equal(t, int64(f.cfg.TotalShards()), f.bc.commitCalls.Load(),
+		"every position, settled or not, has to be committed")
+}
+
+// A write acknowledged to the client must not claim redundancy it has not
+// proved, so an unsettled position still says nothing in the degraded header.
+func TestPutObjectOmitsTheDegradedHeaderForAnAbandonedPut(t *testing.T) {
+	t.Parallel()
+
+	f := abandonedFixture(t, 2, 1, 1)
+	w := httptest.NewRecorder()
+
+	PutObject(f.mc, f.bc, f.ring, testCache(), f.cfg).
+		ServeHTTP(w, objectPut("k", randomBytes(t, 1<<15)))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get(degradedWriteHeader),
+		"a shard that turned out to be present is not a degraded write")
+}

--- a/internal/gate/handlers/shards.go
+++ b/internal/gate/handlers/shards.go
@@ -75,6 +75,12 @@ type writeResult struct {
 	// other or neither, never both.
 	missing []config.NodeID
 	handoff []int
+
+	// ambiguous names the positions whose node took the whole body and then
+	// did not report. The shard may be prepared there or may not, so it counts
+	// toward neither the floor nor the degraded signal, and the commit that
+	// follows the record settles it either way.
+	ambiguous []int
 }
 
 func (r writeResult) landedCount() int {
@@ -539,9 +545,17 @@ func collectStreams(ctx context.Context, cfg Config, streams []*shardStream, res
 			if firstErr == nil {
 				firstErr = outcome.err
 			}
+			logShardWriteFailure(ctx, s.holder, i, outcome.err)
+			// The holder took the body and went quiet. Leave it named in the
+			// record so a read finds the shard if it is there, and let the
+			// commit phase decide; a refusal we never received is not one.
+			if errors.Is(outcome.err, blob.ErrCommitUnknown) {
+				result.ambiguous = append(result.ambiguous, i)
+
+				continue
+			}
 			result.holders[i] = s.owner
 			result.missing = append(result.missing, s.owner)
-			logShardWriteFailure(ctx, s.holder, i, outcome.err)
 
 			continue
 		}
@@ -620,6 +634,17 @@ func commitShards(ctx context.Context, bc BlobClient, objectHash [32]byte, place
 			Index: uint32(index), //nolint:gosec // G115: index bounded by DataShards + ParityShards (small uint).
 			Epoch: place.WriteEpoch,
 		})
+		if slices.Contains(written.ambiguous, index) {
+			// This commit is the answer the put never gave. Say which way it
+			// went: a node whose writes all land but never report in time is
+			// invisible otherwise, and that is the whole defect.
+			logAmbiguousResolution(ctx, node, index, place.WriteEpoch, overtaken, err)
+			if overtaken {
+				lost.Add(1)
+			}
+
+			return
+		}
 		switch {
 		case err != nil:
 			slog.WarnContext(ctx, "Shard commit failed",
@@ -630,6 +655,32 @@ func commitShards(ctx context.Context, bc BlobClient, objectHash [32]byte, place
 		}
 	})
 	return int(lost.Load())
+}
+
+// logAmbiguousResolution reports what became of a shard whose put was
+// abandoned. Prepared means the node was only slow and the stripe is at full
+// width after all; not prepared means the shard really is absent and repair
+// owns it. Overtaken means it did land and a newer generation has since won
+// the position, which is last-write-wins and not this write's problem.
+func logAmbiguousResolution(
+	ctx context.Context, node config.NodeID, index int, epoch uint64, overtaken bool, err error,
+) {
+	switch {
+	case err != nil && errors.Is(err, blob.ErrNotPrepared):
+		slog.WarnContext(ctx, "Shard was not prepared; the put that was abandoned did not land",
+			"node", node, "index", index, "epoch", fmt.Sprintf("%016x", epoch))
+	case err != nil:
+		slog.WarnContext(ctx, "Shard commit failed after an abandoned put; a read will complete it",
+			"node", node, "index", index, "epoch", fmt.Sprintf("%016x", epoch), "err", err)
+	case overtaken:
+		telemetry.RecordShardError(ctx, telemetry.ShardOpWrite, telemetry.ShardReasonSlowCommit, uint64(node))
+		slog.InfoContext(ctx, "Shard was prepared after its put was abandoned, then overtaken",
+			"node", node, "index", index, "epoch", fmt.Sprintf("%016x", epoch))
+	default:
+		telemetry.RecordShardError(ctx, telemetry.ShardOpWrite, telemetry.ShardReasonSlowCommit, uint64(node))
+		slog.InfoContext(ctx, "Shard was prepared after its put was abandoned; committed at full width",
+			"node", node, "index", index, "epoch", fmt.Sprintf("%016x", epoch))
+	}
 }
 
 // abortShards discards shards prepared for a write that will not be published,
@@ -657,10 +708,13 @@ func abortShards(ctx context.Context, bc BlobClient, objectHash [32]byte, place 
 // committing it would be told so and aborting it would ask a node to discard
 // whatever generation it does hold. A position that was handed off is prepared
 // on the holder and nowhere else, so both have to be addressed there.
+// An ambiguous position is visited alongside the landed ones: committing it
+// publishes a shard that did prepare, and answers ErrNotPrepared for one that
+// did not, which is how a put nobody reported on is settled at no cost.
 func forEachShard(written writeResult, fn func(index int, node config.NodeID)) {
 	var wg sync.WaitGroup
 	for i, node := range written.holders {
-		if i < len(written.landed) && !written.landed[i] {
+		if i < len(written.landed) && !written.landed[i] && !slices.Contains(written.ambiguous, i) {
 			continue
 		}
 		wg.Go(func() { fn(i, node) })
@@ -711,6 +765,8 @@ func shardErrorReason(err error) string {
 		return telemetry.ShardReasonStaleEpoch
 	case errors.Is(err, blob.ErrNotFound):
 		return telemetry.ShardReasonNotFound
+	case errors.Is(err, blob.ErrCommitUnknown):
+		return telemetry.ShardReasonCommitUnknown
 	default:
 		return telemetry.ShardReasonTransport
 	}

--- a/internal/gate/handlers/writepath_test.go
+++ b/internal/gate/handlers/writepath_test.go
@@ -107,6 +107,10 @@ type fakeBlob struct {
 	declaring    func(size int64) error
 	failPutOn    func(index uint32) bool
 	failCommitOn func(index uint32) bool
+
+	// abandonPutOn models a node on a stalling drive: it takes the whole body
+	// and prepares the shard, then fails to report before the commit bound.
+	abandonPutOn func(index uint32) bool
 }
 
 func newFakeBlob() *fakeBlob {
@@ -143,6 +147,12 @@ func (b *fakeBlob) Put(_ context.Context, _ config.NodeID, req blob.PutRequest, 
 	b.mu.Lock()
 	b.prepared[shardID{key: req.Key, index: req.Index}] = fakeShard{data: buf.Bytes(), epoch: req.Epoch}
 	b.mu.Unlock()
+
+	// The shard is prepared either way. What the caller is told is the whole
+	// difference between a slow node and a lost write.
+	if b.abandonPutOn != nil && b.abandonPutOn(req.Index) {
+		return nil, fmt.Errorf("put to node holding shard %d: %w", req.Index, blob.ErrCommitUnknown)
+	}
 
 	return &blob.PutResponse{Size: int64(buf.Len()), Epoch: req.Epoch}, nil
 }

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -739,6 +739,14 @@ const (
 	// ShardReasonStaleEpoch is a node holding the shard under a different
 	// write epoch than the placement record names: up, answering, and wrong.
 	ShardReasonStaleEpoch = "stale_epoch"
+	// ShardReasonCommitUnknown is a node that took the whole body and did not
+	// report before the commit bound, so whether the shard prepared is unknown
+	// at the time the write is scored.
+	ShardReasonCommitUnknown = "commit_unknown"
+	// ShardReasonSlowCommit is a node whose put was abandoned and whose shard
+	// turned out to be prepared after all: the write was never lost, only
+	// late. A node accumulating these is stalling rather than failing.
+	ShardReasonSlowCommit = "slow_commit"
 )
 
 // Object read paths. A reconstructed read consumed parity to answer it, so the


### PR DESCRIPTION
## Summary

Blob node 5 on the node1-node4 cluster failed every `PutObject` for over two days while its reads kept succeeding, so the cluster reported itself healthy and writes were silently degraded. It is what stretched the DRAIN volume seal past `unmountSealTimeout` during the v1.18.0 upgrade and destroyed both running guests.

The trigger is hardware and predastore cannot fix it. node1's predastore drive logged 12 of that node's 19 NVMe timeouts, all since 2026-08-26, against 1, 2 and 1 on the other three nodes. Every one is `I/O tag N QID nn timeout, completion polled` — the command completed and only its completion interrupt was late. The drive is slow, not broken, stalling for around the 30s kernel `io_timeout` default.

What predastore did with slow-but-successful is the defect, and it is one line of misplaced trust: **the put client capped the response envelope at 10s, but the server does not send that envelope until the shard has been fsynced.** The cap was on the disk.

## The envelope timeout was really a disk timeout

`ClientConfig.EnvelopeTimeout` is documented as bounding "the fixed exchanges either side of a body: opening the stream, the half-close, and reading the response envelope. These are small and their size is known, so a total cap fits them."

`Server.handlePut` does not respond until after `writer.Close()`, and Close is the commit. So a 30s device stall failed every put on a node where every put landed, producing the production string verbatim:

```
put to node 5: await response envelope: context deadline exceeded
```

`CommitTimeout` now bounds the envelopes a node cannot send until it has fsynced — a put's response, and commit and abort. It defaults to 45s, above the kernel's 30s `io_timeout`, so a device that stalls and then completes is waited out. `EnvelopeTimeout` keeps its 10s cap on open, stat and delete, which is what it was always documented to be.

## An abandoned put is not a refused one

The write still lands. That makes these false negatives rather than lost writes, which is worse, because the gate acted on them.

Past even the commit bound the put now reports `ErrCommitUnknown` rather than a refusal it never received. The gate records those positions as `ambiguous` instead of `missing`: they stay out of the degraded signal, the record keeps naming the node the shard was aimed at, and the existing `commitShards` pass settles them. A commit that publishes proves the shard was prepared; `ErrNotPrepared` proves it was not, at no extra cost. An ambiguous position that comes back overtaken counts toward the superseded tally like any other — being beaten by a newer generation is last-write-wins and not this write's problem.

This is not new machinery. `Server.resolveEpoch` already completes a commit abandoned by its writer when a read asks for the epoch, logging "completed a shard commit abandoned by its writer". The read path already knew these shards were recoverable. The write path was the half that did not.

With `DegradedWrites` on by default, `MinShards()` is `DataShards`, so at RS(2,1) a single ambiguous position still cleared the floor and the write was acknowledged degraded. That is the "silently degraded" in the bead: every object written while node 5 was sick was reported as holding one shard fewer than it does.

**Accepted consequence.** An ambiguous position is still not counted toward the write floor, because the floor is evaluated in `writeObject` before any commit is attempted. Only shards that have been proved acknowledge a write. With `DegradedWrites` off — not the shipped default — a slow node therefore still fails the write outright, which is no worse than before, where the same position counted as missing.

## What was deliberately not done

The first cut of this included a `ConnPool` change: stop `noteProgress` clearing a run of write stalls, so the eviction counter could reach a verdict on a node whose reads work and whose writes do not.

It is the wrong remedy and it is not here. Eviction is a transport-level heuristic and node 5's transport was healthy — the connection was fine and the drive was slow. Evicting reconnects to the same slow drive and changes nothing, which is why it ran at 40/hour for two days without ever helping. The stall run is also per stream read rather than per operation, so separating reads from writes means threading the opcode through `healthStream` and retuning eviction semantics that were settled recently. With the commit bound in place the stalls stop at the source.

## Observability

The repair `pending` gauge cannot see this fault: the write was acknowledged, so no shard is owed. Two bounded reasons on the existing per-node shard-error counter carry it instead:

- `commit_unknown` — the node took the body and did not report in time.
- `slow_commit` — the shard turned out to be prepared after all, recorded when the commit settles it.

A node accumulating `slow_commit` is stalling rather than failing, which is exactly what node 5 was doing and what nothing could previously say.

## Testing

`make preflight` passes: 0 lint issues, 0 vulnerabilities, diff coverage 76.3%.

Client level, against a real `blob.Server` over the pipe transport, so no cluster is needed:

- `TestPutWaitsOutASlowCommit` — sets `EnvelopeTimeout` short and `CommitTimeout` long on purpose, because that is what proves which bound the put is under. Reverting `Put` to the envelope bound fails it with the production error verbatim.
- `TestPutReportsAnAbandonedCommitAsUnknown` — past even the commit bound, the put reports unknown, the shard lands anyway, and the commit finds it and is not overtaken.
- `TestPutBodyStallTripsTheIdleGuard` — a drive that stalls mid-body still aborts at the idle timeout and is *not* reported as unknown: a body that never arrived cannot have prepared a shard.

Gate level: the position is unsettled rather than missing, the record still names the node holding the shard, the commit is actually sent, and the response does not claim redundancy that was never lost.

`make e2e-stress` ran at `ecbe488`, the rebased commit, and passed every scenario: `repair` 4, `handoff` 4, `node-rejoin` 7, `node-resync` 15, `node-rebuild` 23, `multipart-upload` 3, `last-modified` 10, `large-object` 10, `concurrent-put` 24, `torn-overwrite` 5, `stale-shard` 48. Warp finished error-free. `concurrent-put` came in with the rebase and is the one that matters most here, since it covers the epoch and supersession handling the ambiguous positions were folded into. `repair` and `handoff` are the two this change bears on directly, and both accepted 12 of 12 writes with a host under `SIGSTOP` — a host that stays dialable and answers nothing, which is the fault shape node 5 presents.

The freeze test is a **partial** pass. Survivors elected a leader with the host frozen, 9 meta writes committed, they still served after 90s, and the thawed replica rejoined in 2s against a 120s deadline — but its closing round trip through the thawed gate failed, the box having filled and the gate having answered `InsufficientStorage`. The harness did not catch it and the run exited 0 regardless; see below.

## Rebase note

Originally raised against `feat/shard-repair-protocol`. That branch squash-merged into `dev`, which gave the new commit a fresh SHA and left this branch's base outside `dev`'s history, so the PR showed all 38 of its commits. Rebased onto `dev` and reduced to the one commit.

The rebase was not clean, and the conflict was substantive rather than textual: `commitShards` now runs *before* the placement record rather than after, and `Commit` returns an `overtaken` flag for last-write-wins. Resolved by folding the ambiguous-position handling into the new `switch` and having it report and count supersession like any other position.

## Three things reviewers should not take on trust

**A green stress run that was not entirely green.** `round_trip` (`scripts/bench/e2e-stress.sh:264`) has no explicit return, so its status is that of the trailing `s3 rb --force`, which succeeds on the empty bucket a failed put leaves behind; and `set -e` does not apply inside a function called on the left of `||`. The put, the copy and the diff can therefore all fail unseen, which is exactly what happened to the freeze test's last assertion. Pre-existing, not from this change, and wants its own bead — a harness that can report a run it did not have undermines every scenario in the file.

**Three e2e coverage gaps, from disk rather than code.** The box had 7.6 GB free, so `STRESS_LARGE_SIZES` was capped to `1GiB 2GiB` rather than the default `2GiB 4GiB 8GiB`; the harness skipped 2 multipart part sizes, `256MiBx8` and `1GiBx8`; and the freeze test's closing round trip is the failure above. The first two were reported loudly by the harness. The large sizes have not been exercised against this change.

**No bare-metal verification.** Nothing here has run against node1's actual drive.

## Still open

`mulga-fnsp1` stays open. Its acceptance criteria are about node1's actual drive — blob node 5 accepting writes without stalling, no eviction entries in steady state, a DRAIN seal completing inside `unmountSealTimeout`.

The drive also wants its own bead. Every change here makes the cluster survive a stalling device rather than making the device good, and twelve completion timeouts on one P4510 since a single date is a failing or firmware-buggy drive.

Plan: `docs/development/bugs/predastore-blob-node-write-stall.md` on mulga `main`.

Bead: `mulga-fnsp1`

