### PR TITLE
fix: refuse to start e2e-performance without disk headroom

### DIFF
--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -13,6 +13,8 @@ A minimal, manually-invoked harness for tracking predastore performance over tim
   used by the `partial-put` scenario. No S3 client can express this: they all
   either finish the body or abort, and both already work. `-rate` paces the send
   so a caller can kill it mid-body.
+- `e2e-performance.sh` — correctness round trips followed by isolated Warp
+  workloads, one profile at a time. Chosen by `PERF_PRESET` (`smoke` or `compare`).
 
 ### `e2e-stress` scenarios
 
@@ -78,6 +80,33 @@ for the large and kill cases), `STRESS_PARTIAL_KILL_RATE` and
 The abandon bound must stay above the gate's 50s request deadline or it asserts
 nothing. Concurrency times the large declared size is roughly the peak memory the
 run needs, so raising either on a small machine is how it gets OOM-killed.
+
+### `e2e-performance` presets and disk budget
+
+`PERF_PRESET` selects `smoke` (30s per workload, default) or `compare` (2m).
+Each of the three Warp workloads (`put`, `multipart-put`, `get`) writes into
+its own bucket for the duration of the preset, and `e2e-performance.sh` drops
+a bucket as soon as its workload finishes — the next workload never has to
+coexist on disk with data already measured.
+
+Before starting each profile, the script checks free space on the filesystem
+holding `WORK_DIR` against a per-preset floor and refuses to start if it is
+short, naming the shortfall. This runs before the cluster starts, so a failed
+check leaves no cluster and no data directory behind.
+
+| Preset    | Measured peak (pre-cleanup, all three buckets) | Budget |
+|-----------|--------------------------------------------------|--------|
+| `smoke`   | ~40 GiB                                          | 56 GiB (`60129542144` bytes) |
+| `compare` | ~50 GB                                           | 70 GB (`70000000000` bytes) |
+
+The budget is a floor with headroom over the measured peak, not a computed
+prediction: `put` runs for a fixed **duration**, not a fixed object count, so
+a faster disk writes more in that time, not less, than what was measured.
+Each budget is `measured peak × 1.3` (30% headroom for hardware variance and
+erasure-coded bytes on disk exceeding the client-side throughput the
+measurement was taken from) `÷ 0.95`, so a run landing exactly on budget still
+leaves the blob engine's 5%-free watermark intact rather than finishing at 4%
+free. Override with `PERF_MIN_FREE_BYTES`.
 
 All benchmarks can be run via the top-level dispatcher:
 

--- a/scripts/bench/e2e-performance.sh
+++ b/scripts/bench/e2e-performance.sh
@@ -23,7 +23,7 @@
 #                    which this machine did not produce and cannot read.
 #
 # Preset overrides: PERF_DURATION, PERF_CONCURRENT, PERF_PUT_SIZE,
-# PERF_PART_SIZE, PERF_PARTS, PERF_GET_SIZE.
+# PERF_PART_SIZE, PERF_PARTS, PERF_GET_SIZE, PERF_MIN_FREE_BYTES.
 #
 
 set -euo pipefail
@@ -52,6 +52,17 @@ case "$PERF_PRESET" in
         MULTIPART_SIZE="${PERF_PART_SIZE:-5MiB}"
         MULTIPART_PARTS="${PERF_PARTS:-2}"
         GET_SIZE="${PERF_GET_SIZE:-10MiB}"
+        # `put` runs for a fixed duration, not a fixed object count, so this
+        # is a floor with headroom over a measured peak, not a prediction: a
+        # faster disk writes more in 30s, not less, than what was measured.
+        # Measured peak (sum of the three workload buckets, before any
+        # cleanup) was ~40 GiB. +30% headroom covers hardware variance and
+        # erasure-coded bytes on disk exceeding the client-side throughput
+        # the measurement was taken from: 40 * 1.3 = 52 GiB. Dividing by
+        # 0.95 keeps the blob engine's 5%-free watermark intact even if a
+        # run lands exactly on budget, rather than finishing at 4% free:
+        # 52 / 0.95 = 54.74 GiB, rounded up to 56 GiB.
+        MIN_FREE_BYTES="${PERF_MIN_FREE_BYTES:-60129542144}" # 56 GiB
         ;;
     compare)
         DURATION="${PERF_DURATION:-2m}"
@@ -60,6 +71,9 @@ case "$PERF_PRESET" in
         MULTIPART_SIZE="${PERF_PART_SIZE:-8MiB}"
         MULTIPART_PARTS="${PERF_PARTS:-16}"
         GET_SIZE="${PERF_GET_SIZE:-128MiB}"
+        # Same reasoning as smoke, against a measured peak of ~50 GB:
+        # 50 * 1.3 = 65 GB, / 0.95 = 68.42 GB, rounded up to 70 GB.
+        MIN_FREE_BYTES="${PERF_MIN_FREE_BYTES:-70000000000}" # 70 GB
         ;;
     *)
         echo "unknown PERF_PRESET: $PERF_PRESET (want smoke or compare)" >&2
@@ -110,6 +124,32 @@ mkdir -p "$PREDA_CONFIG_DIR"
 # directory stops those competing with the cluster for a small /tmp tmpfs.
 export TMPDIR="$WORK_DIR/tmp"
 mkdir -p "$PREDA_DIR" "$TMPDIR"
+
+# work_fs_stat reads byte-denominated `df` fields for the filesystem holding
+# WORK_DIR. -PB1 gives a single POSIX-format line in 1-byte blocks, so this
+# avoids parsing df's human-readable (G/M-suffixed) output. WORK_DIR must
+# already exist (mktemp -d above), or df has nothing to report on.
+work_fs_stat() {
+    df -PB1 "$WORK_DIR" | awk -v f="$1" 'NR==2 {print $f}'
+}
+
+WORK_FS_TOTAL_BYTES="$(work_fs_stat 2)"
+
+# check_free_space refuses to start a config without headroom for its
+# workload, so a capacity failure is a preflight message before any cluster
+# or data directory exists, rather than a Warp error mid-workload.
+check_free_space() {
+    local avail requirement shortfall mount
+    avail="$(work_fs_stat 4)"
+    [ -n "$avail" ] || { echo "could not read free space on $WORK_DIR" >&2; exit 1; }
+    requirement="$MIN_FREE_BYTES"
+    if [ "$avail" -lt "$requirement" ]; then
+        shortfall=$((requirement - avail))
+        mount="$(df -P "$WORK_DIR" | awk 'NR==2 {print $NF}')"
+        echo "insufficient free space for preset '$PERF_PRESET' on $mount ($WORK_DIR): needs $requirement bytes, has $avail bytes, short by $shortfall bytes" >&2
+        exit 1
+    fi
+}
 
 CURRENT_CONFIG=""
 cleanup() {
@@ -201,6 +241,16 @@ run_correctness() {
     aws_s3 s3 rb "s3://$bucket" --force >/dev/null
 }
 
+# drop_bucket removes a bucket once its workload has been measured, so the
+# next workload's writes don't have to coexist with it on disk. The
+# measurement is already recorded by the time this runs, so a failure here
+# is logged and swallowed rather than failing the run.
+drop_bucket() {
+    local bucket="$1"
+    aws_s3 s3 rb "s3://$bucket" --force >/dev/null 2>&1 ||
+        echo "warning: failed to drop bucket $bucket; continuing" >&2
+}
+
 # run_warp measures each workload on its own. A mixed workload cannot say which
 # path regressed, which is the whole question a before/after run is asked.
 run_warp() {
@@ -223,20 +273,33 @@ run_warp() {
         --full
     )
 
+    local put_bucket="warp-${config_name}-put-${RUN_ID}"
+    local multipart_bucket="warp-${config_name}-multipart-put-${RUN_ID}"
+    local get_bucket="warp-${config_name}-get-${RUN_ID}"
+
     mkdir -p "$output_dir"
     run_warp_checked "$output_dir/put.log" "$WARP" put "${common[@]}" \
         --disable-multipart --obj.size="$PUT_SIZE" \
-        --bucket="warp-${config_name}-put-${RUN_ID}" --benchdata="$output_dir/put"
+        --bucket="$put_bucket" --benchdata="$output_dir/put"
+    # Each workload owns its bucket, so dropping it here cannot affect the
+    # multipart-put or get workloads that follow. This is what keeps the
+    # config's peak disk usage to the largest single workload rather than
+    # the sum of all three.
+    drop_bucket "$put_bucket"
+
     run_warp_checked "$output_dir/multipart-put.log" "$WARP" multipart-put "${common[@]}" \
         --part.size="$MULTIPART_SIZE" --parts="$MULTIPART_PARTS" \
-        --part.concurrent="$part_concurrent" --bucket="warp-${config_name}-multipart-put-${RUN_ID}" \
+        --part.concurrent="$part_concurrent" --bucket="$multipart_bucket" \
         --benchdata="$output_dir/multipart-put"
+    drop_bucket "$multipart_bucket"
+
     # The GET set is seeded by multipart upload and then read whole. Warp's
     # `multipart` command reads with GET ?partNumber=N, a separate S3 feature
     # predastore does not implement.
     run_warp_checked "$output_dir/get.log" "$WARP" get "${common[@]}" \
         --objects=16 --obj.size="$GET_SIZE" --part.size="$MULTIPART_SIZE" \
-        --bucket="warp-${config_name}-get-${RUN_ID}" --benchdata="$output_dir/get"
+        --bucket="$get_bucket" --benchdata="$output_dir/get"
+    drop_bucket "$get_bucket"
 
     write_warp_analysis "$output_dir"
 }
@@ -331,6 +394,13 @@ fi
     echo "logical_cpus=$(getconf _NPROCESSORS_ONLN)"
     echo "memory_bytes=$(awk '/MemTotal/ {print $2 * 1024}' /proc/meminfo 2>/dev/null || echo unknown)"
     echo
+    echo "Work filesystem"
+    echo "---------------"
+    echo "work_dir=$WORK_DIR"
+    echo "work_fs_avail_bytes=$(work_fs_stat 4)"
+    echo "work_fs_total_bytes=$WORK_FS_TOTAL_BYTES"
+    echo "min_free_bytes_required=$MIN_FREE_BYTES"
+    echo
     echo "Workload controls"
     echo "-----------------"
     echo "preset=$PERF_PRESET"
@@ -372,6 +442,11 @@ for config_name in $PERF_CONFIGS; do
         HOST_LIST="$(gate_endpoints "$CONFIG_FILE" | paste -sd,)"
         [ -n "$HOST_LIST" ] || { echo "no host in $config_name runs a gate" >&2; exit 1; }
         ENDPOINT="https://$(gate_endpoints "$CONFIG_FILE" | head -1)"
+
+        # Only the cluster this script starts writes to this box's disk. A
+        # cluster named by PERF_EXTERNAL_HOSTS stores its data elsewhere, so
+        # the free space here says nothing about whether that run can proceed.
+        check_free_space
 
         CURRENT_CONFIG="$config_name"
         echo "Starting $config_name ($HOST_LIST)"


### PR DESCRIPTION
## Summary

`make e2e-performance` writes roughly 40 GiB per config and drops none of it
until the config ends, so a runner without that headroom fails mid-workload
with an S3 capacity error rather than a clear message. The blob engine's
5%-free write refusal is correct and is not touched here.

- Add a free-space precondition per preset (`smoke`, `compare`), checked
  before each config starts and before any cluster or data directory exists.
  The budget is a documented floor with headroom over the measured peak, not
  a computed prediction, since `put` runs for a fixed duration and a faster
  disk writes more, not less.
- Drop each Warp workload's bucket as soon as it is measured instead of
  waiting for the whole config to finish, since the three workloads already
  use separate buckets. This takes the peak from the sum of the three
  workloads to the largest of them. `--noclear` is unchanged.
- Record the work filesystem's available and total bytes, and the budget
  applied, in `run-info.txt`, so a capacity failure carries the number that
  explains it.
- Skip the free-space check when `PERF_EXTERNAL_HOSTS` is set: that mode
  measures a cluster this script did not start, so the data lives on other
  machines and this box's disk says nothing about whether the run can
  proceed.
- Document the per-preset budget in `scripts/bench/README.md`.

## Test plan

- [x] Forced the check to fail with `PERF_MIN_FREE_BYTES` set absurdly high:
      exits before any cluster starts, printing the shortfall, with no
      leftover cluster or work directory.
- [x] Ran the full `smoke` suite end to end (`1host` then `3host`) on a real
      box; both configs completed, peak disk usage stayed well under budget.
- [x] Verified against the store (`aws s3api list-buckets` polled live during
      the run, not warp's exit code) that the `put` bucket is gone before the
      `multipart-put` workload begins.
- [x] Confirmed the free-space check is skipped when `PERF_EXTERNAL_HOSTS` is
      set, without otherwise changing behaviour.
- [x] `shellcheck -x -P scripts scripts/bench/e2e-performance.sh` is clean.
- [x] `make preflight` passes.