### PR TITLE
ci: drive the performance job on the three-host bare-metal harness

### DIFF
--- a/.github/workflows/predastore-e2e.yml
+++ b/.github/workflows/predastore-e2e.yml
@@ -185,48 +185,38 @@ jobs:
 
   performance:
     name: Performance (Warp, bare metal)
-    # Pinned to the dedicated runner: it only executes ssh/scp against the
-    # three hardware hosts and holds no cluster data of its own.
+    # The runner only drives ssh/scp against the hardware hosts and holds no
+    # cluster data of its own.
     runs-on: [self-hosted, ci-predastore]
     timeout-minutes: 45
     # inputs is null on a push, and GitHub coerces both sides of != to a
     # number there, so the event has to be checked first.
     if: github.event_name != 'workflow_dispatch' || inputs.run_performance
 
-    # A fixed group with no ref in it, so every performance run across every
-    # branch queues behind the one in flight. Killing a benchmark part way
-    # through leaves a cluster and its data behind on three machines rather
-    # than one, which is why this waits rather than cancels.
+    # A fixed group with no ref in it, so runs across every branch queue behind
+    # each other. Killing a benchmark part way through leaves a cluster and its
+    # data behind on several machines, which is why this waits rather cancels.
     concurrency:
       group: predastore-performance
       cancel-in-progress: false
 
+    # The target hosts, their addresses and the directory the cluster is
+    # deployed to are deployment facts, not repository ones. They are supplied
+    # by repository variables and the job fails if any is unset.
     env:
-      HW_HOSTS: ${{ vars.PREDASTORE_HW_HOSTS || 'tf-user@bottlebrush tf-user@ironbark tf-user@casuarina' }}
-      HW_ADDRS: ${{ vars.PREDASTORE_HW_ADDRS || '10.10.8.4 10.10.8.5 10.10.8.6' }}
-      # Same disk hwbench.sh itself defaults to (disk1: disk2 and disk3 carry
-      # spinifex's own storage services and confound the numbers). Only the
-      # leaf directory differs, so clean's rm -rf never reaches a manual run.
-      HW_ROOT: ${{ vars.PREDASTORE_HW_ROOT || '/mnt/disk1/tf-user/predastore-ci' }}
-      # HW_WORK is resolved against RUNNER_TEMP in the "Resolve HW_WORK" step
-      # below, not set here — runner.temp isn't reachable from job-level env:.
-      # One ref: the commit under test. hwbench.sh's own default is three
-      # refs including two hardcoded shas, a comparison harness rather than
-      # a CI run.
+      HW_HOSTS: ${{ vars.PREDASTORE_HW_HOSTS }}
+      HW_ADDRS: ${{ vars.PREDASTORE_HW_ADDRS }}
+      HW_ROOT: ${{ vars.PREDASTORE_HW_ROOT }}
+      # One ref: the commit under test, rather than the script's own default of
+      # several refs for a before/after comparison.
       HW_REFS: ci:${{ github.sha }}
       PERF_TAG: ci-${{ github.run_id }}
-      # smoke matches what this job measured before this change (the
-      # Makefile's own default). Presets, durations, sizes and workloads are
-      # unchanged by this move to bare metal.
       PERF_PRESET: smoke
 
     steps:
-      # bottlebrush/ironbark/casuarina are the hypervisors for the env1-env21
-      # nested dev clusters and for engineers' own workstation VMs. Checked
-      # before any ssh to the hosts, mirroring the sentinel-file mutex
-      # spinifex's gpu-e2e.yml uses for wattle: a sentinel on the RUNNER (not
-      # the target hosts) or a repo/environment variable pauses this job
-      # cleanly instead of racing manual work on the cluster.
+      # The hardware hosts also carry the nested dev clusters and engineers'
+      # workstation VMs. A sentinel on the RUNNER or a repository variable
+      # pauses this job cleanly rather than racing manual work on them.
       - name: Manual-work / cluster-in-use mutex gate
         id: gate
         env:
@@ -236,25 +226,48 @@ jobs:
           PAUSED=false
           if [ -f "$HOME/.ci-predastore-hw-paused" ]; then
             PAUSED=true
-            echo "::warning::ci-predastore-hw paused via ~/.ci-predastore-hw-paused sentinel on the runner — skipping this run (manual work in progress on bottlebrush/ironbark/casuarina). Remove the file to resume CI."
+            echo "::warning::paused via the ~/.ci-predastore-hw-paused sentinel on the runner; manual work is in progress on the hardware hosts. Remove the file to resume CI."
           fi
           if [ "$(echo "${REPO_VAR_PAUSED:-}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
             PAUSED=true
-            echo "::warning::ci-predastore-hw paused via repo/environment variable CI_PREDASTORE_HW_PAUSED=true — skipping this run."
+            echo "::warning::paused via repository variable CI_PREDASTORE_HW_PAUSED=true."
           fi
           echo "paused=${PAUSED}" >> "$GITHUB_OUTPUT"
 
       - name: Paused — nothing to do
         if: steps.gate.outputs.paused == 'true'
-        run: echo "cluster is paused for manual work; job exits cleanly without touching bottlebrush/ironbark/casuarina."
+        run: echo "paused for manual work; exiting without touching the hardware hosts."
+
+      # Checked before any ssh. HW_ROOT is deleted recursively on every host at
+      # the end of a run, so a shallow path here would be destructive: require
+      # an absolute path at least three components deep.
+      - name: Check required configuration
+        if: steps.gate.outputs.paused != 'true'
+        run: |
+          set -euo pipefail
+          fail=0
+          for name in HW_HOSTS HW_ADDRS HW_ROOT; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::repository variable PREDASTORE_${name} is not set"
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ] || exit 1
+          if [ "$(wc -w <<< "$HW_HOSTS")" -ne "$(wc -w <<< "$HW_ADDRS")" ]; then
+            echo "::error::PREDASTORE_HW_HOSTS and PREDASTORE_HW_ADDRS name a different number of hosts"
+            exit 1
+          fi
+          case "$HW_ROOT" in
+            /*/*/*) ;;
+            *) echo "::error::PREDASTORE_HW_ROOT must be an absolute path at least three components deep; it is deleted recursively on every host"; exit 1 ;;
+          esac
 
       - name: Checkout Code
         if: steps.gate.outputs.paused != 'true'
         uses: actions/checkout@v7
 
-      # runner.temp isn't reachable from job-level env:, and whether the
-      # runner's /tmp is tmpfs is unconfirmed, so HW_WORK is resolved here
-      # against RUNNER_TEMP, which shares the checkout's own disk.
+      # runner.temp is not reachable from job-level env:, and the runner's /tmp
+      # may be tmpfs, so HW_WORK is resolved here against RUNNER_TEMP.
       - name: Resolve HW_WORK
         if: steps.gate.outputs.paused != 'true'
         run: echo "HW_WORK=$RUNNER_TEMP/hwbench-ci" >> "$GITHUB_ENV"
@@ -266,9 +279,9 @@ jobs:
           cache-dependency-path: "go.sum"
           go-version-file: "go.mod"
 
-      # hwbench.sh's on() shells out to plain `ssh $host ...` with no -i or
-      # -F, so the identity and known_hosts have to be the default ones for
-      # this runner user rather than passed on the command line.
+      # hwbench.sh's on() shells out to plain `ssh $host` with no -i or -F, so
+      # the identity has to be this runner user's default. The Host stanzas are
+      # derived from HW_HOSTS rather than named here.
       - name: Install SSH key for the hardware hosts
         if: steps.gate.outputs.paused != 'true'
         run: |
@@ -278,31 +291,31 @@ jobs:
           printf '%s\n' "${{ secrets.PREDASTORE_HW_SSH_KEY }}" > "$HOME/.ssh/predastore-hw-ci"
           printf '%s\n' "${{ secrets.PREDASTORE_HW_KNOWN_HOSTS }}" >> "$HOME/.ssh/known_hosts"
           chmod 600 "$HOME/.ssh/known_hosts"
-          {
-            echo "Host bottlebrush ironbark casuarina"
-            echo "  User tf-user"
-            echo "  IdentityFile $HOME/.ssh/predastore-hw-ci"
-            echo "  IdentitiesOnly yes"
-          } >> "$HOME/.ssh/config"
+          for target in $HW_HOSTS; do
+            {
+              echo "Host ${target#*@}"
+              echo "  User ${target%@*}"
+              echo "  IdentityFile $HOME/.ssh/predastore-hw-ci"
+              echo "  IdentitiesOnly yes"
+            } >> "$HOME/.ssh/config"
+          done
           chmod 600 "$HOME/.ssh/config"
 
       # cmd_tools ships the AWS CLI from this path on the RUNNER to the tools
-      # host — it does not install it. clean removes it from the tools host
-      # every run, so this has to be present on the runner every run too.
+      # host rather than installing it, and clean removes it from that host
+      # every run, so it has to be present here every run.
       - name: Check AWS CLI v2 is present on the runner
         if: steps.gate.outputs.paused != 'true'
         run: |
           set -euo pipefail
           if [ ! -d /usr/local/aws-cli ]; then
-            echo "::error::/usr/local/aws-cli is missing on this runner. hwbench.sh tools ships the AWS CLI from here to the tools host; install AWS CLI v2 to /usr/local/aws-cli once on this runner (see PR description) before this job can run." >&2
+            echo "::error::/usr/local/aws-cli is missing on this runner. Install AWS CLI v2 there once before this job can run." >&2
             exit 1
           fi
 
-      # cmd_build worktrees each ref under $HW_WORK and never removes it. A
-      # fresh sha every CI run would otherwise accumulate worktrees on the
-      # runner — the same disk problem this change exists to fix, moved one
-      # directory across. Pruning here, not in the script, keeps hwbench.sh's
-      # behavior unchanged for its normal (human, long-lived work dir) use.
+      # cmd_build worktrees each ref under $HW_WORK and never removes it, so a
+      # fresh sha every run would accumulate them. Pruning here rather than in
+      # the script leaves hwbench.sh's long-lived work dir behaviour alone.
       - name: Clean stale hwbench work dir
         if: steps.gate.outputs.paused != 'true'
         run: |
@@ -338,10 +351,9 @@ jobs:
         if: steps.gate.outputs.paused != 'true'
         run: scripts/bench/hw/hwbench.sh perf ci "$PERF_TAG"
 
-      # cmd_perf writes to $HW_ROOT/results on the tools host (the last host
-      # in HW_HOSTS) and save_host_logs writes per-host logs on every host.
-      # Nothing lands on the runner on its own, and clean below deletes the
-      # source, so this has to run first and has to run even on failure.
+      # Results are written on the tools host (the last in HW_HOSTS) and logs
+      # on every host, so nothing reaches the runner on its own. clean below
+      # deletes the source, so this runs first and runs even on failure.
       - name: Fetch results and host logs
         if: always() && steps.gate.outputs.paused != 'true'
         run: |
@@ -368,8 +380,8 @@ jobs:
           if-no-files-found: ignore
           retention-days: 30
 
-      # stop and clean run under always() so a cancelled run does not leave
-      # s3d processes and cluster data on three machines rather than one.
+      # Both run under always() so a cancelled run does not leave s3d
+      # processes and cluster data behind on the hardware hosts.
       - name: hwbench stop
         if: always() && steps.gate.outputs.paused != 'true'
         run: scripts/bench/hw/hwbench.sh stop || true

--- a/.github/workflows/predastore-e2e.yml
+++ b/.github/workflows/predastore-e2e.yml
@@ -204,13 +204,12 @@ jobs:
     env:
       HW_HOSTS: ${{ vars.PREDASTORE_HW_HOSTS || 'tf-user@bottlebrush tf-user@ironbark tf-user@casuarina' }}
       HW_ADDRS: ${{ vars.PREDASTORE_HW_ADDRS || '10.10.8.4 10.10.8.5 10.10.8.6' }}
-      # A CI-only root, distinct from the default a human uses running
-      # hwbench.sh by hand on the same machines. clean removes this path on
-      # every host at the end of every run; it must never share a path with
-      # someone's manual deployment.
+      # Same disk hwbench.sh itself defaults to (disk1: disk2 and disk3 carry
+      # spinifex's own storage services and confound the numbers). Only the
+      # leaf directory differs, so clean's rm -rf never reaches a manual run.
       HW_ROOT: ${{ vars.PREDASTORE_HW_ROOT || '/mnt/disk1/tf-user/predastore-ci' }}
-      # Also CI-only, so a stale worktree here is never a human's.
-      HW_WORK: /tmp/hwbench-ci
+      # HW_WORK is resolved against RUNNER_TEMP in the "Resolve HW_WORK" step
+      # below, not set here — runner.temp isn't reachable from job-level env:.
       # One ref: the commit under test. hwbench.sh's own default is three
       # refs including two hardcoded shas, a comparison harness rather than
       # a CI run.
@@ -252,6 +251,13 @@ jobs:
       - name: Checkout Code
         if: steps.gate.outputs.paused != 'true'
         uses: actions/checkout@v7
+
+      # runner.temp isn't reachable from job-level env:, and whether the
+      # runner's /tmp is tmpfs is unconfirmed, so HW_WORK is resolved here
+      # against RUNNER_TEMP, which shares the checkout's own disk.
+      - name: Resolve HW_WORK
+        if: steps.gate.outputs.paused != 'true'
+        run: echo "HW_WORK=$RUNNER_TEMP/hwbench-ci" >> "$GITHUB_ENV"
 
       - name: Setup Go
         if: steps.gate.outputs.paused != 'true'

--- a/.github/workflows/predastore-e2e.yml
+++ b/.github/workflows/predastore-e2e.yml
@@ -184,47 +184,196 @@ jobs:
           retention-days: 14
 
   performance:
-    name: Performance (Warp)
-    # Pinned to the dedicated runner for two reasons: the compare preset writes
-    # tens of gigabytes, which no hosted runner has, and a throughput baseline
-    # compared across hosts reports a difference in machines as a regression.
+    name: Performance (Warp, bare metal)
+    # Pinned to the dedicated runner: it only executes ssh/scp against the
+    # three hardware hosts and holds no cluster data of its own.
     runs-on: [self-hosted, ci-predastore]
     timeout-minutes: 45
-    # inputs is null on a push, and GitHub coerces both sides of != to a number,
-    # so `inputs.run_performance != false` is `0 != 0` there and the job never
-    # runs. The event has to be checked first.
+    # inputs is null on a push, and GitHub coerces both sides of != to a
+    # number there, so the event has to be checked first.
     if: github.event_name != 'workflow_dispatch' || inputs.run_performance
 
     # A fixed group with no ref in it, so every performance run across every
     # branch queues behind the one in flight. Killing a benchmark part way
-    # through wastes the whole run and leaves a cluster and its data behind,
-    # which is why this waits rather than cancels.
+    # through leaves a cluster and its data behind on three machines rather
+    # than one, which is why this waits rather than cancels.
     concurrency:
       group: predastore-performance
       cancel-in-progress: false
 
+    env:
+      HW_HOSTS: ${{ vars.PREDASTORE_HW_HOSTS || 'tf-user@bottlebrush tf-user@ironbark tf-user@casuarina' }}
+      HW_ADDRS: ${{ vars.PREDASTORE_HW_ADDRS || '10.10.8.4 10.10.8.5 10.10.8.6' }}
+      # A CI-only root, distinct from the default a human uses running
+      # hwbench.sh by hand on the same machines. clean removes this path on
+      # every host at the end of every run; it must never share a path with
+      # someone's manual deployment.
+      HW_ROOT: ${{ vars.PREDASTORE_HW_ROOT || '/mnt/disk1/tf-user/predastore-ci' }}
+      # Also CI-only, so a stale worktree here is never a human's.
+      HW_WORK: /tmp/hwbench-ci
+      # One ref: the commit under test. hwbench.sh's own default is three
+      # refs including two hardcoded shas, a comparison harness rather than
+      # a CI run.
+      HW_REFS: ci:${{ github.sha }}
+      PERF_TAG: ci-${{ github.run_id }}
+      # smoke matches what this job measured before this change (the
+      # Makefile's own default). Presets, durations, sizes and workloads are
+      # unchanged by this move to bare metal.
+      PERF_PRESET: smoke
+
     steps:
+      # bottlebrush/ironbark/casuarina are the hypervisors for the env1-env21
+      # nested dev clusters and for engineers' own workstation VMs. Checked
+      # before any ssh to the hosts, mirroring the sentinel-file mutex
+      # spinifex's gpu-e2e.yml uses for wattle: a sentinel on the RUNNER (not
+      # the target hosts) or a repo/environment variable pauses this job
+      # cleanly instead of racing manual work on the cluster.
+      - name: Manual-work / cluster-in-use mutex gate
+        id: gate
+        env:
+          REPO_VAR_PAUSED: ${{ vars.CI_PREDASTORE_HW_PAUSED }}
+        run: |
+          set -euo pipefail
+          PAUSED=false
+          if [ -f "$HOME/.ci-predastore-hw-paused" ]; then
+            PAUSED=true
+            echo "::warning::ci-predastore-hw paused via ~/.ci-predastore-hw-paused sentinel on the runner — skipping this run (manual work in progress on bottlebrush/ironbark/casuarina). Remove the file to resume CI."
+          fi
+          if [ "$(echo "${REPO_VAR_PAUSED:-}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
+            PAUSED=true
+            echo "::warning::ci-predastore-hw paused via repo/environment variable CI_PREDASTORE_HW_PAUSED=true — skipping this run."
+          fi
+          echo "paused=${PAUSED}" >> "$GITHUB_OUTPUT"
+
+      - name: Paused — nothing to do
+        if: steps.gate.outputs.paused == 'true'
+        run: echo "cluster is paused for manual work; job exits cleanly without touching bottlebrush/ironbark/casuarina."
+
       - name: Checkout Code
+        if: steps.gate.outputs.paused != 'true'
         uses: actions/checkout@v7
 
       - name: Setup Go
+        if: steps.gate.outputs.paused != 'true'
         uses: actions/setup-go@v7
         with:
           cache-dependency-path: "go.sum"
           go-version-file: "go.mod"
 
-      # Artefacts only. Gating this on throughput is mulga-wpjsx, and it has to
-      # gate TTFB p99 rather than mean throughput: measured spread on this
-      # harness is 8.8-14.9% run to run, and back-to-back runs on one host show
-      # a systematic penalty to whichever runs second.
-      - name: Run Warp Suite
-        run: make e2e-performance
+      # hwbench.sh's on() shells out to plain `ssh $host ...` with no -i or
+      # -F, so the identity and known_hosts have to be the default ones for
+      # this runner user rather than passed on the command line.
+      - name: Install SSH key for the hardware hosts
+        if: steps.gate.outputs.paused != 'true'
+        run: |
+          set -euo pipefail
+          install -m 0700 -d "$HOME/.ssh"
+          install -m 0600 /dev/null "$HOME/.ssh/predastore-hw-ci"
+          printf '%s\n' "${{ secrets.PREDASTORE_HW_SSH_KEY }}" > "$HOME/.ssh/predastore-hw-ci"
+          printf '%s\n' "${{ secrets.PREDASTORE_HW_KNOWN_HOSTS }}" >> "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/known_hosts"
+          {
+            echo "Host bottlebrush ironbark casuarina"
+            echo "  User tf-user"
+            echo "  IdentityFile $HOME/.ssh/predastore-hw-ci"
+            echo "  IdentitiesOnly yes"
+          } >> "$HOME/.ssh/config"
+          chmod 600 "$HOME/.ssh/config"
+
+      # cmd_tools ships the AWS CLI from this path on the RUNNER to the tools
+      # host — it does not install it. clean removes it from the tools host
+      # every run, so this has to be present on the runner every run too.
+      - name: Check AWS CLI v2 is present on the runner
+        if: steps.gate.outputs.paused != 'true'
+        run: |
+          set -euo pipefail
+          if [ ! -d /usr/local/aws-cli ]; then
+            echo "::error::/usr/local/aws-cli is missing on this runner. hwbench.sh tools ships the AWS CLI from here to the tools host; install AWS CLI v2 to /usr/local/aws-cli once on this runner (see PR description) before this job can run." >&2
+            exit 1
+          fi
+
+      # cmd_build worktrees each ref under $HW_WORK and never removes it. A
+      # fresh sha every CI run would otherwise accumulate worktrees on the
+      # runner — the same disk problem this change exists to fix, moved one
+      # directory across. Pruning here, not in the script, keeps hwbench.sh's
+      # behavior unchanged for its normal (human, long-lived work dir) use.
+      - name: Clean stale hwbench work dir
+        if: steps.gate.outputs.paused != 'true'
+        run: |
+          set -euo pipefail
+          rm -rf "$HW_WORK"
+          git worktree prune
+
+      - name: Install warp
+        if: steps.gate.outputs.paused != 'true'
+        run: make warp-install
+
+      - name: hwbench build
+        if: steps.gate.outputs.paused != 'true'
+        run: scripts/bench/hw/hwbench.sh build
+
+      - name: hwbench deploy
+        if: steps.gate.outputs.paused != 'true'
+        run: scripts/bench/hw/hwbench.sh deploy ci
+
+      - name: hwbench tools
+        if: steps.gate.outputs.paused != 'true'
+        run: scripts/bench/hw/hwbench.sh tools
+
+      - name: hwbench start
+        if: steps.gate.outputs.paused != 'true'
+        run: scripts/bench/hw/hwbench.sh start ci
+
+      - name: hwbench verify
+        if: steps.gate.outputs.paused != 'true'
+        run: scripts/bench/hw/hwbench.sh verify ci
+
+      - name: hwbench perf
+        if: steps.gate.outputs.paused != 'true'
+        run: scripts/bench/hw/hwbench.sh perf ci "$PERF_TAG"
+
+      # cmd_perf writes to $HW_ROOT/results on the tools host (the last host
+      # in HW_HOSTS) and save_host_logs writes per-host logs on every host.
+      # Nothing lands on the runner on its own, and clean below deletes the
+      # source, so this has to run first and has to run even on failure.
+      - name: Fetch results and host logs
+        if: always() && steps.gate.outputs.paused != 'true'
+        run: |
+          set -euo pipefail
+          TOOLS_HOST="$(awk '{print $NF}' <<< "$HW_HOSTS")"
+          mkdir -p scripts/bench/results/e2e-performance scripts/bench/hw/hostlogs
+          scp -q -r -o BatchMode=yes -o ConnectTimeout=10 \
+            "$TOOLS_HOST:$HW_ROOT/results/." scripts/bench/results/e2e-performance/ || true
+          for h in $HW_HOSTS; do
+            hn="${h#*@}"
+            mkdir -p "scripts/bench/hw/hostlogs/$hn"
+            scp -q -r -o BatchMode=yes -o ConnectTimeout=10 \
+              "$h:$HW_ROOT/hostlogs/." "scripts/bench/hw/hostlogs/$hn/" || true
+          done
 
       - name: Upload Results
-        if: always()
+        if: always() && steps.gate.outputs.paused != 'true'
         uses: actions/upload-artifact@v5
         with:
           name: performance
-          path: scripts/bench/results/e2e-performance/
+          path: |
+            scripts/bench/results/e2e-performance/
+            scripts/bench/hw/hostlogs/
           if-no-files-found: ignore
           retention-days: 30
+
+      # stop and clean run under always() so a cancelled run does not leave
+      # s3d processes and cluster data on three machines rather than one.
+      - name: hwbench stop
+        if: always() && steps.gate.outputs.paused != 'true'
+        run: scripts/bench/hw/hwbench.sh stop || true
+
+      - name: hwbench clean
+        if: always() && steps.gate.outputs.paused != 'true'
+        run: scripts/bench/hw/hwbench.sh clean || true
+
+      - name: Clean hwbench work dir
+        if: always() && steps.gate.outputs.paused != 'true'
+        run: |
+          rm -rf "$HW_WORK"
+          git worktree prune || true

--- a/scripts/bench/hw/hwbench.sh
+++ b/scripts/bench/hw/hwbench.sh
@@ -298,13 +298,17 @@ cmd_perf() {
     for i in "${!ADDRS[@]}"; do hosts="${hosts:+$hosts,}${ADDRS[$i]}:$GATE_PORT"; done
     sha="$(cat "$WORK/build/s3d-$ref.sha" 2>/dev/null || echo unknown)"
 
-    on "$TOOLS_HOST" "mkdir -p $HW_ROOT/harness/scripts/bench $HW_ROOT/results"
+    on "$TOOLS_HOST" "mkdir -p $HW_ROOT/harness/scripts/bench $HW_ROOT/results $HW_ROOT/tmp"
     scp -q "$REPO_DIR/scripts/lib.sh" "$TOOLS_HOST:$HW_ROOT/harness/scripts/lib.sh"
     scp -q "$REPO_DIR/scripts/bench/e2e-performance.sh" \
         "$TOOLS_HOST:$HW_ROOT/harness/scripts/bench/e2e-performance.sh"
 
     local rc=0
+    # e2e-performance.sh mktemp's its WORK_DIR under ${TMPDIR:-/tmp} before it
+    # repoints TMPDIR at a subdirectory of that same WORK_DIR, so warp's
+    # staged uploads never actually leave the ambient TMPDIR. Set it here first.
     on "$TOOLS_HOST" "chmod +x $HW_ROOT/harness/scripts/bench/e2e-performance.sh && \
+        TMPDIR=$HW_ROOT/tmp \
         PATH=$HW_ROOT/tools/aws-cli/v2/current/bin:\$PATH \
         WARP=$HW_ROOT/tools/warp \
         PERF_PRESET=${PERF_PRESET:-compare} \


### PR DESCRIPTION
## Summary

- The `performance` job ran the loopback `1host`/`3host` profiles, which put every simulated host's shards on the runner's own filesystem — roughly 40 GiB, which fails on the runner's actual free space. `scripts/bench/hw/hwbench.sh` already runs the same measurement across the three hardware hosts, one shard per host under a dedicated mount, so this job now drives that instead. The runner stays a job executor and holds no cluster data.
- Sequences `build`, `deploy`, `tools`, `start`, `verify`, `perf`, then fetches results and host logs back before `stop` and `clean` run under `if: always()`.
- `HW_REFS` is pinned to one ref, the commit under test (`ci:${{ github.sha }}`), instead of hwbench.sh's own three-ref comparison default.
- Adds a sentinel-file / repo-variable mutex gate (`~/.ci-predastore-hw-paused`, `vars.CI_PREDASTORE_HW_PAUSED`) before any SSH to the hosts, mirroring the pattern `spinifex/.github/workflows/gpu-e2e.yml` uses for wattle — the hardware hosts also carry the nested dev clusters and engineers' own workstation VMs.
- No host name, address or deployment path appears in the workflow. They are supplied as repository variables and a preflight step fails the job naming any that is unset.
- `HW_ROOT` and `HW_WORK` are CI-only paths, distinct from what a human uses running `hwbench.sh` by hand on the same machines, so `clean`'s `rm -rf` can never touch someone's manual deployment.
- The runner-side `hwbench build` worktree accumulation (a fresh sha every run, never removed) is handled in the workflow — `rm -rf "$HW_WORK" && git worktree prune` at job start and again at job end — rather than editing the script.

## Base branch

Rebased onto `dev` now that #112 has merged. #112 was squash-merged as `00df3b1`, so `feat/shard-repair-protocol` is not an ancestor of `dev` and this branch was replayed with `git rebase --onto origin/dev 4811e14` rather than retargeted.

The performance job is spliced into the existing four-job `predastore-e2e.yml` from #115/#116, replacing its `make e2e-performance` step. `compatibility`, `conformance` and `stress` are untouched.

## Operator setup required before this can run

- **Secret `PREDASTORE_HW_SSH_KEY`** — a passphrase-less private key (`BatchMode=yes` is used) authorized on each hardware host as the user named in `PREDASTORE_HW_HOSTS`.
- **Secret `PREDASTORE_HW_KNOWN_HOSTS`** — one `known_hosts` line per hardware host. Collect these with `ssh-keyscan -t ed25519` from an already-trusted vantage point, not from the runner itself on first use.
- **AWS CLI v2 installed at `/usr/local/aws-cli` on the runner** — `hwbench.sh tools` ships it from there to the tools host; it doesn't install it. The job fails fast with a clear message if it's missing.
- **Required repository variables.** The workflow carries no defaults for these and fails naming any that is unset:
  - `PREDASTORE_HW_HOSTS` — space separated ssh targets in host-id order, as `user@host`
  - `PREDASTORE_HW_ADDRS` — the matching addresses, same order and count
  - `PREDASTORE_HW_ROOT` — CI-only deployment directory, distinct from what a human uses running `hwbench.sh` by hand so `clean` cannot reach a manual deployment. Must be absolute and at least three components deep, since it is deleted recursively on every host
- **Optional repository variable** `CI_PREDASTORE_HW_PAUSED` — set `true` to pause the job.

## What I could not test

I cannot SSH to the hardware hosts and did not try. This change has not been run end to end. What I did verify: `actionlint` and `shellcheck` are clean (aside from a pre-existing self-hosted-label warning `actionlint` already raises against `dev`'s own workflow), `make preflight` passes, and I traced every step against `hwbench.sh`'s actual source — every env var it reads is set, every subcommand gets the arguments it expects, and every path the fetch step reads from is one `cmd_perf`/`save_host_logs` actually writes to.

## Test plan

- [x] `actionlint .github/workflows/predastore-e2e.yml` — clean except the pre-existing `ci-predastore` self-hosted-label warning also present on `dev`'s file
- [x] `shellcheck` on every `run:` block in the new job
- [x] `make preflight`
- [ ] Cannot be run end to end without SSH access to the hardware hosts
