### PR TITLE
fix: do not tear down the hardware cluster when the run never configured one

### DIFF
--- a/.github/workflows/predastore-e2e.yml
+++ b/.github/workflows/predastore-e2e.yml
@@ -242,6 +242,7 @@ jobs:
       # the end of a run, so a shallow path here would be destructive: require
       # an absolute path at least three components deep.
       - name: Check required configuration
+        id: config
         if: steps.gate.outputs.paused != 'true'
         run: |
           set -euo pipefail
@@ -355,7 +356,7 @@ jobs:
       # on every host, so nothing reaches the runner on its own. clean below
       # deletes the source, so this runs first and runs even on failure.
       - name: Fetch results and host logs
-        if: always() && steps.gate.outputs.paused != 'true'
+        if: always() && steps.gate.outputs.paused != 'true' && steps.config.outcome == 'success'
         run: |
           set -euo pipefail
           TOOLS_HOST="$(awk '{print $NF}' <<< "$HW_HOSTS")"
@@ -370,7 +371,7 @@ jobs:
           done
 
       - name: Upload Results
-        if: always() && steps.gate.outputs.paused != 'true'
+        if: always() && steps.gate.outputs.paused != 'true' && steps.config.outcome == 'success'
         uses: actions/upload-artifact@v5
         with:
           name: performance
@@ -381,17 +382,19 @@ jobs:
           retention-days: 30
 
       # Both run under always() so a cancelled run does not leave s3d
-      # processes and cluster data behind on the hardware hosts.
+      # processes and cluster data behind on the hardware hosts. hwbench.sh
+      # substitutes its own defaults for an empty HW_ROOT, so a run that never
+      # got past the configuration check must not reach clean.
       - name: hwbench stop
-        if: always() && steps.gate.outputs.paused != 'true'
+        if: always() && steps.gate.outputs.paused != 'true' && steps.config.outcome == 'success'
         run: scripts/bench/hw/hwbench.sh stop || true
 
       - name: hwbench clean
-        if: always() && steps.gate.outputs.paused != 'true'
+        if: always() && steps.gate.outputs.paused != 'true' && steps.config.outcome == 'success'
         run: scripts/bench/hw/hwbench.sh clean || true
 
       - name: Clean hwbench work dir
-        if: always() && steps.gate.outputs.paused != 'true'
+        if: always() && steps.gate.outputs.paused != 'true' && steps.config.outcome == 'success'
         run: |
           rm -rf "$HW_WORK"
           git worktree prune || true


### PR DESCRIPTION
## Summary

The performance job's teardown steps (`Fetch results`, `Upload Results`, `hwbench stop`, `hwbench clean`, `Clean hwbench work dir`) ran under `always()` gated only on the pause sentinel. A run that failed the `Check required configuration` step still reached them.

That matters because `hwbench.sh` uses `\${HW_ROOT:-<default>}` and `\${HW_HOSTS:-<default>}`, and `:-` substitutes on **empty**, not only on unset. With the repository variables unset the workflow exports empty strings, hwbench falls back to its own defaults, and `hwbench clean` targets the deployment directory a person uses running the harness by hand — recursively, on every host.

## How it was found

Run 33454676284, the first run after #123 merged. `Check required configuration` failed (no repository variables set yet) and steps 18-22 still executed. It was harmless only because `Install SSH key` had been skipped in the same way, so every connection failed and `|| true` swallowed it. Provisioning `PREDASTORE_HW_SSH_KEY` removes that accidental protection.

## Change

Give the check step `id: config` and add `&& steps.config.outcome == 'success'` to the five teardown conditions. Cleanup now runs only when the run got far enough to have created something.

## Test plan

- [x] `actionlint` / `shellcheck` clean via `make preflight`
- [x] YAML parses; step conditions verified
- [ ] Confirmed against a real run once the repository variables and secrets are provisioned