### PR TITLE
ci: stop the conformance and stress jobs burning the runner clock

### DIFF
--- a/.github/workflows/predastore-e2e.yml
+++ b/.github/workflows/predastore-e2e.yml
@@ -125,7 +125,12 @@ jobs:
       # Comparison, never strict. Predastore fails a large part of s3-tests and
       # will for a long while, so the question this job answers is whether the
       # branch moved anything, not whether the suite is green.
+      #
+      # Bounded below the job timeout on purpose: a job that hits its own
+      # timeout skips every later step, including the manifest upload, so the
+      # one artefact that would explain the failure is never produced.
       - name: Conformance Suite
+        timeout-minutes: 20
         run: make s3-tests
 
       - name: Upload Manifest
@@ -170,8 +175,15 @@ jobs:
       # should look red: an overwrite with no commit point across its shards
       # leaves the object part new and part old, served as a 200 with the right
       # length and ETag. The baseline marks it as known rather than excusing it.
+      #
+      # partial-put holds four stalled uploads open for STRESS_PARTIAL_HOLD
+      # each, one after another, which is most of its runtime. 120s still
+      # clears the 90s abandon bound the scenario asserts against by the same
+      # margin the assertion needs, and saves four minutes of runner time.
       - name: Run Scenario
         if: inputs.stress_scenarios == '' || contains(inputs.stress_scenarios, matrix.scenario)
+        env:
+          STRESS_PARTIAL_HOLD: 120
         run: make e2e-stress-strict STRESS_SCENARIOS=${{ matrix.scenario }}
 
       - name: Upload Results

--- a/scripts/s3-tests.sh
+++ b/scripts/s3-tests.sh
@@ -182,16 +182,26 @@ BASELINE_COMMITTED="$SCRIPT_DIR/s3-tests-baseline.txt"
 
 log "Running ceph/s3-tests at ${S3TESTS_REF:0:12} against https://$HOST:$PORT"
 
+# CI is cleared deliberately. pytest disables its own assertion truncation when
+# it detects a CI environment, and this suite compares whole object bodies, so
+# one failed multi-megabyte comparison emits that body four times. The product
+# of this run is the manifest and the regression list, not the diffs.
+#
+# --tb=line for the same reason: several hundred known failures each rendering
+# a full traceback through botocore's internals says nothing the manifest does
+# not, and buries what does. -rf keeps the one-line failure roll-up.
 (
     cd "$CHECKOUT" || exit 2
     PYTHONPATH="$PLUGIN_DIR:$CHECKOUT" \
     PYTHONWARNINGS=ignore \
+    CI= \
     S3TEST_CONF="$CONF" \
     PREDA_S3TESTS_MANIFEST="$RUN" \
     PREDA_S3TESTS_SKIPS="$SKIPS" \
     PREDA_S3TESTS_BASELINE_FILE="$BASELINE_COMMITTED" \
         "$VENV/bin/pytest" "${SUITES[@]}" \
-            -q --no-header -p no:cacheprovider -p predastore_cleanup "$@"
+            -q --no-header --tb=line -rf \
+            -p no:cacheprovider -p predastore_cleanup "$@"
 )
 
 if [ ! -s "$RUN" ]; then


### PR DESCRIPTION
Three CI-side changes. No product behaviour moves.

## Conformance took 35-45 minutes for a five minute suite

pytest disables its own assertion truncation when it detects a CI environment. This suite compares whole object bodies, so a single failed multi-megabyte comparison prints that body four times, and the runner ingests the result a line at a time — measured at 60-171 seconds per line on the worst offenders. `test_atomic_dual_write_{1,4,8}mb` regressed on dev and between them they account for essentially all of the extra half hour. That is deterministic on commit, not flaky: `5b8dfcd` ran in 5m07s, `00df3b1` in 35m29s.

Clearing `CI` restores the truncation. `--tb=line` drops the botocore tracebacks that several hundred known failures each render in full — they say nothing the manifest does not and bury what does. `-rf` keeps the one-line failure roll-up.

The underlying write-ordering failure is tracked separately and is untouched here.

## The conformance step had no timeout of its own

Only the job did, and a job that hits its own timeout skips every later step — including the manifest upload, which is the one artefact that would explain the failure. A 20 minute step timeout leaves the upload to run.

## partial-put spends most of its runtime waiting

The scenario holds four stalled uploads open for `STRESS_PARTIAL_HOLD` seconds each, one after another. At the 180s default that is twelve minutes of the roughly fifteen the leg takes, pass or fail. 120s still clears the 90s `STRESS_PARTIAL_ABANDON` bound the scenario asserts against, so the assertion fires exactly as before.

## Testing

`make preflight` passes. The changes are to a shell script's pytest invocation and to workflow step configuration, so the real verification is the next run's wall clock.