### PR TITLE
ci: run the perf harness at more than its smallest setting

### DIFF
--- a/.github/workflows/predastore-e2e.yml
+++ b/.github/workflows/predastore-e2e.yml
@@ -198,9 +198,11 @@ jobs:
   performance:
     name: Performance (Warp, bare metal)
     # The runner only drives ssh/scp against the hardware hosts and holds no
-    # cluster data of its own.
+    # cluster data of its own, apart from the loopback run below.
     runs-on: [self-hosted, ci-predastore]
-    timeout-minutes: 45
+    # Room for the loopback run in front of the hardware one. Both presets are
+    # smoke, so the whole job has been landing inside 30.
+    timeout-minutes: 60
     # inputs is null on a push, and GitHub coerces both sides of != to a
     # number there, so the event has to be checked first.
     if: github.event_name != 'workflow_dispatch' || inputs.run_performance
@@ -340,6 +342,22 @@ jobs:
         if: steps.gate.outputs.paused != 'true'
         run: make warp-install
 
+      # The bare-metal numbers have no denominator without this. The same code
+      # and the same workloads with the network taken out is what says whether
+      # three hosts are worth having, and PERF_CONFIGS covers 1host and 3host.
+      #
+      # It runs before the hardware cluster starts rather than after it stops:
+      # if this runner is one of the hardware hosts, a loopback cluster beside
+      # a live one measures neither of them.
+      - name: Run Warp Suite (loopback)
+        if: steps.gate.outputs.paused != 'true'
+        env:
+          # /tmp here may be tmpfs and a 30s PUT workload stages gigabytes
+          # through it, so the script's work directory is steered off it.
+          TMPDIR: ${{ runner.temp }}
+          PERF_RESULTS_ROOT: scripts/bench/results/e2e-performance-loopback
+        run: make e2e-performance
+
       - name: hwbench build
         if: steps.gate.outputs.paused != 'true'
         run: scripts/bench/hw/hwbench.sh build
@@ -387,8 +405,12 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: performance
+          # Two roots, not one. A loopback figure and a bare-metal one are not
+          # comparable, and interleaving them under a single timestamped tree
+          # invites reading one as the other.
           path: |
             scripts/bench/results/e2e-performance/
+            scripts/bench/results/e2e-performance-loopback/
             scripts/bench/hw/hostlogs/
           if-no-files-found: ignore
           retention-days: 30

--- a/.github/workflows/predastore-e2e.yml
+++ b/.github/workflows/predastore-e2e.yml
@@ -200,9 +200,10 @@ jobs:
     # The runner only drives ssh/scp against the hardware hosts and holds no
     # cluster data of its own, apart from the loopback run below.
     runs-on: [self-hosted, ci-predastore]
-    # Room for the loopback run in front of the hardware one. Both presets are
-    # smoke, so the whole job has been landing inside 30.
-    timeout-minutes: 60
+    # Four measurement passes now rather than one: two loopback and two on the
+    # hardware, of which the compare preset is much the longest. A single smoke
+    # pass was landing inside 30, so this leaves the same margin again.
+    timeout-minutes: 90
     # inputs is null on a push, and GitHub coerces both sides of != to a
     # number there, so the event has to be checked first.
     if: github.event_name != 'workflow_dispatch' || inputs.run_performance
@@ -224,8 +225,6 @@ jobs:
       # One ref: the commit under test, rather than the script's own default of
       # several refs for a before/after comparison.
       HW_REFS: ci:${{ github.sha }}
-      PERF_TAG: ci-${{ github.run_id }}
-      PERF_PRESET: smoke
 
     steps:
       # The hardware hosts also carry the nested dev clusters and engineers'
@@ -358,6 +357,23 @@ jobs:
           PERF_RESULTS_ROOT: scripts/bench/results/e2e-performance-loopback
         run: make e2e-performance
 
+      # The pass above puts 1 MiB objects, where erasure coding and the disk
+      # dominate and per-operation cost disappears into them. Most real S3
+      # traffic is smaller than this, so the metadata path needs its own pass.
+      #
+      # The part size stays at 5 MiB because S3 rejects a smaller non-final
+      # part, so multipart-put repeats what it already did. put and get are
+      # the two that change shape, and concurrency rises to make them bite.
+      - name: Run Warp Suite (loopback, small objects)
+        if: steps.gate.outputs.paused != 'true'
+        env:
+          TMPDIR: ${{ runner.temp }}
+          PERF_RESULTS_ROOT: scripts/bench/results/e2e-performance-loopback-small
+          PERF_PUT_SIZE: 64KiB
+          PERF_GET_SIZE: 64KiB
+          PERF_CONCURRENT: 16
+        run: make e2e-performance
+
       - name: hwbench build
         if: steps.gate.outputs.paused != 'true'
         run: scripts/bench/hw/hwbench.sh build
@@ -378,9 +394,28 @@ jobs:
         if: steps.gate.outputs.paused != 'true'
         run: scripts/bench/hw/hwbench.sh verify ci
 
-      - name: hwbench perf
+      # Two passes over the same cluster. smoke is 30s workloads at 1 MiB and
+      # answers whether the path works at all; compare is 2m at 64 MiB with
+      # 16-part uploads, which is the sizing the harness was written for and
+      # the only one that saturates anything.
+      #
+      # The tag names the results directory and feeds the warp bucket names,
+      # which S3 caps at 63 characters, so it stays short. Uniqueness across
+      # runs comes from the timestamp the harness already stamps each run with.
+      - name: hwbench perf (smoke)
         if: steps.gate.outputs.paused != 'true'
-        run: scripts/bench/hw/hwbench.sh perf ci "$PERF_TAG"
+        env:
+          PERF_PRESET: smoke
+        run: scripts/bench/hw/hwbench.sh perf ci smoke
+
+      # Runs second, so it writes onto disks already holding the smoke pass.
+      # clean below empties HW_ROOT at the end of every run, so this is one
+      # pass worth of objects rather than an accumulation across runs.
+      - name: hwbench perf (compare)
+        if: steps.gate.outputs.paused != 'true'
+        env:
+          PERF_PRESET: compare
+        run: scripts/bench/hw/hwbench.sh perf ci compare
 
       # Results are written on the tools host (the last in HW_HOSTS) and logs
       # on every host, so nothing reaches the runner on its own. clean below
@@ -411,6 +446,7 @@ jobs:
           path: |
             scripts/bench/results/e2e-performance/
             scripts/bench/results/e2e-performance-loopback/
+            scripts/bench/results/e2e-performance-loopback-small/
             scripts/bench/hw/hostlogs/
           if-no-files-found: ignore
           retention-days: 30


### PR DESCRIPTION
The performance job was measuring one shape — 30 second workloads at 1 MiB, on three hosts, with nothing to compare the result against. The harness is already capable of much more than that: `e2e-performance.sh` takes every sizing knob from the environment, and `hwbench.sh` takes a tag per pass so several passes can share one deployed cluster. Both of those go unused today.

So this is a workflow change only. No script edits, no new config files, no `warp cmp` wiring.

## Four passes instead of one

**Loopback, 1 MiB.** `PERF_CONFIGS` already defaults to `1host 3host`, and `e2e-performance.sh` renders and starts both itself. The bare-metal aggregate has no denominator without this: "three hosts do 272 MiB/s" cannot be told apart from "one host does 272 and the other two contribute nothing".

**Loopback, 64 KiB.** At 1 MiB the erasure coding and the disk dominate and per-operation cost disappears into them. Most real S3 traffic is smaller, where signature validation, the raft commit and shard placement are the whole cost, and an ops/sec regression there is currently invisible. Concurrency rises to 16 so it bites. The part size stays at 5 MiB because S3 rejects a smaller non-final part, so `multipart-put` repeats what it already did — `put` and `get` are the two that change shape.

**Hardware, smoke.** As before.

**Hardware, compare.** 2m workloads, concurrency 8, 64 MiB PUT, 16-part uploads, 128 MiB GET. This is the sizing the harness was written for and the only one that saturates anything. `cmd_perf` already defaults to it; the job was overriding it to smoke.

Both hardware passes run against one deployed cluster, so the extra pass costs the benchmark time and not another build, deploy and start.

## Result layout

Each pass gets its own root, uploaded under the existing `performance` artifact. A loopback figure and a bare-metal one are not comparable, and neither is 64 KiB against 1 MiB; interleaving them under one timestamped tree invites reading one as another.

## Tag change

The hardware tag is now the preset name rather than `ci-<run_id>`. It reaches the warp bucket names, which S3 caps at 63 characters, and `ci-ci-<11 digit run id>-compare-multipart-put-<timestamp>` sits right on that limit. Uniqueness across runs already comes from the timestamp the harness stamps every run directory with.

## Placement and timeout

The loopback passes run before the hardware cluster starts, not after it stops: if this runner is one of the hardware hosts, a loopback cluster standing beside a live one measures neither. `TMPDIR` points at `runner.temp` because `/tmp` here may be tmpfs and a PUT workload stages gigabytes through the script's work directory.

A loopback failure therefore blocks the hardware run. That is intended — `e2e-performance.sh` does AWS CLI round trips with SHA256 comparison before it times anything, so a failure there means the data path is broken and a throughput number is not worth collecting.

Timeout goes 45 to 90. A single smoke pass was landing inside 30.

## Testing

`make preflight` passes; the workflow parses and the step order and per-step environment are as intended. `make e2e-performance` is the same target this job ran before the hardware work landed, so it is already proven on this runner. Real verification is the next run's artifact carrying four roots.

## Not in scope

Multi-ref before/after on the hardware — `HW_REFS` already accepts several `name:ref` pairs and `cmd_build` builds each, so it needs only a loop, but it also needs `fetch-depth: 0` and roughly doubles the job.

LIST, DELETE, STAT and range GET, which `run_warp` cannot reach from the environment because it hardcodes `put`, `multipart-put` and `get`.

Gating on any of these numbers is `mulga-wpjsx`. `warp cmp` has no threshold flag and exits 0 regardless, so a gate means threshold logic written against measured spread — which these repeated passes start to supply.