### PR TITLE
feat: implement the S3 batch delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Two of these have constraints the container cannot paper over:
 | Multipart | `CreateMultipartUpload`, `UploadPart`, `CompleteMultipartUpload`, `AbortMultipartUpload` |
 | Authentication | AWS Signature Version 4, presigned URLs |
 
-Multi-object delete (`DeleteObjects`) is not implemented; delete objects one at a time.
+Multi-object delete (`DeleteObjects`) takes up to 1000 keys per request and reports the outcome of each one.
 
 How far that support goes is measured rather than claimed. [docs/S3-COMPATIBILITY.md](docs/S3-COMPATIBILITY.md) holds the result of running `ceph/s3-tests` — the suite Ceph RGW, MinIO and Garage are all validated against — with the per-case manifest in `scripts/s3-tests-baseline.txt`. Read it before assuming an operation behaves the way S3 documents it.
 
@@ -346,7 +346,6 @@ sudo sysctl -w net.core.wmem_max=7500000
 - [x] Background segment compaction
 - [ ] Envelope encryption (master key rotation, per-bucket / per-tenant keys)
 - [ ] Gossip-based node discovery
-- [ ] Multi-object delete (`DeleteObjects`)
 - [ ] Automatic shard rebalancing
 - [ ] Background read-repair
 - [ ] Bucket versioning

--- a/config.go
+++ b/config.go
@@ -49,6 +49,7 @@ type NodeConfig = config.Node
 type (
 	RS         = config.RS
 	Repair     = config.Repair
+	Reaper     = config.Reaper
 	Compaction = config.Compaction
 	S3         = config.S3
 	Bucket     = config.Bucket
@@ -209,6 +210,16 @@ func gateConfig(
 			Workers:  c.Repair.Workers,
 			PageSize: c.Repair.PageSize,
 			Interval: time.Duration(c.Repair.IntervalSeconds) * time.Second,
+		},
+
+		// Reaper has no ownership scoping: every gate that runs repair also
+		// runs it, and a tombstone racing two gates costs redundant RPCs and
+		// nothing else.
+		Reaper: gate.ReaperConfig{
+			Enabled:  c.Reaper.IsEnabled(),
+			Workers:  c.Reaper.Workers,
+			PageSize: c.Reaper.PageSize,
+			Interval: time.Duration(c.Reaper.IntervalSeconds) * time.Second,
 		},
 
 		Addr:        config.NodeBindAddr(host, n),

--- a/docs/S3-COMPATIBILITY.md
+++ b/docs/S3-COMPATIBILITY.md
@@ -15,8 +15,8 @@ make s3-tests
 
 | | count |
 | --- | --- |
-| pass | 178 |
-| fail | 216 |
+| pass | 181 |
+| fail | 213 |
 | skip | 492 |
 | error | 0 |
 
@@ -29,13 +29,12 @@ A passing case is never one of the 486, whatever family's marker or node id woul
 
 A skip is not a pass. It means the same thing it always did for the suite's own skips: predastore has not been measured against that case in this run, on purpose. `docs/development/bugs/` and `docs/development/improvements/` carry the beads for anything in progress; a deliberate skip here means no bead is open yet.
 
-The 216 remaining fails are not features predastore has not started — those are now skipped — they are operations predastore attempts and gets wrong, or is actively being fixed: DeleteObjects, CopyObject and multipart copy, ETag, `ListObjects` v1 `Marker`, user metadata, sub-resource routing, and the request-validation cases in `test_headers.py`. The gaps that hurt an ordinary client are a much shorter list, and they are in the first table below.
+The 213 remaining fails are not features predastore has not started — those are now skipped — they are operations predastore attempts and gets wrong, or is actively being fixed: CopyObject and multipart copy, ETag, `ListObjects` v1 `Marker`, user metadata, sub-resource routing, and the request-validation cases in `test_headers.py`. The gaps that hurt an ordinary client are a much shorter list, and they are in the first table below.
 
 ## The gaps that break real clients
 
 | Operation | State | What happens |
 | --- | --- | --- |
-| `DeleteObjects` | **Missing** | 405 Method Not Allowed. Every client that empties a bucket in batches — the AWS CLI's `s3 rm --recursive`, rclone `purge`, the s3-tests teardown — falls back or fails. |
 | ETag | **Wrong value** | Not the body MD5. `PUT` of `hello` returns `678f45d4…`, not `5d41402a…`. It is also unquoted, where S3 quotes it, and `ListObjectsV2` returns it as the empty string while `HEAD` and `GET` return a value. rclone rejects every upload as corrupt on this. |
 | `ListObjects` (v1) | **Partial** | `Marker` is ignored. A v1 listing with `Marker=baz&MaxKeys=2` returns the first two keys again rather than the ones after `baz`, so a v1 client paging a prefix loops. v2's `continuation-token` and `start-after` do work. |
 | `ListObjectVersions` | **Answers the wrong document** | `GET /{bucket}?versions` is not routed, so it falls through and serves a plain `ListBucketResult`. boto3 parses that as zero versions and reports success. A client asking what versions exist is told "none". |
@@ -74,7 +73,7 @@ deliberately not implemented is not here; see the next table.
 | Object create / write | 11 | 25 | Metadata and conditional headers. |
 | Multipart upload | 6 | 6 | |
 | Ranged GET | 4 | 1 | |
-| DeleteObjects | 0 | 9 | 405. |
+| DeleteObjects | 3 | 6 | Implemented. What is left is versioned deletes, and the v1 key-limit case, which pages the bucket with `Marker`. |
 | CopyObject / copy part | 4 | 23 | Excludes encrypted copy, which is a deliberate skip below. |
 
 ## Deliberate skips
@@ -130,6 +129,6 @@ make s3-tests-baseline
 
 ## Caveat: the run needs a cleanup fallback
 
-s3-tests empties a bucket with `ListObjectVersions` and `DeleteObjects`. Predastore supports neither correctly, so nothing is deleted, every `DeleteBucket` answers `BucketNotEmpty`, and that failure lands in the *setup* of the next case. Unpatched, the run is 884 errors that say nothing about the 884 operations they were meant to measure.
+s3-tests empties a bucket with `ListObjectVersions` and `DeleteObjects`. `DeleteObjects` works now, but `ListObjectVersions` still answers the wrong document, so nothing is deleted, every `DeleteBucket` answers `BucketNotEmpty`, and that failure lands in the *setup* of the next case. Unpatched, the run is 884 errors that say nothing about the 884 operations they were meant to measure.
 
-`scripts/s3tests/predastore_cleanup.py` replaces the suite's teardown helper with per-key deletes. No test body, assertion or fixture value changes, and cleanup is not a measured behaviour. Delete that half of the plugin when `DeleteObjects` lands.
+`scripts/s3tests/predastore_cleanup.py` replaces the suite's teardown helper with per-key deletes. No test body, assertion or fixture value changes, and cleanup is not a measured behaviour. It stays until `ListObjectVersions` answers the right document, which is the half of the problem the batch delete did not fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -111,7 +111,6 @@ One cluster-wide master key, no envelope layer. Rotating it would mean re-encryp
 
 ## S3 API
 
-- `POST /{bucket}?delete=` (batch DeleteObjects). Returns 405 because no route exists; warp's mixed-test cleanup hits it. Routing plus a fan-out over the existing single-object delete.
 - **Pagination for `ListObjects`.** The handler scans and returns everything under the prefix, hardcodes `IsTruncated: false`, and does not enforce `max-keys`. A large bucket returns an unbounded response.
 - **`LastModified` is not stored.** Listings report the current time for every object. Needs a timestamp in the placement record, or a parallel metadata key.
 - **ETag backfill for pre-v3 objects.** `PutObject` and `CompleteMultipartUpload` store the body's MD5 in placement record v3 — a plain hex digest for a single part, `"<md5>-<N>"` for a multipart object assembled from N parts — and `GetObject`, `HeadObject` and `ListObjectsV2` return it as the ETag. An object written under an older placement version has no stored digest, so these surfaces omit its ETag rather than serve a stale value, and there is no migration to add one.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -183,6 +183,24 @@ type Repair struct {
 // no local blob node still runs none, because there is nothing for it to own.
 func (r Repair) IsEnabled() bool { return r.Enabled == nil || *r.Enabled }
 
+// Reaper tunes the background sweep that reclaims the shards a delete leaves
+// tombstoned. It is on by default: a delete no longer removes its shards
+// inline, so without this sweep running they are never reclaimed at all.
+type Reaper struct {
+	Enabled *bool `toml:"enabled"`
+
+	// Workers bounds concurrent tombstone reclaims, PageSize how many
+	// tombstone rows a scan asks for at a time, and IntervalSeconds the gap
+	// between passes. Zero takes the sweep's own default for each.
+	Workers         int `toml:"workers"`
+	PageSize        int `toml:"page_size"`
+	IntervalSeconds int `toml:"interval_seconds"`
+}
+
+// IsEnabled reports whether the sweep should run. Absent means on; a host with
+// no local blob node still runs none, because there is nothing for it to own.
+func (r Reaper) IsEnabled() bool { return r.Enabled == nil || *r.Enabled }
+
 // Compaction tunes the shard store's background compactor. A zero interval
 // falls back to the store's default; compaction itself is never off, because
 // without it overwrite and delete churn never reclaims dead shards.
@@ -272,6 +290,8 @@ type Config struct {
 	Hosts []Host `toml:"host"`
 
 	Repair Repair `toml:"repair"`
+
+	Reaper Reaper `toml:"reaper"`
 
 	Compaction Compaction `toml:"compaction"`
 

--- a/internal/gate/delete_test.go
+++ b/internal/gate/delete_test.go
@@ -1,11 +1,13 @@
 package gate
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDeleteObjectNoAuth(t *testing.T) {
@@ -20,6 +22,39 @@ func TestDeleteObjectNoAuth(t *testing.T) {
 	server.ServeHTTP(rr, req)
 
 	assert.Equal(t, 403, rr.Code, "Status code should be 403")
+}
+
+// The batch delete is selected by ?delete alone. A POST at a bucket without it
+// is not an operation predastore serves, and must not fall through to one.
+func TestPostBucketWithoutDeleteIsNotAllowed(t *testing.T) {
+	config := newAuthTestConfig()
+	server := newTestGate(t, config)
+
+	req := httptest.NewRequest(http.MethodPost, "/local", nil)
+	signTestReq(t, req, nil, "AKIAIOSFODNN7EXAMPLE",
+		"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", config.Region, "s3")
+
+	rr := httptest.NewRecorder()
+	server.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code, "body: %s", rr.Body.String())
+}
+
+func TestDeleteObjectsRoutesThroughTheGate(t *testing.T) {
+	config := newAuthTestConfig()
+	server := newTestGate(t, config)
+
+	body := []byte("<Delete><Object><Key>gone.txt</Key></Object></Delete>")
+	req := httptest.NewRequest(http.MethodPost, "/local?delete=", bytes.NewReader(body))
+	signTestReq(t, req, body, "AKIAIOSFODNN7EXAMPLE",
+		"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", config.Region, "s3")
+
+	rr := httptest.NewRecorder()
+	server.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	assert.Contains(t, rr.Body.String(), "<DeleteResult>")
+	assert.Contains(t, rr.Body.String(), "gone.txt")
 }
 
 func TestDeleteObjectBadAuth(t *testing.T) {

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mulgadc/predastore/internal/config"
 	"github.com/mulgadc/predastore/internal/gate/auth"
 	"github.com/mulgadc/predastore/internal/gate/handlers"
+	"github.com/mulgadc/predastore/internal/gate/reaper"
 	"github.com/mulgadc/predastore/internal/gate/repair"
 	"github.com/mulgadc/predastore/internal/meta"
 )
@@ -38,6 +39,9 @@ var (
 
 	_ repair.MetaClient = MetaClient(nil)
 	_ repair.BlobClient = BlobClient(nil)
+
+	_ reaper.MetaClient = MetaClient(nil)
+	_ reaper.BlobClient = BlobClient(nil)
 )
 
 // RS fixes the erasure code the gate places objects with.
@@ -63,6 +67,20 @@ type RepairConfig struct {
 	// Workers bounds concurrent shard rebuilds, PageSize how many placement
 	// records a scan asks for at a time, and Interval the gap between passes.
 	// Zero takes the repair package's own default for each.
+	Workers  int
+	PageSize int
+	Interval time.Duration
+}
+
+// ReaperConfig tunes the background sweep that reclaims the shards a delete
+// leaves tombstoned. It is on by default: a delete no longer removes its
+// shards inline, so without this sweep they are never reclaimed at all.
+type ReaperConfig struct {
+	Enabled bool
+
+	// Workers bounds concurrent tombstone reclaims, PageSize how many
+	// tombstone rows a scan asks for at a time, and Interval the gap between
+	// passes. Zero takes the reaper package's own default for each.
 	Workers  int
 	PageSize int
 	Interval time.Duration
@@ -97,6 +115,10 @@ type Config struct {
 	// Repair sweeps for shards a local blob node owns but does not hold at the
 	// generation its record names.
 	Repair RepairConfig
+
+	// Reaper sweeps for tombstones a delete left and reclaims the shards they
+	// name.
+	Reaper ReaperConfig
 
 	// TODO: Move to IAM
 	Auth []auth.Entry

--- a/internal/gate/handlers/delete_object.go
+++ b/internal/gate/handlers/delete_object.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -12,16 +13,22 @@ import (
 	"github.com/mulgadc/predastore/internal/gate/model"
 )
 
-// deletedObjectPrefix keys the tombstone left behind by a delete, so a future
-// compaction coordinator can find which nodes hold dead shards.
-const deletedObjectPrefix = "deleted:"
+// DeletedObjectPrefix keys the tombstone left behind by a delete whose shard
+// fan-out failed, so the reaper sweep can find which nodes still hold shards
+// it needs to reclaim. Exported so the reaper package, which pages only these
+// rows, can build the same scan prefix without duplicating it.
+const DeletedObjectPrefix = "deleted:"
 
-// DeletedObjectInfo tracks a deleted object for compaction coordination.
+// DeletedObjectInfo names the shards a failed fan-out left behind, so the
+// reaper sweep can reclaim them once it is safe to. It is load-bearing: once
+// the placement record is gone, this is the only record of where the shards
+// are.
 type DeletedObjectInfo struct {
 	Bucket         string          `json:"bucket"`
 	Key            string          `json:"key"`
 	ObjectHash     [32]byte        `json:"object_hash"`
 	DeletedAt      int64           `json:"deleted_at"`       // Unix timestamp
+	WriteEpoch     uint64          `json:"write_epoch"`      // The placement's write epoch, so the reaper can tell a recreate from its own delete still in flight
 	DataShardNodes []config.NodeID `json:"data_shard_nodes"` // Which nodes had data shards
 	ParityNodes    []config.NodeID `json:"parity_nodes"`     // Which nodes had parity shards
 }
@@ -55,6 +62,14 @@ func DeleteObject(mc MetaClient, bc BlobClient, cache *BucketCache) http.Handler
 // the single-object route answers as 404 and the batch route reports as
 // deleted — S3's delete is idempotent only in the batch form.
 //
+// The shard fan-out runs inline, same as ever. Its failure does not fail the
+// delete: instead a tombstone naming the shards is written, and the reaper
+// sweep reclaims them later. On success no tombstone is written at all, so
+// the common path pays nothing extra. A tombstone write that itself fails
+// does fail the delete and leaves both index entries in place — once the
+// placement record is gone the tombstone would be the only surviving record
+// of which nodes hold the shards, and losing it there leaks them permanently.
+//
 // The caller has already established that the bucket exists.
 func deleteStoredObject(ctx context.Context, mc MetaClient, bc BlobClient, bucket, key string) error {
 	objectHash := model.ObjectHash(bucket, key)
@@ -69,32 +84,34 @@ func deleteStoredObject(ctx context.Context, mc MetaClient, bc BlobClient, bucke
 		return model.NewS3Error(model.ErrInternalError, "corrupt metadata", 500)
 	}
 
-	// A node that refuses its shard delete leaves garbage the compactor will
-	// reclaim; the object must still disappear from state.
 	if err := deleteObject(ctx, bc, bucket, key, objectHash, place); err != nil {
 		slog.ErrorContext(ctx, "deleteObject failed", "error", err)
+
+		deletedInfo := DeletedObjectInfo{
+			Bucket:         bucket,
+			Key:            key,
+			ObjectHash:     objectHash,
+			DeletedAt:      time.Now().Unix(),
+			WriteEpoch:     place.WriteEpoch,
+			DataShardNodes: place.DataShardNodes,
+			ParityNodes:    place.ParityShardNodes,
+		}
+		var deletedBuf bytes.Buffer
+		if err := gob.NewEncoder(&deletedBuf).Encode(deletedInfo); err != nil {
+			return model.NewS3Error(model.ErrInternalError, fmt.Sprintf("encode tombstone: %v", err), 500)
+		}
+		if err := metaPut(ctx, mc, model.TableObjects, DeletedObjectPrefix+bucket+"/"+key, deletedBuf.Bytes()); err != nil {
+			return model.NewS3Error(model.ErrInternalError, err.Error(), 500)
+		}
 	}
 
-	// TODO: A future compaction coordinator can scan these entries to know which
-	// shard servers have deleted data that needs WAL compaction.
-	deletedInfo := DeletedObjectInfo{
-		Bucket:         bucket,
-		Key:            key,
-		ObjectHash:     objectHash,
-		DeletedAt:      time.Now().Unix(),
-		DataShardNodes: place.DataShardNodes,
-		ParityNodes:    place.ParityShardNodes,
-	}
-	var deletedBuf bytes.Buffer
-	if err := gob.NewEncoder(&deletedBuf).Encode(deletedInfo); err == nil {
-		_ = metaPut(ctx, mc, model.TableObjects, deletedObjectPrefix+bucket+"/"+key, deletedBuf.Bytes()) // Best effort
+	if err := metaDelete(ctx, mc, model.TableObjects, objectARN(bucket, key)); err != nil {
+		return model.NewS3Error(model.ErrInternalError, err.Error(), 500)
 	}
 
 	if err := metaDelete(ctx, mc, model.TableObjects, string(objectHash[:])); err != nil {
 		return model.NewS3Error(model.ErrInternalError, err.Error(), 500)
 	}
-
-	_ = metaDelete(ctx, mc, model.TableObjects, objectARN(bucket, key)) // Best effort
 
 	return nil
 }

--- a/internal/gate/handlers/delete_object.go
+++ b/internal/gate/handlers/delete_object.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/gob"
 	"log/slog"
 	"net/http"
@@ -40,48 +41,60 @@ func DeleteObject(mc MetaClient, bc BlobClient, cache *BucketCache) http.Handler
 			return
 		}
 
-		objectHash := model.ObjectHash(bucket, key)
-
-		data, err := metaGet(ctx, mc, model.TableObjects, string(objectHash[:]))
-		if err != nil {
-			HandleError(w, r, model.ErrNoSuchKeyError.WithResource(key))
+		if err := deleteStoredObject(ctx, mc, bc, bucket, key); err != nil {
+			HandleError(w, r, err)
 			return
 		}
-
-		place, err := DecodePlacement(data)
-		if err != nil {
-			HandleError(w, r, model.NewS3Error(model.ErrInternalError, "corrupt metadata", 500))
-			return
-		}
-
-		// A node that refuses its shard delete leaves garbage the compactor will
-		// reclaim; the object must still disappear from state.
-		if err := deleteObject(ctx, bc, bucket, key, objectHash, place); err != nil {
-			slog.ErrorContext(ctx, "deleteObject failed", "error", err)
-		}
-
-		// TODO: A future compaction coordinator can scan these entries to know which
-		// shard servers have deleted data that needs WAL compaction.
-		deletedInfo := DeletedObjectInfo{
-			Bucket:         bucket,
-			Key:            key,
-			ObjectHash:     objectHash,
-			DeletedAt:      time.Now().Unix(),
-			DataShardNodes: place.DataShardNodes,
-			ParityNodes:    place.ParityShardNodes,
-		}
-		var deletedBuf bytes.Buffer
-		if err := gob.NewEncoder(&deletedBuf).Encode(deletedInfo); err == nil {
-			_ = metaPut(ctx, mc, model.TableObjects, deletedObjectPrefix+bucket+"/"+key, deletedBuf.Bytes()) // Best effort
-		}
-
-		if err := metaDelete(ctx, mc, model.TableObjects, string(objectHash[:])); err != nil {
-			HandleError(w, r, model.NewS3Error(model.ErrInternalError, err.Error(), 500))
-			return
-		}
-
-		_ = metaDelete(ctx, mc, model.TableObjects, objectARN(bucket, key)) // Best effort
 
 		w.WriteHeader(http.StatusNoContent)
 	})
+}
+
+// deleteStoredObject removes one object: its shards, then the metadata that
+// names them. A key that is not there returns model.ErrNoSuchKeyError, which
+// the single-object route answers as 404 and the batch route reports as
+// deleted — S3's delete is idempotent only in the batch form.
+//
+// The caller has already established that the bucket exists.
+func deleteStoredObject(ctx context.Context, mc MetaClient, bc BlobClient, bucket, key string) error {
+	objectHash := model.ObjectHash(bucket, key)
+
+	data, err := metaGet(ctx, mc, model.TableObjects, string(objectHash[:]))
+	if err != nil {
+		return model.ErrNoSuchKeyError.WithResource(key)
+	}
+
+	place, err := DecodePlacement(data)
+	if err != nil {
+		return model.NewS3Error(model.ErrInternalError, "corrupt metadata", 500)
+	}
+
+	// A node that refuses its shard delete leaves garbage the compactor will
+	// reclaim; the object must still disappear from state.
+	if err := deleteObject(ctx, bc, bucket, key, objectHash, place); err != nil {
+		slog.ErrorContext(ctx, "deleteObject failed", "error", err)
+	}
+
+	// TODO: A future compaction coordinator can scan these entries to know which
+	// shard servers have deleted data that needs WAL compaction.
+	deletedInfo := DeletedObjectInfo{
+		Bucket:         bucket,
+		Key:            key,
+		ObjectHash:     objectHash,
+		DeletedAt:      time.Now().Unix(),
+		DataShardNodes: place.DataShardNodes,
+		ParityNodes:    place.ParityShardNodes,
+	}
+	var deletedBuf bytes.Buffer
+	if err := gob.NewEncoder(&deletedBuf).Encode(deletedInfo); err == nil {
+		_ = metaPut(ctx, mc, model.TableObjects, deletedObjectPrefix+bucket+"/"+key, deletedBuf.Bytes()) // Best effort
+	}
+
+	if err := metaDelete(ctx, mc, model.TableObjects, string(objectHash[:])); err != nil {
+		return model.NewS3Error(model.ErrInternalError, err.Error(), 500)
+	}
+
+	_ = metaDelete(ctx, mc, model.TableObjects, objectARN(bucket, key)) // Best effort
+
+	return nil
 }

--- a/internal/gate/handlers/delete_object_test.go
+++ b/internal/gate/handlers/delete_object_test.go
@@ -1,0 +1,155 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"errors"
+	"testing"
+
+	"github.com/mulgadc/predastore/internal/blob"
+	"github.com/mulgadc/predastore/internal/config"
+	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// putFailingMeta fails a Put whose key matches failOn, and otherwise behaves
+// like the meta store underneath it.
+type putFailingMeta struct {
+	*fakeMeta
+
+	failOn func(key string) bool
+}
+
+func (m *putFailingMeta) Put(ctx context.Context, key string, value []byte) error {
+	if m.failOn != nil && m.failOn(key) {
+		return errors.New("simulated meta failure")
+	}
+	return m.fakeMeta.Put(ctx, key, value)
+}
+
+var _ MetaClient = (*putFailingMeta)(nil)
+
+// failingBlob fails every shard Delete, standing in for a fan-out that could
+// not reach any node.
+type failingBlob struct {
+	*fakeBlob
+}
+
+func (b *failingBlob) Delete(_ context.Context, _ config.NodeID, _ blob.DeleteRequest) (*blob.DeleteResponse, error) {
+	return nil, errors.New("simulated node unreachable")
+}
+
+var _ BlobClient = (*failingBlob)(nil)
+
+// tombstoneKey is the stored key one delete's tombstone lands under.
+func tombstoneKey(bucket, key string) string { return DeletedObjectPrefix + bucket + "/" + key }
+
+// decodeTombstone reads and gob-decodes the tombstone a delete left.
+func decodeTombstone(t *testing.T, mc MetaClient, bucket, key string) DeletedObjectInfo {
+	t.Helper()
+	data, err := metaGet(context.Background(), mc, model.TableObjects, tombstoneKey(bucket, key))
+	require.NoError(t, err)
+
+	var info DeletedObjectInfo
+	require.NoError(t, gob.NewDecoder(bytes.NewReader(data)).Decode(&info))
+	return info
+}
+
+// tombstoneExists reports whether a delete left a tombstone behind.
+func tombstoneExists(mc MetaClient, bucket, key string) bool {
+	_, err := metaGet(context.Background(), mc, model.TableObjects, tombstoneKey(bucket, key))
+	return err == nil
+}
+
+// A fan-out that succeeds is the common case, and it must leave no tombstone
+// at all: that is the whole point of only using one on the failure path.
+func TestDeleteStoredObjectSuccessWritesNoTombstone(t *testing.T) {
+	t.Parallel()
+
+	f := newDeleteFixture(t, "a.txt")
+
+	err := deleteStoredObject(context.Background(), f.write.mc, f.write.bc, deleteTestBucket, "a.txt")
+
+	require.NoError(t, err)
+	assert.False(t, f.exists(t, "a.txt"), "the placement record must be gone")
+	assert.False(t, tombstoneExists(f.write.mc, deleteTestBucket, "a.txt"), "a successful fan-out must leave no tombstone")
+}
+
+// When the fan-out fails the delete still succeeds from the caller's point of
+// view, and the tombstone it leaves behind is what the reaper sweep reclaims
+// from, so it has to survive decodable and naming exactly what the placement
+// did.
+func TestDeleteStoredObjectFailedFanOutWritesTombstone(t *testing.T) {
+	t.Parallel()
+
+	f := newDeleteFixture(t)
+	ctx := context.Background()
+	objectHash := model.ObjectHash(deleteTestBucket, "a.txt")
+
+	place, _, err := f.write.write(ctx, objectHash, bytes.NewReader([]byte("body")), 4)
+	require.NoError(t, err)
+	record, err := EncodePlacement(place)
+	require.NoError(t, err)
+	require.NoError(t, metaPut(ctx, f.write.mc, model.TableObjects, string(objectHash[:]), record))
+	require.NoError(t, metaPut(ctx, f.write.mc, model.TableObjects, objectARN(deleteTestBucket, "a.txt"), objectHash[:]))
+
+	bc := &failingBlob{fakeBlob: f.write.bc}
+	err = deleteStoredObject(ctx, f.write.mc, bc, deleteTestBucket, "a.txt")
+	require.NoError(t, err, "a failed fan-out must not fail the delete")
+
+	info := decodeTombstone(t, f.write.mc, deleteTestBucket, "a.txt")
+	assert.Equal(t, deleteTestBucket, info.Bucket)
+	assert.Equal(t, "a.txt", info.Key)
+	assert.Equal(t, objectHash, info.ObjectHash)
+	assert.Equal(t, place.WriteEpoch, info.WriteEpoch)
+	assert.Equal(t, place.DataShardNodes, info.DataShardNodes)
+	assert.Equal(t, place.ParityShardNodes, info.ParityNodes)
+
+	assert.False(t, f.exists(t, "a.txt"), "the placement record must still be removed")
+	_, arnErr := metaGet(ctx, f.write.mc, model.TableObjects, objectARN(deleteTestBucket, "a.txt"))
+	assert.Error(t, arnErr, "the listing row must still be removed")
+}
+
+// A tombstone write that fails after the fan-out also failed must fail the
+// whole delete and leave both index entries in place: once the placement
+// record is gone the tombstone would be the only record of where the shards
+// are, so losing it there would leak them permanently.
+func TestFailedTombstoneWriteAfterFailedFanOutLeavesBothIndexEntries(t *testing.T) {
+	t.Parallel()
+
+	f := newDeleteFixture(t, "a.txt")
+	failingMeta := &putFailingMeta{
+		fakeMeta: f.write.mc,
+		failOn: func(key string) bool {
+			return key == TableKey(model.TableObjects, tombstoneKey(deleteTestBucket, "a.txt"))
+		},
+	}
+	bc := &failingBlob{fakeBlob: f.write.bc}
+
+	err := deleteStoredObject(context.Background(), failingMeta, bc, deleteTestBucket, "a.txt")
+
+	require.Error(t, err)
+	assert.True(t, f.exists(t, "a.txt"), "the placement record must survive a failed tombstone write")
+
+	_, arnErr := metaGet(context.Background(), f.write.mc, model.TableObjects, objectARN(deleteTestBucket, "a.txt"))
+	assert.NoError(t, arnErr, "the listing row must survive a failed tombstone write")
+
+	_, tombErr := metaGet(context.Background(), f.write.mc, model.TableObjects, tombstoneKey(deleteTestBucket, "a.txt"))
+	assert.Error(t, tombErr, "no tombstone should exist when its own write failed")
+}
+
+// A missing key is still model.ErrNoSuchKeyError, unaffected by whether the
+// fan-out would have succeeded: both the single-object 404 and the batch's
+// idempotent report depend on it.
+func TestDeleteStoredObjectMissingKeyIsNoSuchKey(t *testing.T) {
+	t.Parallel()
+
+	f := newDeleteFixture(t)
+
+	err := deleteStoredObject(context.Background(), f.write.mc, f.write.bc, deleteTestBucket, "never-existed.txt")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, model.ErrNoSuchKeyError)
+}

--- a/internal/gate/handlers/delete_objects.go
+++ b/internal/gate/handlers/delete_objects.go
@@ -112,10 +112,8 @@ func deleteBatch(
 	indices := make(chan int)
 
 	var wg sync.WaitGroup
-	wg.Add(workers)
 	for range workers {
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := range indices {
 				// A request that ran out of time reports the keys it never
 				// reached rather than claiming them deleted.
@@ -125,7 +123,7 @@ func deleteBatch(
 				}
 				outcomes[i] = deleteStoredObject(ctx, mc, bc, bucket, objects[i].Key)
 			}
-		}()
+		})
 	}
 
 	for i := range objects {

--- a/internal/gate/handlers/delete_objects.go
+++ b/internal/gate/handlers/delete_objects.go
@@ -1,0 +1,148 @@
+package handlers
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+
+	"github.com/mulgadc/predastore/internal/gate/model"
+)
+
+const (
+	// maxDeleteObjects is the batch size S3 accepts. Beyond it the request is
+	// rejected rather than trimmed, so a client cannot believe it deleted keys
+	// the server never looked at.
+	maxDeleteObjects = 1000
+
+	// deleteObjectsBodyLimit bounds the request document. A full batch of keys
+	// at S3's 1024-byte maximum is a little over a megabyte, so this is four
+	// times the largest legitimate body and no basis for an allocation a
+	// malformed length could drive.
+	deleteObjectsBodyLimit = 4 << 20
+
+	// deleteObjectsWorkers bounds how many keys are deleted at once. Each one
+	// is a metadata read, a shard fan-out and two metadata writes, and a batch
+	// of a thousand run one at a time is the round-trip cost this operation
+	// exists to remove.
+	deleteObjectsWorkers = 8
+)
+
+// DeleteObjects serves POST /{bucket}?delete: the batch delete.
+//
+// Every key is reported on independently. One that cannot be deleted produces
+// an Error entry beside the Deleted entries for the rest and never fails the
+// request, which is what lets a client emptying a bucket make progress.
+func DeleteObjects(mc MetaClient, bc BlobClient, cache *BucketCache) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		resource, ok := routedBucket(w, r)
+		if !ok {
+			return
+		}
+		bucket := resource.Name
+
+		if err := requireBucket(ctx, mc, cache, bucket); err != nil {
+			HandleError(w, r, err)
+			return
+		}
+
+		body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, deleteObjectsBodyLimit))
+		if err != nil {
+			HandleError(w, r, model.NewS3Error(model.ErrMalformedXML,
+				"The delete request could not be read", 400))
+			return
+		}
+
+		var request DeleteRequest
+		if err := xml.Unmarshal(body, &request); err != nil {
+			HandleError(w, r, model.NewS3Error(model.ErrMalformedXML,
+				"The XML you provided was not well-formed or did not validate against our published schema", 400))
+			return
+		}
+		if len(request.Objects) == 0 || len(request.Objects) > maxDeleteObjects {
+			HandleError(w, r, model.NewS3Error(model.ErrMalformedXML,
+				fmt.Sprintf("A delete request must name between 1 and %d objects", maxDeleteObjects), 400))
+			return
+		}
+
+		outcomes := deleteBatch(ctx, mc, bc, bucket, request.Objects)
+
+		result := DeleteResult{}
+		for i, object := range request.Objects {
+			key := object.Key
+			// A key that was never there is reported as deleted: a client
+			// emptying a bucket races its own listing, and failing it for a key
+			// that is already gone gives it nothing to do about the answer.
+			if outcomes[i] != nil && !errors.Is(outcomes[i], model.ErrNoSuchKeyError) {
+				code, message := deleteFailure(outcomes[i])
+				result.Errors = append(result.Errors, DeleteError{Key: key, Code: code, Message: message})
+				continue
+			}
+			if request.Quiet {
+				continue
+			}
+			result.Deleted = append(result.Deleted, DeletedObject{Key: key})
+		}
+
+		if len(result.Errors) > 0 {
+			slog.WarnContext(ctx, "Batch delete reported failures",
+				"bucket", bucket, "requested", len(request.Objects), "failed", len(result.Errors))
+		}
+
+		if err := writeXML(w, http.StatusOK, result); err != nil {
+			slog.DebugContext(ctx, "failed to write XML response", "error", err)
+		}
+	})
+}
+
+// deleteBatch deletes each key and returns the outcomes in request order. The
+// results are written by index rather than collected, so the answer follows the
+// order the client asked in without a lock over it.
+func deleteBatch(
+	ctx context.Context, mc MetaClient, bc BlobClient, bucket string, objects []DeleteRequestObject,
+) []error {
+	outcomes := make([]error, len(objects))
+
+	workers := min(deleteObjectsWorkers, len(objects))
+	indices := make(chan int)
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for i := range indices {
+				// A request that ran out of time reports the keys it never
+				// reached rather than claiming them deleted.
+				if err := ctx.Err(); err != nil {
+					outcomes[i] = err
+					continue
+				}
+				outcomes[i] = deleteStoredObject(ctx, mc, bc, bucket, objects[i].Key)
+			}
+		}()
+	}
+
+	for i := range objects {
+		indices <- i
+	}
+	close(indices)
+	wg.Wait()
+
+	return outcomes
+}
+
+// deleteFailure renders one key's failure as the code and message its Error
+// entry carries. An error the delete path did not classify is InternalError
+// rather than the raw text, which can name internal state.
+func deleteFailure(err error) (string, string) {
+	if s3err, ok := model.IsS3Error(err); ok {
+		return string(s3err.Code), s3err.Message
+	}
+	return string(model.ErrInternalError), "The object could not be deleted"
+}

--- a/internal/gate/handlers/delete_objects_test.go
+++ b/internal/gate/handlers/delete_objects_test.go
@@ -1,0 +1,212 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const deleteTestBucket = "b"
+
+// deleteFixture is a bucket holding real objects — written through the write
+// path and recorded under the keys production records — behind the batch
+// delete handler.
+type deleteFixture struct {
+	write   writeFixture
+	handler http.Handler
+}
+
+func newDeleteFixture(t *testing.T, keys ...string) deleteFixture {
+	t.Helper()
+	f := newWriteFixture(4, 2)
+	cache := NewBucketCache([]BucketConfig{{Name: deleteTestBucket, Region: "ap-southeast-2"}})
+
+	fixture := deleteFixture{write: f, handler: DeleteObjects(f.mc, f.bc, cache)}
+	for _, key := range keys {
+		fixture.seed(t, key, []byte("body of "+key))
+	}
+	return fixture
+}
+
+// seed stores one object the way PutObject does: shards written and committed,
+// the placement record under the object hash, and the listing row under the ARN.
+func (f deleteFixture) seed(t *testing.T, key string, body []byte) {
+	t.Helper()
+	ctx := context.Background()
+	objectHash := model.ObjectHash(deleteTestBucket, key)
+
+	place, _, err := f.write.write(ctx, objectHash, bytes.NewReader(body), int64(len(body)))
+	require.NoError(t, err)
+
+	record, err := EncodePlacement(place)
+	require.NoError(t, err)
+	require.NoError(t, metaPut(ctx, f.write.mc, model.TableObjects, string(objectHash[:]), record))
+	require.NoError(t, metaPut(ctx, f.write.mc, model.TableObjects,
+		objectARN(deleteTestBucket, key), objectHash[:]))
+}
+
+// exists reports whether the object's placement record is still in state, which
+// is what a later GET resolves through.
+func (f deleteFixture) exists(t *testing.T, key string) bool {
+	t.Helper()
+	objectHash := model.ObjectHash(deleteTestBucket, key)
+	_, err := metaGet(context.Background(), f.write.mc, model.TableObjects, string(objectHash[:]))
+	return err == nil
+}
+
+// deleteKeys issues one batch delete and decodes the answer.
+func (f deleteFixture) deleteKeys(t *testing.T, quiet bool, keys ...string) (*httptest.ResponseRecorder, DeleteResult) {
+	t.Helper()
+	rr := f.post(t, deleteBody(quiet, keys...))
+
+	var result DeleteResult
+	if rr.Code == http.StatusOK {
+		require.NoError(t, xml.NewDecoder(bytes.NewReader(rr.Body.Bytes())).Decode(&result),
+			"body: %s", rr.Body.String())
+	}
+	return rr, result
+}
+
+func (f deleteFixture) post(t *testing.T, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/"+deleteTestBucket+"?delete=", strings.NewReader(body))
+	req = req.WithContext(WithBucket(req.Context(), model.Bucket{Name: deleteTestBucket}))
+	rr := httptest.NewRecorder()
+	f.handler.ServeHTTP(rr, req)
+	return rr
+}
+
+func deleteBody(quiet bool, keys ...string) string {
+	var b strings.Builder
+	b.WriteString("<Delete>")
+	if quiet {
+		b.WriteString("<Quiet>true</Quiet>")
+	}
+	for _, key := range keys {
+		fmt.Fprintf(&b, "<Object><Key>%s</Key></Object>", key)
+	}
+	b.WriteString("</Delete>")
+	return b.String()
+}
+
+func deletedKeys(result DeleteResult) []string {
+	keys := make([]string, 0, len(result.Deleted))
+	for _, d := range result.Deleted {
+		keys = append(keys, d.Key)
+	}
+	return keys
+}
+
+func TestDeleteObjectsRemovesEveryKey(t *testing.T) {
+	f := newDeleteFixture(t, "a.txt", "b.txt", "sub/c.txt")
+
+	rr, result := f.deleteKeys(t, false, "a.txt", "b.txt", "sub/c.txt")
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, result.Errors)
+	// The answer follows the order the client asked in.
+	assert.Equal(t, []string{"a.txt", "b.txt", "sub/c.txt"}, deletedKeys(result))
+
+	for _, key := range []string{"a.txt", "b.txt", "sub/c.txt"} {
+		assert.False(t, f.exists(t, key), "%s survived the batch delete", key)
+	}
+}
+
+// A key that is not there is deleted, not an error: a client emptying a bucket
+// races its own listing, and this is the difference from the single-object
+// route, which answers 404.
+func TestDeleteObjectsReportsMissingKeyAsDeleted(t *testing.T) {
+	f := newDeleteFixture(t, "present.txt")
+
+	rr, result := f.deleteKeys(t, false, "present.txt", "never-existed.txt")
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, result.Errors)
+	assert.Equal(t, []string{"present.txt", "never-existed.txt"}, deletedKeys(result))
+}
+
+// One key that cannot be deleted must not take the rest of the batch with it.
+func TestDeleteObjectsReportsPerKeyFailure(t *testing.T) {
+	f := newDeleteFixture(t, "good.txt")
+
+	// A record the placement decoder rejects is the failure a caller can do
+	// nothing about, and the one that must not fail its neighbours.
+	corrupt := model.ObjectHash(deleteTestBucket, "corrupt.txt")
+	require.NoError(t, metaPut(context.Background(), f.write.mc, model.TableObjects,
+		string(corrupt[:]), []byte("not a placement record")))
+
+	rr, result := f.deleteKeys(t, false, "good.txt", "corrupt.txt")
+
+	assert.Equal(t, http.StatusOK, rr.Code, "a failed key must not fail the request")
+	assert.Equal(t, []string{"good.txt"}, deletedKeys(result))
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "corrupt.txt", result.Errors[0].Key)
+	assert.Equal(t, string(model.ErrInternalError), result.Errors[0].Code)
+	assert.False(t, f.exists(t, "good.txt"))
+}
+
+func TestDeleteObjectsQuietReturnsErrorsOnly(t *testing.T) {
+	f := newDeleteFixture(t, "good.txt")
+
+	corrupt := model.ObjectHash(deleteTestBucket, "corrupt.txt")
+	require.NoError(t, metaPut(context.Background(), f.write.mc, model.TableObjects,
+		string(corrupt[:]), []byte("not a placement record")))
+
+	rr, result := f.deleteKeys(t, true, "good.txt", "corrupt.txt")
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, result.Deleted, "quiet suppresses the deleted keys")
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "corrupt.txt", result.Errors[0].Key)
+	assert.False(t, f.exists(t, "good.txt"), "quiet still deletes")
+}
+
+func TestDeleteObjectsRejectsBatchesOutsideBounds(t *testing.T) {
+	f := newDeleteFixture(t)
+
+	tests := map[string]string{
+		"no objects": deleteBody(false),
+		"over 1000":  deleteBody(false, manyKeys(maxDeleteObjects+1)...),
+		"not XML":    "{}",
+		"wrong root": "<Nonsense><Object><Key>a</Key></Object></Nonsense>",
+	}
+
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			rr := f.post(t, body)
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.Contains(t, rr.Body.String(), string(model.ErrMalformedXML))
+		})
+	}
+}
+
+// A full batch is the size this operation exists for, so it is exercised rather
+// than assumed to behave like a small one.
+func TestDeleteObjectsAcceptsAFullBatch(t *testing.T) {
+	f := newDeleteFixture(t)
+	keys := manyKeys(maxDeleteObjects)
+
+	rr, result := f.deleteKeys(t, false, keys...)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, result.Errors)
+	assert.Len(t, result.Deleted, maxDeleteObjects)
+	assert.Equal(t, keys, deletedKeys(result))
+}
+
+func manyKeys(n int) []string {
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("key-%04d", i)
+	}
+	return keys
+}

--- a/internal/gate/handlers/meta.go
+++ b/internal/gate/handlers/meta.go
@@ -47,7 +47,7 @@ func ObjectHashOfKey(stored string) ([32]byte, bool) {
 	if !found || len(key) != sha256.Size {
 		return [32]byte{}, false
 	}
-	for _, reserved := range []string{arnObjectPrefix, deletedObjectPrefix, partKeyPrefix} {
+	for _, reserved := range []string{arnObjectPrefix, DeletedObjectPrefix, partKeyPrefix} {
 		if strings.HasPrefix(key, reserved) {
 			return [32]byte{}, false
 		}

--- a/internal/gate/handlers/xmltypes.go
+++ b/internal/gate/handlers/xmltypes.go
@@ -169,6 +169,37 @@ type S3Error struct {
 	HostId     string   `xml:"HostId"`
 }
 
+// DeleteRequest is the body of POST /{bucket}?delete. Quiet asks for the
+// deleted keys to be left out of the answer, leaving only the failures.
+type DeleteRequest struct {
+	XMLName xml.Name              `xml:"Delete"`
+	Quiet   bool                  `xml:"Quiet"`
+	Objects []DeleteRequestObject `xml:"Object"`
+}
+
+type DeleteRequestObject struct {
+	Key string `xml:"Key"`
+}
+
+// DeleteResult answers POST /{bucket}?delete. A key that could not be deleted
+// is reported beside the ones that were, so the outcome is per key and the
+// request itself still succeeds.
+type DeleteResult struct {
+	XMLName xml.Name        `xml:"DeleteResult"`
+	Deleted []DeletedObject `xml:"Deleted"`
+	Errors  []DeleteError   `xml:"Error"`
+}
+
+type DeletedObject struct {
+	Key string `xml:"Key"`
+}
+
+type DeleteError struct {
+	Key     string `xml:"Key"`
+	Code    string `xml:"Code"`
+	Message string `xml:"Message"`
+}
+
 // CreateBucketConfiguration is the request body for CreateBucket.
 type CreateBucketConfiguration struct {
 	XMLName            xml.Name `xml:"CreateBucketConfiguration"`

--- a/internal/gate/middleware.go
+++ b/internal/gate/middleware.go
@@ -138,7 +138,7 @@ func (s *Server) throttleMiddleware() func(http.Handler) http.Handler {
 			},
 			func(r *http.Request) (string, error) {
 				bucket, key := requestBucketKey(r.Context())
-				return s3Action(r.Method, bucket, key), nil
+				return s3Action(r, bucket, key), nil
 			},
 		},
 		func(w http.ResponseWriter, r *http.Request) {
@@ -201,8 +201,14 @@ func (s *Server) sigV4AuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		action := s3Action(method, bucket, key)
+		action := s3Action(r, bucket, key)
 		resource := s3Resource(bucket, key)
+		// The batch delete names its keys in the body, which is not read here.
+		// Authorizing it against every key in the bucket denies a caller who may
+		// delete only some of them, which is the safe direction to be wrong in.
+		if isBulkDelete(r, key) {
+			resource = s3Resource(bucket, "*")
+		}
 
 		// IAM policy evaluation (NATS-sourced credentials only).
 		if !credResult.SkipPolicyCheck {

--- a/internal/gate/model/errors.go
+++ b/internal/gate/model/errors.go
@@ -33,6 +33,7 @@ const (
 	ErrInvalidArgument         S3ErrorCode = "InvalidArgument"
 	ErrSignatureDoesNotMatch   S3ErrorCode = "SignatureDoesNotMatch"
 	ErrMalformedChunkedBody    S3ErrorCode = "InvalidRequest"
+	ErrMalformedXML            S3ErrorCode = "MalformedXML"
 )
 
 // S3Error represents a typed S3 error with code and message.

--- a/internal/gate/policy.go
+++ b/internal/gate/policy.go
@@ -33,11 +33,20 @@ func bucketAccessAllowed(method, callerAccountID string, meta *model.BucketMetad
 	return false
 }
 
-// s3Action maps an HTTP method and the resolved bucket/key to the IAM S3 action.
-func s3Action(method, bucket, key string) string {
+// isBulkDelete reports whether a request is POST /{bucket}?delete, the batch
+// delete. It addresses no key, so without this it would take the multipart
+// mapping below and a principal holding only s3:PutObject could empty a bucket.
+func isBulkDelete(r *http.Request, key string) bool {
+	return r.Method == http.MethodPost && key == "" && r.URL.Query().Has("delete")
+}
+
+// s3Action maps a request and the resolved bucket/key to the IAM S3 action.
+// The request is read rather than the method alone because S3 distinguishes
+// some operations by sub-resource rather than by method.
+func s3Action(r *http.Request, bucket, key string) string {
 	hasKey := key != ""
 
-	switch method {
+	switch r.Method {
 	case http.MethodGet:
 		if bucket == "" {
 			return "s3:ListAllMyBuckets"
@@ -57,6 +66,9 @@ func s3Action(method, bucket, key string) string {
 		}
 		return "s3:CreateBucket"
 	case http.MethodPost:
+		if isBulkDelete(r, key) {
+			return "s3:DeleteObject"
+		}
 		return "s3:PutObject" // multipart uploads
 	case http.MethodDelete:
 		if hasKey {

--- a/internal/gate/policy_test.go
+++ b/internal/gate/policy_test.go
@@ -16,26 +16,33 @@ import (
 func TestS3Action(t *testing.T) {
 	tests := []struct {
 		method string
+		target string
 		bucket string
 		key    string
 		want   string
 	}{
-		{"GET", "", "", "s3:ListAllMyBuckets"},
-		{"GET", "my-bucket", "", "s3:ListBucket"},
-		{"GET", "my-bucket", "key.txt", "s3:GetObject"},
-		{"HEAD", "my-bucket", "key.txt", "s3:GetObject"},
-		{"HEAD", "my-bucket", "", "s3:ListBucket"},
-		{"PUT", "my-bucket", "", "s3:CreateBucket"},
-		{"PUT", "my-bucket", "key.txt", "s3:PutObject"},
-		{"POST", "my-bucket", "key.txt", "s3:PutObject"},
-		{"DELETE", "my-bucket", "", "s3:DeleteBucket"},
-		{"DELETE", "my-bucket", "key.txt", "s3:DeleteObject"},
-		{"PATCH", "my-bucket", "key.txt", ""},
+		{"GET", "/", "", "", "s3:ListAllMyBuckets"},
+		{"GET", "/my-bucket", "my-bucket", "", "s3:ListBucket"},
+		{"GET", "/my-bucket/key.txt", "my-bucket", "key.txt", "s3:GetObject"},
+		{"HEAD", "/my-bucket/key.txt", "my-bucket", "key.txt", "s3:GetObject"},
+		{"HEAD", "/my-bucket", "my-bucket", "", "s3:ListBucket"},
+		{"PUT", "/my-bucket", "my-bucket", "", "s3:CreateBucket"},
+		{"PUT", "/my-bucket/key.txt", "my-bucket", "key.txt", "s3:PutObject"},
+		{"POST", "/my-bucket/key.txt?uploads", "my-bucket", "key.txt", "s3:PutObject"},
+		{"DELETE", "/my-bucket", "my-bucket", "", "s3:DeleteBucket"},
+		{"DELETE", "/my-bucket/key.txt", "my-bucket", "key.txt", "s3:DeleteObject"},
+		{"PATCH", "/my-bucket/key.txt", "my-bucket", "key.txt", ""},
+		// The batch delete is a POST that names no key. Mapping it to
+		// s3:PutObject with the other POSTs would let a principal holding only
+		// write access empty a bucket.
+		{"POST", "/my-bucket?delete", "my-bucket", "", "s3:DeleteObject"},
+		{"POST", "/my-bucket?delete=", "my-bucket", "", "s3:DeleteObject"},
 	}
 
 	for _, tt := range tests {
-		got := s3Action(tt.method, tt.bucket, tt.key)
-		assert.Equal(t, tt.want, got, "s3Action(%q, %q, %q)", tt.method, tt.bucket, tt.key)
+		r := httptest.NewRequest(tt.method, tt.target, nil)
+		got := s3Action(r, tt.bucket, tt.key)
+		assert.Equal(t, tt.want, got, "s3Action(%q %q, %q, %q)", tt.method, tt.target, tt.bucket, tt.key)
 	}
 }
 
@@ -76,6 +83,27 @@ func doc(effect, action, resource string) iampolicy.PolicyDocument {
 // allowed reports whether the S3 action on resource is permitted.
 func allowed(action, resource string, policies []iampolicy.PolicyDocument) bool {
 	return iampolicy.EvaluateWithKeys(action, resource, policies, nil) == iampolicy.Allow
+}
+
+// The batch delete is authorized as a delete of every key in the bucket. Write
+// access alone must not reach it, and delete access on one key must not carry
+// the whole batch.
+func TestEvaluateS3Access_BulkDelete(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/my-bucket?delete=", nil)
+	action := s3Action(r, "my-bucket", "")
+	resource := s3Resource("my-bucket", "*")
+
+	assert.Equal(t, "s3:DeleteObject", action)
+	assert.Equal(t, "arn:aws:s3:::my-bucket/*", resource)
+
+	writeOnly := []iampolicy.PolicyDocument{doc("Allow", "s3:PutObject", "arn:aws:s3:::my-bucket/*")}
+	assert.False(t, allowed(action, resource, writeOnly))
+
+	oneKey := []iampolicy.PolicyDocument{doc("Allow", "s3:DeleteObject", "arn:aws:s3:::my-bucket/one.txt")}
+	assert.False(t, allowed(action, resource, oneKey))
+
+	bucketWide := []iampolicy.PolicyDocument{doc("Allow", "s3:DeleteObject", "arn:aws:s3:::my-bucket/*")}
+	assert.True(t, allowed(action, resource, bucketWide))
 }
 
 func TestEvaluateS3Access_DefaultDeny(t *testing.T) {

--- a/internal/gate/reaper/cluster_test.go
+++ b/internal/gate/reaper/cluster_test.go
@@ -1,0 +1,174 @@
+package reaper
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mulgadc/predastore/internal/blob"
+	"github.com/mulgadc/predastore/internal/config"
+	"github.com/mulgadc/predastore/internal/meta"
+	"github.com/stretchr/testify/require"
+)
+
+// The fakes below stand in for a cluster, not for the clients: they model the
+// shape a real node and a real meta replica present, so a test exercises the
+// same decisions the sweep makes against production.
+
+type shardAddr struct {
+	node  config.NodeID
+	key   [32]byte
+	index uint32
+}
+
+// fakeBlob stands in for the blob nodes. A node can be held down, which is
+// how a test models one that is unreachable when a delete needs it.
+type fakeBlob struct {
+	mu     sync.Mutex
+	shards map[shardAddr]bool
+	down   map[config.NodeID]bool
+
+	deletes []shardAddr
+}
+
+func newFakeBlob() *fakeBlob {
+	return &fakeBlob{shards: make(map[shardAddr]bool), down: make(map[config.NodeID]bool)}
+}
+
+// hold marks a shard as present on a node, as a completed write left it.
+func (f *fakeBlob) hold(node config.NodeID, key [32]byte, index uint32) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.shards[shardAddr{node, key, index}] = true
+}
+
+func (f *fakeBlob) stop(nodes ...config.NodeID) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, n := range nodes {
+		f.down[n] = true
+	}
+}
+
+func (f *fakeBlob) resume(nodes ...config.NodeID) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, n := range nodes {
+		delete(f.down, n)
+	}
+}
+
+func (f *fakeBlob) has(node config.NodeID, key [32]byte, index uint32) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.shards[shardAddr{node, key, index}]
+}
+
+var errNodeDown = errors.New("node unreachable")
+
+func (f *fakeBlob) Delete(_ context.Context, node config.NodeID, req blob.DeleteRequest) (*blob.DeleteResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.down[node] {
+		return nil, errNodeDown
+	}
+
+	addr := shardAddr{node, req.Key, req.Index}
+	f.deletes = append(f.deletes, addr)
+	held := f.shards[addr]
+	delete(f.shards, addr)
+
+	return &blob.DeleteResponse{Deleted: held}, nil
+}
+
+var _ BlobClient = (*fakeBlob)(nil)
+
+type fakeMeta struct {
+	mu   sync.Mutex
+	rows map[string][]byte
+}
+
+func newFakeMeta() *fakeMeta { return &fakeMeta{rows: make(map[string][]byte)} }
+
+func (m *fakeMeta) put(key string, value []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rows[key] = value
+}
+
+func (m *fakeMeta) has(key string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.rows[key]
+	return ok
+}
+
+func (m *fakeMeta) Get(_ context.Context, key string) ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, ok := m.rows[key]
+	if !ok {
+		return nil, meta.ErrNotFound
+	}
+	return v, nil
+}
+
+func (m *fakeMeta) Delete(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.rows, key)
+	return nil
+}
+
+// ScanFrom sorts, because a cursor only means anything over an ordered
+// enumeration and badger iterates in key order.
+func (m *fakeMeta) ScanFrom(_ context.Context, prefix, after string, limit int) ([]meta.Item, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	keys := make([]string, 0, len(m.rows))
+	for k := range maps.Keys(m.rows) {
+		if strings.HasPrefix(k, prefix) && k > after {
+			keys = append(keys, k)
+		}
+	}
+	slices.Sort(keys)
+
+	items := make([]meta.Item, 0, len(keys))
+	for _, k := range keys {
+		items = append(items, meta.Item{Key: k, Value: m.rows[k]})
+		if limit > 0 && len(items) == limit {
+			break
+		}
+	}
+
+	return items, nil
+}
+
+var _ MetaClient = (*fakeMeta)(nil)
+
+// cluster is a fake blob set and a fake meta store, wired the way a gate
+// wires the reaper.
+type cluster struct {
+	t    *testing.T
+	blob *fakeBlob
+	meta *fakeMeta
+}
+
+func newCluster(t *testing.T) *cluster {
+	t.Helper()
+	return &cluster{t: t, blob: newFakeBlob(), meta: newFakeMeta()}
+}
+
+// service builds a reaper sweeping this cluster.
+func (c *cluster) service(pageSize int) *Service {
+	c.t.Helper()
+	s, err := New(Config{Meta: c.meta, Blob: c.blob, Workers: 4, PageSize: pageSize})
+	require.NoError(c.t, err)
+	return s
+}

--- a/internal/gate/reaper/reaper.go
+++ b/internal/gate/reaper/reaper.go
@@ -1,0 +1,432 @@
+// Package reaper reclaims the shards a delete leaves behind.
+//
+// A delete no longer talks to shard nodes: it writes a tombstone naming the
+// shards, removes the index entries that make the object visible, and
+// returns. This is the coordinator that reads the tombstone back and does the
+// deferred work.
+//
+// It is a sweep, not a subscription, modelled closely on internal/gate/repair:
+// Config/New/Run/Pass/Stats, a worker pool over a channel, and ScanFrom paging
+// with a cursor. It differs in what it pages — only the tombstone rows, so a
+// cluster that is not deleting pays nothing for it — and in what it does with
+// what it finds: reclaim a tombstone's shards and drop it, once every one of
+// them is confirmed gone.
+//
+// Before deleting anything it re-reads the placement record at the
+// tombstone's hash and compares its WriteEpoch against the tombstone's own.
+// A plain existence check is not enough: deleteStoredObject writes the
+// tombstone before it removes the placement record, so a pass landing in
+// that window would see the very object being deleted, conclude it had been
+// recreated, and drop the tombstone without reclaiming its shards — leaking
+// them permanently, on every delete, on a window two raft writes wide. The
+// epoch tells the two cases apart: a match is the same delete still in
+// flight, left alone for a later pass; a mismatch is a genuine recreate —
+// object hashes are deterministic, so it lands on the same nodes and
+// indices — and the tombstone is dropped without touching a shard, since
+// deleting there would delete the recreated object's data.
+//
+// It deliberately does not close the window between that check and the
+// delete landing: a concurrent recreate in that narrow gap could still lose a
+// race against the sweep. Closing it needs the shard delete itself to carry
+// the placement's write epoch and the blob engine to honour it, which is a
+// protocol change out of scope here. It is no worse than the window the
+// inline delete already left against a concurrent PUT.
+//
+// A tombstone with WriteEpoch == 0 predates this field. Those deletes fanned
+// their shards out inline before the tombstone was even durable, so there is
+// nothing left to reclaim, and it is dropped without a placement check.
+//
+// There is no election. Every gate that runs repair also runs this sweep, and
+// two gates racing the same tombstone issue the same idempotent shard deletes
+// and the same idempotent tombstone removal — redundant RPCs, nothing else.
+package reaper
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/mulgadc/predastore/internal/blob"
+	"github.com/mulgadc/predastore/internal/config"
+	"github.com/mulgadc/predastore/internal/gate/handlers"
+	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/mulgadc/predastore/internal/meta"
+	"github.com/mulgadc/predastore/internal/telemetry"
+)
+
+// MetaClient is the slice of the meta client a sweep needs: ScanFrom pages the
+// tombstones, Get checks whether a hash has since been recreated, and Delete
+// drops a tombstone once it is resolved either way.
+type MetaClient interface {
+	Get(ctx context.Context, key string) ([]byte, error)
+	Delete(ctx context.Context, key string) error
+	ScanFrom(ctx context.Context, prefix, after string, limit int) ([]meta.Item, error)
+}
+
+var _ MetaClient = (*meta.Client)(nil)
+
+// BlobClient is what the sweep needs of a blob node: the ability to remove
+// one shard.
+type BlobClient interface {
+	Delete(ctx context.Context, node config.NodeID, req blob.DeleteRequest) (*blob.DeleteResponse, error)
+}
+
+var _ BlobClient = (*blob.Client)(nil)
+
+// Config is everything a reaper sweep runs on.
+type Config struct {
+	Meta MetaClient
+	Blob BlobClient
+
+	// Workers bounds concurrent tombstone reclaims. Zero takes the default
+	// below.
+	Workers int
+
+	// PageSize is how many tombstone rows a scan asks for at a time. Zero
+	// defaults.
+	PageSize int
+
+	// Interval is the gap between the end of one pass and the start of the
+	// next. Zero defaults.
+	Interval time.Duration
+}
+
+// DefaultWorkers is the reclaim concurrency. Half the host, capped, the same
+// reasoning repair uses: a delete waiting on the sweep is not urgent the way a
+// missing shard is, but it should not be starved by everything else the
+// process is doing either.
+func DefaultWorkers() int { return min(runtime.NumCPU()/2+1, maxDefaultWorkers) }
+
+const (
+	maxDefaultWorkers = 8
+	defaultPageSize   = 512
+	defaultInterval   = 5 * time.Minute
+)
+
+// Stats is what a pass did. Scanned counts tombstones read, Reclaimed the ones
+// removed — whether their shards were deleted or the key had been recreated —
+// and Pending is what the last completed pass left owing.
+type Stats struct {
+	Passes    int64
+	Scanned   int64
+	Reclaimed int64
+	Failed    int64
+	Pending   int64
+}
+
+// Service sweeps for tombstones and reclaims what they name.
+type Service struct {
+	cfg      Config
+	workers  int
+	pageSize int
+	interval time.Duration
+
+	passes, scanned, reclaimed, failed, pending atomic.Int64
+}
+
+// New validates cfg and applies its defaults. It starts nothing.
+func New(cfg Config) (*Service, error) {
+	if cfg.Meta == nil || cfg.Blob == nil {
+		return nil, errors.New("reaper needs a meta client and a blob client")
+	}
+
+	s := &Service{
+		cfg:      cfg,
+		workers:  cmpOr(cfg.Workers, DefaultWorkers()),
+		pageSize: cmpOr(cfg.PageSize, defaultPageSize),
+		interval: cfg.Interval,
+	}
+	if s.interval <= 0 {
+		s.interval = defaultInterval
+	}
+
+	return s, nil
+}
+
+func cmpOr(v, fallback int) int {
+	if v > 0 {
+		return v
+	}
+
+	return fallback
+}
+
+// Stats reports the running counters.
+func (s *Service) Stats() Stats {
+	return Stats{
+		Passes:    s.passes.Load(),
+		Scanned:   s.scanned.Load(),
+		Reclaimed: s.reclaimed.Load(),
+		Failed:    s.failed.Load(),
+		Pending:   s.pending.Load(),
+	}
+}
+
+// Run sweeps until ctx is cancelled. A pass that fails is logged and retried
+// on the next tick rather than stopping the service: the condition it is
+// trying to fix is usually the same one that made it fail.
+func (s *Service) Run(ctx context.Context) error {
+	slog.InfoContext(ctx, "Reaper sweep started",
+		"workers", s.workers, "interval_ms", s.interval.Milliseconds())
+
+	for {
+		if err := s.Pass(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			slog.ErrorContext(ctx, "Reaper pass failed", "err", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(s.interval):
+		}
+	}
+}
+
+// Pass runs one sweep to completion.
+//
+// It is not resumable: a restart part-way through starts the enumeration
+// again from the beginning. Only the position is lost, never work — every
+// reclaim is idempotent, both the shard deletes and the tombstone removal, so
+// repeating a page costs redundant RPCs and nothing else.
+func (s *Service) Pass(ctx context.Context) error {
+	work := make(chan task)
+	var wg sync.WaitGroup
+	var owed atomic.Int64
+
+	for range s.workers {
+		wg.Go(func() {
+			for t := range work {
+				ok, err := s.reclaim(ctx, t)
+				switch {
+				case err != nil:
+					s.failed.Add(1)
+					slog.WarnContext(ctx, "Reaper reclaim failed", "key", t.key, "err", err)
+				case ok:
+					owed.Add(-1)
+					s.reclaimed.Add(1)
+				default:
+					// A tombstone for a delete still in flight: neither
+					// reclaimed nor failed, just still owed for a later pass.
+				}
+			}
+		})
+	}
+
+	err := s.scan(ctx, func(t task) error {
+		owed.Add(1)
+		s.pending.Add(1)
+		select {
+		case work <- t:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+
+	close(work)
+	wg.Wait()
+
+	// Whatever the pass could not reclaim is still owed, and the next pass
+	// will find it again. Settling the gauge here rather than decrementing per
+	// item keeps it from drifting when a pass is cut short.
+	s.pending.Store(max(owed.Load(), 0))
+	s.passes.Add(1)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// task is one tombstone row, decoded.
+type task struct {
+	key  string // the row's full stored key, as ScanFrom returned it
+	info handlers.DeletedObjectInfo
+}
+
+// scan pages through the tombstone rows and emits each one it can decode. A
+// row it cannot decode is logged and skipped rather than failing the pass: a
+// tombstone from a future format must not stall reclaim for every other one.
+func (s *Service) scan(ctx context.Context, emit func(task) error) error {
+	prefix := handlers.TableKey(model.TableObjects, handlers.DeletedObjectPrefix)
+	cursor := ""
+	for {
+		items, err := s.cfg.Meta.ScanFrom(ctx, prefix, cursor, s.pageSize)
+		if err != nil {
+			return fmt.Errorf("scan tombstones: %w", err)
+		}
+		if len(items) == 0 {
+			return nil
+		}
+
+		for _, item := range items {
+			cursor = item.Key
+
+			var info handlers.DeletedObjectInfo
+			if decErr := gob.NewDecoder(bytes.NewReader(item.Value)).Decode(&info); decErr != nil {
+				slog.WarnContext(ctx, "Undecodable tombstone skipped", "key", item.Key, "err", decErr)
+
+				continue
+			}
+			s.scanned.Add(1)
+			if err := emit(task{key: item.Key, info: info}); err != nil {
+				return err
+			}
+		}
+
+		if len(items) < s.pageSize {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+	}
+}
+
+// reclaim resolves one tombstone.
+//
+// It reports whether the tombstone was removed. A false result with a nil
+// error means the tombstone was deliberately left alone — the delete that
+// wrote it is still in flight — which is not a failure: it is still owed, and
+// the caller must not count it against Failed. A false result with a non-nil
+// error explains why the reclaim could not complete.
+func (s *Service) reclaim(ctx context.Context, t task) (bool, error) {
+	if t.info.WriteEpoch == 0 {
+		// Legacy tombstone: its delete already fanned the shards out inline,
+		// before this field existed to name the generation. Nothing remains
+		// to reclaim.
+		if err := s.cfg.Meta.Delete(ctx, t.key); err != nil {
+			return false, fmt.Errorf("drop legacy tombstone: %w", err)
+		}
+
+		return true, nil
+	}
+
+	liveKey := handlers.TableKey(model.TableObjects, string(t.info.ObjectHash[:]))
+	data, err := s.cfg.Meta.Get(ctx, liveKey)
+	switch {
+	case err == nil:
+		place, decErr := handlers.DecodePlacement(data)
+		if decErr != nil {
+			return false, fmt.Errorf("decode live placement: %w", decErr)
+		}
+
+		if place.WriteEpoch == t.info.WriteEpoch {
+			// Same generation at the same hash is the delete that wrote this
+			// tombstone, caught before its placement removal, not a recreate.
+			// The next pass finds the placement gone and reclaims normally.
+			return false, nil
+		}
+
+		// A different epoch at the same hash is a genuine recreate. Object
+		// hashes are deterministic, so the new write already superseded these
+		// shards in place, and reclaiming superseded extents is the compactor's.
+		if delErr := s.cfg.Meta.Delete(ctx, t.key); delErr != nil {
+			return false, fmt.Errorf("drop tombstone superseded by a recreated key: %w", delErr)
+		}
+
+		return true, nil
+	case errors.Is(err, meta.ErrNotFound):
+		// No live record: the key has not been recreated, so it is safe to
+		// reclaim the shards below.
+	default:
+		return false, fmt.Errorf("check for a recreated object: %w", err)
+	}
+
+	if err := s.deleteShards(ctx, t.info); err != nil {
+		return false, err
+	}
+
+	if err := s.cfg.Meta.Delete(ctx, t.key); err != nil {
+		return false, fmt.Errorf("drop reclaimed tombstone: %w", err)
+	}
+
+	return true, nil
+}
+
+// shardTarget is one shard a tombstone names: the node that held it and the
+// index the write path assigned it.
+type shardTarget struct {
+	node  config.NodeID
+	index int
+}
+
+// shardTargets rebuilds the (node, shardIndex) pairs a tombstone names, the
+// same way the write and read paths do: data shards first at 0..k-1, then
+// parity.
+func shardTargets(info handlers.DeletedObjectInfo) []shardTarget {
+	targets := make([]shardTarget, 0, len(info.DataShardNodes)+len(info.ParityNodes))
+	for i, n := range info.DataShardNodes {
+		targets = append(targets, shardTarget{node: n, index: i})
+	}
+	for i, n := range info.ParityNodes {
+		targets = append(targets, shardTarget{node: n, index: len(info.DataShardNodes) + i})
+	}
+
+	return targets
+}
+
+// deleteShards removes every shard a tombstone names. A shard the node no
+// longer holds answers Deleted: false, which is success — the delete this
+// tombstone owes was already done, by an earlier pass or by the node itself.
+// Anything else leaves the tombstone in place for the next pass, which is
+// what recovers a node that was down when the delete happened.
+func (s *Service) deleteShards(ctx context.Context, info handlers.DeletedObjectInfo) error {
+	targets := shardTargets(info)
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(targets))
+
+	for _, target := range targets {
+		wg.Add(1)
+		go func(t shardTarget) {
+			defer wg.Done()
+
+			start := time.Now()
+			resp, err := s.cfg.Blob.Delete(ctx, t.node, blob.DeleteRequest{
+				Key:   info.ObjectHash,
+				Index: uint32(t.index), //nolint:gosec // G115: index bounded by DataShards + ParityShards (small uint).
+			})
+			recordShardDelete(ctx, t.node, start, err)
+			if err != nil {
+				errCh <- fmt.Errorf("node %d index %d: %w", t.node, t.index, err)
+
+				return
+			}
+			if !resp.Deleted {
+				slog.DebugContext(ctx, "Reaper: shard already gone", "node", t.node, "index", t.index)
+			}
+		}(target)
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// recordShardDelete counts one shard delete against one node, mirroring the
+// telemetry the inline delete used to record so the shard-op series it feeds
+// keeps meaning what it always has.
+func recordShardDelete(ctx context.Context, node config.NodeID, start time.Time, err error) {
+	outcome := telemetry.OutcomeSuccess
+	if err != nil {
+		outcome = telemetry.OutcomeError
+	}
+	telemetry.RecordShardOp(ctx, telemetry.ShardOpDelete, outcome, uint64(node), time.Since(start).Seconds())
+	if err != nil {
+		telemetry.RecordShardError(ctx, telemetry.ShardOpDelete, telemetry.ShardReasonTransport, uint64(node))
+	}
+}

--- a/internal/gate/reaper/reaper.go
+++ b/internal/gate/reaper/reaper.go
@@ -385,25 +385,22 @@ func (s *Service) deleteShards(ctx context.Context, info handlers.DeletedObjectI
 	errCh := make(chan error, len(targets))
 
 	for _, target := range targets {
-		wg.Add(1)
-		go func(t shardTarget) {
-			defer wg.Done()
-
+		wg.Go(func() {
 			start := time.Now()
-			resp, err := s.cfg.Blob.Delete(ctx, t.node, blob.DeleteRequest{
+			resp, err := s.cfg.Blob.Delete(ctx, target.node, blob.DeleteRequest{
 				Key:   info.ObjectHash,
-				Index: uint32(t.index), //nolint:gosec // G115: index bounded by DataShards + ParityShards (small uint).
+				Index: uint32(target.index), //nolint:gosec // G115: index bounded by DataShards + ParityShards (small uint).
 			})
-			recordShardDelete(ctx, t.node, start, err)
+			recordShardDelete(ctx, target.node, start, err)
 			if err != nil {
-				errCh <- fmt.Errorf("node %d index %d: %w", t.node, t.index, err)
+				errCh <- fmt.Errorf("node %d index %d: %w", target.node, target.index, err)
 
 				return
 			}
 			if !resp.Deleted {
-				slog.DebugContext(ctx, "Reaper: shard already gone", "node", t.node, "index", t.index)
+				slog.DebugContext(ctx, "Reaper: shard already gone", "node", target.node, "index", target.index)
 			}
-		}(target)
+		})
 	}
 	wg.Wait()
 	close(errCh)

--- a/internal/gate/reaper/reaper_test.go
+++ b/internal/gate/reaper/reaper_test.go
@@ -1,0 +1,345 @@
+package reaper
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/gob"
+	"fmt"
+	"testing"
+
+	"github.com/mulgadc/predastore/internal/config"
+	"github.com/mulgadc/predastore/internal/gate/handlers"
+	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tombstoneRow is one tombstone as a test builds and stores it.
+type tombstoneRow struct {
+	bucket, key string
+	hash        [32]byte
+	epoch       uint64
+	data, m     []config.NodeID
+}
+
+// tombstone builds a tombstone naming the given data and parity nodes, keyed
+// by a hash unique to the name — deterministic, the way model.ObjectHash is,
+// so the recreate case can reuse it.
+func tombstone(name string, epoch uint64, data, parity []config.NodeID) tombstoneRow {
+	return tombstoneRow{
+		bucket: "b", key: name,
+		hash: sha256.Sum256([]byte(name)), epoch: epoch,
+		data: data, m: parity,
+	}
+}
+
+// store writes a tombstone row to the cluster's meta store, gob-encoded the
+// way deleteStoredObject leaves one, and holds the shards it names on their
+// nodes, as a completed write left them.
+func (c *cluster) store(t *testing.T, row tombstoneRow) string {
+	t.Helper()
+
+	stored := c.storeTombstoneOnly(t, row)
+
+	for i, n := range row.data {
+		c.blob.hold(n, row.hash, uint32(i))
+	}
+	for i, n := range row.m {
+		c.blob.hold(n, row.hash, uint32(len(row.data)+i))
+	}
+
+	return stored
+}
+
+// storeTombstoneOnly writes the tombstone row without holding any shard on
+// any node, as if the node had already reclaimed them.
+func (c *cluster) storeTombstoneOnly(t *testing.T, row tombstoneRow) string {
+	t.Helper()
+
+	info := handlers.DeletedObjectInfo{
+		Bucket: row.bucket, Key: row.key, ObjectHash: row.hash,
+		WriteEpoch: row.epoch, DataShardNodes: row.data, ParityNodes: row.m,
+	}
+	var buf bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&buf).Encode(info))
+
+	stored := handlers.TableKey(model.TableObjects,
+		handlers.DeletedObjectPrefix+row.bucket+"/"+row.key)
+	c.meta.put(stored, buf.Bytes())
+
+	return stored
+}
+
+// recordLivePlacement writes a placement record at hash, at the given epoch.
+// A recreate lands its new write on the same nodes and indices a delete
+// tombstoned — object hashes are deterministic on bucket and key — but always
+// mints a new WriteEpoch, which is the only thing that tells it apart from
+// the record deleteStoredObject has not removed yet for this very tombstone.
+func (c *cluster) recordLivePlacement(t *testing.T, hash [32]byte, epoch uint64, data, parity []config.NodeID) {
+	t.Helper()
+	place := handlers.ObjectToShardNodes{
+		Size: 1, WriteEpoch: epoch, DataShardNodes: data, ParityShardNodes: parity,
+	}
+	raw, err := handlers.EncodePlacement(place)
+	require.NoError(t, err)
+	c.meta.put(handlers.TableKey(model.TableObjects, string(hash[:])), raw)
+}
+
+func nodes(ids ...int) []config.NodeID {
+	out := make([]config.NodeID, len(ids))
+	for i, id := range ids {
+		out[i] = config.NodeID(id)
+	}
+	return out
+}
+
+// A pass must reclaim exactly the shards a tombstone names, at the indices
+// the write path assigned them — data shards first, then parity — and then
+// remove the tombstone itself.
+func TestPassReclaimsExactlyTheNamedShardsThenDropsTheTombstone(t *testing.T) {
+	t.Parallel()
+
+	c := newCluster(t)
+	row := tombstone("object", 5, nodes(1, 2), nodes(3))
+	stored := c.store(t, row)
+
+	svc := c.service(8)
+	require.NoError(t, svc.Pass(t.Context()))
+
+	assert.False(t, c.blob.has(1, row.hash, 0), "data shard 0 must be reclaimed")
+	assert.False(t, c.blob.has(2, row.hash, 1), "data shard 1 must be reclaimed")
+	assert.False(t, c.blob.has(3, row.hash, 2), "parity shard must be reclaimed at index 2")
+	assert.False(t, c.meta.has(stored), "the tombstone must be dropped once every shard is gone")
+
+	stats := svc.Stats()
+	assert.Equal(t, int64(1), stats.Scanned)
+	assert.Equal(t, int64(1), stats.Reclaimed)
+	assert.Zero(t, stats.Failed)
+	assert.Zero(t, stats.Pending)
+}
+
+// The recreate hazard: object hashes are deterministic, so a key deleted and
+// then recreated lands its new write on the same nodes and indices the old
+// tombstone names, but a recreate always mints a fresh WriteEpoch — that is
+// the discriminator this test exercises, not mere existence of a placement
+// record. The sweep must not delete a single shard in that case — doing so
+// would delete the recreated object's data — and must still drop the
+// now-superseded tombstone.
+func TestRecreatedKeyDeletesNoShards(t *testing.T) {
+	t.Parallel()
+
+	c := newCluster(t)
+	row := tombstone("recreated", 5, nodes(1, 2), nodes(3))
+	stored := c.store(t, row)
+	c.recordLivePlacement(t, row.hash, row.epoch+1, row.data, row.m)
+
+	svc := c.service(8)
+	require.NoError(t, svc.Pass(t.Context()))
+
+	assert.Empty(t, c.blob.deletes, "no shard delete may reach the blob client for a recreated key")
+	assert.True(t, c.blob.has(1, row.hash, 0), "the recreated shard must survive untouched")
+	assert.False(t, c.meta.has(stored), "the superseded tombstone must still be dropped")
+	assert.Equal(t, int64(1), svc.Stats().Reclaimed)
+}
+
+// The regression case: deleteStoredObject writes the tombstone before it
+// removes the placement record, so a pass can land in that window and read
+// the tombstone's own object still in the index. A plain existence check
+// would mistake that for a recreate and drop the tombstone without reclaiming
+// a single shard — leaking them permanently, on every delete. The epoch
+// match is what tells the two apart: the tombstone must survive untouched
+// while the placement is still there at the same epoch, and only once the
+// placement is gone does a later pass reclaim it.
+func TestSameEpochPlacementIsTheDeleteStillInFlightNotARecreate(t *testing.T) {
+	t.Parallel()
+
+	c := newCluster(t)
+	row := tombstone("in-flight", 5, nodes(1, 2), nodes(3))
+	stored := c.store(t, row)
+	c.recordLivePlacement(t, row.hash, row.epoch, row.data, row.m)
+
+	svc := c.service(8)
+	require.NoError(t, svc.Pass(t.Context()))
+
+	assert.Empty(t, c.blob.deletes, "no shard delete may reach the blob client while the delete is still in flight")
+	assert.True(t, c.meta.has(stored), "the tombstone must survive while its own placement record is still there")
+	stats := svc.Stats()
+	assert.Zero(t, stats.Reclaimed)
+	assert.Zero(t, stats.Failed, "a delete still in flight is not a failure")
+	assert.Equal(t, int64(1), stats.Pending)
+
+	// deleteStoredObject completes: the placement record is gone. The next
+	// pass must now reclaim the shards and drop the tombstone normally.
+	c.meta.mu.Lock()
+	delete(c.meta.rows, handlers.TableKey(model.TableObjects, string(row.hash[:])))
+	c.meta.mu.Unlock()
+
+	require.NoError(t, svc.Pass(t.Context()))
+
+	assert.False(t, c.blob.has(1, row.hash, 0))
+	assert.False(t, c.blob.has(2, row.hash, 1))
+	assert.False(t, c.blob.has(3, row.hash, 2))
+	assert.False(t, c.meta.has(stored), "the tombstone must be reclaimed once the placement record is gone")
+	assert.Equal(t, int64(1), svc.Stats().Reclaimed)
+	assert.Zero(t, svc.Stats().Pending)
+}
+
+// A tombstone with WriteEpoch == 0 predates the field: its delete already
+// fanned the shards out inline, so the sweep must drop it without touching a
+// shard or even consulting the placement table.
+func TestLegacyTombstoneIsDroppedWithoutDeletingShards(t *testing.T) {
+	t.Parallel()
+
+	c := newCluster(t)
+	row := tombstone("legacy", 0, nodes(1, 2), nodes(3))
+	stored := c.store(t, row)
+
+	svc := c.service(8)
+	require.NoError(t, svc.Pass(t.Context()))
+
+	assert.Empty(t, c.blob.deletes, "a legacy tombstone's shards were already fanned out inline")
+	assert.True(t, c.blob.has(1, row.hash, 0), "shards a legacy tombstone names must be left untouched")
+	assert.False(t, c.meta.has(stored), "the legacy tombstone must still be dropped")
+	assert.Equal(t, int64(1), svc.Stats().Reclaimed)
+	assert.Zero(t, svc.Stats().Failed)
+}
+
+// The whole point of the design: a tombstone whose node is down at delete
+// time survives the pass rather than leaking the shard, and a later pass
+// reclaims it once the node returns.
+func TestUnreachableNodeKeepsTheTombstoneUntilItRecovers(t *testing.T) {
+	t.Parallel()
+
+	c := newCluster(t)
+	row := tombstone("stuck", 5, nodes(1, 2), nodes(3))
+	stored := c.store(t, row)
+	c.blob.stop(2)
+
+	svc := c.service(8)
+	require.NoError(t, svc.Pass(t.Context()))
+
+	assert.True(t, c.meta.has(stored), "a tombstone with an unreachable node must survive the pass")
+	assert.False(t, c.blob.has(1, row.hash, 0), "reachable shards are reclaimed even when one node is down")
+	stats := svc.Stats()
+	assert.Equal(t, int64(1), stats.Failed)
+	assert.Equal(t, int64(1), stats.Pending)
+
+	c.blob.resume(2)
+	require.NoError(t, svc.Pass(t.Context()))
+
+	assert.False(t, c.meta.has(stored), "the tombstone must be reclaimed once the node returns")
+	assert.False(t, c.blob.has(2, row.hash, 1))
+	assert.Equal(t, int64(1), svc.Stats().Reclaimed)
+	assert.Zero(t, svc.Stats().Pending)
+}
+
+// DeleteResponse{Deleted: false} means the node never held the shard, which is
+// success — a previous pass or the node itself already reclaimed it — and
+// must not be treated as a failure that keeps the tombstone around.
+func TestAnAlreadyGoneShardIsNotAFailure(t *testing.T) {
+	t.Parallel()
+
+	c := newCluster(t)
+	// No c.blob.hold call: the node has nothing at this address, so Delete
+	// answers Deleted: false without an error.
+	row := tombstone("already-gone", 5, nodes(1), nil)
+	stored := c.storeTombstoneOnly(t, row)
+
+	svc := c.service(8)
+	require.NoError(t, svc.Pass(t.Context()))
+
+	assert.False(t, c.meta.has(stored))
+	assert.Equal(t, int64(1), svc.Stats().Reclaimed)
+	assert.Zero(t, svc.Stats().Failed)
+}
+
+// The sweep pages only the tombstone prefix, so listing rows, part keys and
+// placement records sharing the objects table must never surface as a task.
+func TestSweepIgnoresOtherTableRows(t *testing.T) {
+	t.Parallel()
+
+	c := newCluster(t)
+	row := tombstone("real", 5, nodes(1), nodes(2))
+	c.store(t, row)
+
+	otherHash := sha256.Sum256([]byte("some-other-object"))
+	for _, key := range []string{
+		"arn:aws:s3:::bucket/an-object-key-here",
+		string(otherHash[:]),
+		"part:0198f2a1-6c3e-7c19-9b1e-4f2d5a6b7c8d:00001",
+	} {
+		c.meta.put(handlers.TableKey(model.TableObjects, key), []byte("not a tombstone"))
+	}
+
+	svc := c.service(8)
+	require.NoError(t, svc.Pass(t.Context()))
+
+	assert.Equal(t, int64(1), svc.Stats().Scanned, "only the tombstone row is a reclaim candidate")
+}
+
+// TestPagesThroughMoreTombstonesThanOnePage exercises the cursor the same way
+// repair's does: the tombstone table does not fit one response on a cluster
+// deleting at any volume, and a scan that silently stopped at the first page
+// would reclaim only the alphabetical head of the keyspace.
+func TestPagesThroughMoreTombstonesThanOnePage(t *testing.T) {
+	t.Parallel()
+
+	const count = 37
+	c := newCluster(t)
+
+	stored := make([]string, 0, count)
+	for i := range count {
+		row := tombstone(fmt.Sprintf("object-%03d", i), 1, nodes(1), nil)
+		stored = append(stored, c.store(t, row))
+	}
+
+	svc, err := New(Config{Meta: c.meta, Blob: c.blob, Workers: 3, PageSize: 4})
+	require.NoError(t, err)
+	require.NoError(t, svc.Pass(t.Context()))
+
+	assert.Equal(t, int64(count), svc.Stats().Scanned, "every page must be walked")
+	assert.Equal(t, int64(count), svc.Stats().Reclaimed)
+	for _, key := range stored {
+		assert.False(t, c.meta.has(key))
+	}
+}
+
+func TestRunStopsWithItsContext(t *testing.T) {
+	t.Parallel()
+
+	c := newCluster(t)
+	c.store(t, tombstone("object", 1, nodes(1), nil))
+	svc := c.service(8)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- svc.Run(ctx) }()
+
+	cancel()
+	require.NoError(t, <-done, "a cancelled sweep is a clean stop, not a failure")
+}
+
+func TestNewRejectsAServiceThatCouldNotSweep(t *testing.T) {
+	t.Parallel()
+
+	c := newCluster(t)
+	base := Config{Meta: c.meta, Blob: c.blob}
+
+	t.Run("no clients", func(t *testing.T) {
+		t.Parallel()
+		cfg := base
+		cfg.Meta = nil
+		_, err := New(cfg)
+		assert.Error(t, err)
+	})
+
+	t.Run("defaults fill in", func(t *testing.T) {
+		t.Parallel()
+		svc, err := New(base)
+		require.NoError(t, err)
+		assert.Positive(t, svc.workers)
+		assert.Equal(t, defaultPageSize, svc.pageSize)
+		assert.Equal(t, defaultInterval, svc.interval)
+	})
+}

--- a/internal/gate/routes.go
+++ b/internal/gate/routes.go
@@ -36,6 +36,15 @@ func byHeader(header string, with, without http.Handler) http.Handler {
 	})
 }
 
+// methodNotAllowed answers the requests a route matches on method and pattern
+// but not on the sub-resource that selects the operation.
+func methodNotAllowed() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlers.WriteS3Error(w, r, http.StatusMethodNotAllowed, "MethodNotAllowed",
+			"The specified method is not allowed against this resource")
+	})
+}
+
 // setupRoutes maps the S3 REST API onto the handlers, constructing each one
 // over the dependencies it needs. It runs after the middleware chain is
 // installed, since chi requires all middleware to be registered before the
@@ -67,6 +76,11 @@ func (s *Server) setupRoutes(ring *placement.Ring) {
 		r.Method(http.MethodGet, "/{bucket}", byQuery("uploads",
 			handlers.ListMultipartUploads(mc, cache),
 			handlers.ListObjects(mc, cache)))
+		// A POST at a bucket is the batch delete and nothing else, so without
+		// ?delete the route answers what an unmatched POST answered before it.
+		r.Method(http.MethodPost, "/{bucket}", byQuery("delete",
+			handlers.DeleteObjects(mc, bc, cache),
+			methodNotAllowed()))
 	})
 
 	// Object operations (with key).

--- a/internal/gate/server.go
+++ b/internal/gate/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mulgadc/predastore/internal/gate/auth"
 	"github.com/mulgadc/predastore/internal/gate/handlers"
 	"github.com/mulgadc/predastore/internal/gate/placement"
+	"github.com/mulgadc/predastore/internal/gate/reaper"
 	"github.com/mulgadc/predastore/internal/gate/repair"
 	"github.com/mulgadc/predastore/internal/telemetry"
 )
@@ -52,6 +53,10 @@ type Server struct {
 	// repairer is nil unless repair is enabled and this gate has local blob
 	// nodes to repair for.
 	repairer *repair.Service
+
+	// reaper is nil unless the reaper sweep is enabled and this gate has local
+	// blob nodes to run it for.
+	reaper *reaper.Service
 }
 
 var _ http.Handler = (*Server)(nil)
@@ -122,6 +127,9 @@ func New(cfg Config) (*Server, error) {
 	if s.repairer, err = newRepairer(cfg, ring); err != nil {
 		return nil, err
 	}
+	if s.reaper, err = newReaper(cfg); err != nil {
+		return nil, err
+	}
 
 	s.setupMiddleware()
 	s.setupRoutes(ring)
@@ -150,6 +158,30 @@ func newRepairer(cfg Config, ring *placement.Ring) (*repair.Service, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to build the repair sweep: %w", err)
+	}
+
+	return svc, nil
+}
+
+// newReaper builds the background tombstone sweep, or returns nil when there
+// is nothing for it to do. Like repair, a gate with no colocated blob nodes is
+// not a failure to configure: there is no election, so every gate that could
+// run the sweep does, and a gate-only host legitimately has no shards to
+// reclaim from.
+func newReaper(cfg Config) (*reaper.Service, error) {
+	if !cfg.Reaper.Enabled || len(cfg.LocalBlobNodeIDs) == 0 {
+		return nil, nil
+	}
+
+	svc, err := reaper.New(reaper.Config{
+		Meta:     cfg.Meta,
+		Blob:     cfg.Blob,
+		Workers:  cfg.Reaper.Workers,
+		PageSize: cfg.Reaper.PageSize,
+		Interval: cfg.Reaper.Interval,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build the reaper sweep: %w", err)
 	}
 
 	return svc, nil
@@ -301,6 +333,36 @@ func (s *Server) Run(ctx context.Context) error {
 		defer func() {
 			stopRepair()
 			repairDone.Wait()
+		}()
+	}
+
+	// Scoped and stopped the same way the repairer is: no goroutine outlives
+	// Run, and a reclaim in flight holds streams to peers the drain would
+	// otherwise wait behind.
+	if s.reaper != nil {
+		unregister, err := telemetry.RegisterReaperGauges(func() telemetry.ReaperSnapshot {
+			st := s.reaper.Stats()
+
+			return telemetry.ReaperSnapshot{
+				Pending: st.Pending, Reclaimed: st.Reclaimed,
+				Failed: st.Failed, Passes: st.Passes,
+			}
+		})
+		if err != nil {
+			return fmt.Errorf("failed to register the reaper gauges: %w", err)
+		}
+		defer func() { _ = unregister() }()
+
+		reaperCtx, stopReaper := context.WithCancel(ctx)
+		var reaperDone sync.WaitGroup
+		reaperDone.Go(func() {
+			if err := s.reaper.Run(reaperCtx); err != nil {
+				slog.Error("Reaper sweep stopped", "error", err)
+			}
+		})
+		defer func() {
+			stopReaper()
+			reaperDone.Wait()
 		}()
 	}
 

--- a/internal/gate/telemetry.go
+++ b/internal/gate/telemetry.go
@@ -14,7 +14,7 @@ import (
 func s3SpanMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bucket, key := requestBucketKey(r.Context())
-		action := s3Action(r.Method, bucket, key)
+		action := s3Action(r, bucket, key)
 		if action != "" {
 			otelsetup.SetRequestAction(r.Context(), action)
 		}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -100,6 +100,11 @@ const (
 	metricRepairRepaired = "predastore.repair.repaired"
 	metricRepairFailed   = "predastore.repair.failed"
 	metricRepairPasses   = "predastore.repair.passes"
+
+	metricReaperPending   = "predastore.reaper.pending"
+	metricReaperReclaimed = "predastore.reaper.reclaimed"
+	metricReaperFailed    = "predastore.reaper.failed"
+	metricReaperPasses    = "predastore.reaper.passes" //nolint:gosec // G101: metric name, not a credential value
 )
 
 // metricNames is every name this package registers. Only the tests read it:
@@ -125,6 +130,7 @@ var metricNames = []string{
 	metricMetaFSMLSMBytes, metricMetaFSMVLogBytes, metricMetaSnapshotIndex, metricMetaLogTrailing,
 	metricRPCConnections, metricRPCEvictions, metricRPCStreamsOpen, metricRPCStreamOpenDur,
 	metricRepairPending, metricRepairRepaired, metricRepairFailed, metricRepairPasses,
+	metricReaperPending, metricReaperReclaimed, metricReaperFailed, metricReaperPasses,
 }
 
 // secondsBuckets bounds the duration histograms. The SDK default boundaries
@@ -207,6 +213,11 @@ var (
 	repairRepaired metric.Int64ObservableGauge
 	repairFailed   metric.Int64ObservableGauge
 	repairPasses   metric.Int64ObservableGauge
+
+	reaperPending   metric.Int64ObservableGauge
+	reaperReclaimed metric.Int64ObservableGauge
+	reaperFailed    metric.Int64ObservableGauge
+	reaperPasses    metric.Int64ObservableGauge
 )
 
 // instruments lazily creates the shared instruments. The global meter
@@ -340,6 +351,15 @@ func instruments() {
 		repairFailed = int64Gauge(metricRepairFailed,
 			"Rebuild attempts that failed since start.", "{shard}")
 		repairPasses = int64Gauge(metricRepairPasses,
+			"Sweeps completed since start. Not climbing means the sweep is stalled or was never started.", "{pass}")
+
+		reaperPending = int64Gauge(metricReaperPending,
+			"Tombstones the last completed sweep could not reclaim. Above zero means shards a delete named are still waiting on a node that was unreachable.", "{tombstone}")
+		reaperReclaimed = int64Gauge(metricReaperReclaimed,
+			"Tombstones reclaimed since start, whether by deleting the shards they named or by dropping one superseded by a recreated key.", "{tombstone}")
+		reaperFailed = int64Gauge(metricReaperFailed,
+			"Reclaim attempts that failed since start.", "{tombstone}")
+		reaperPasses = int64Gauge(metricReaperPasses,
 			"Sweeps completed since start. Not climbing means the sweep is stalled or was never started.", "{pass}")
 	})
 }
@@ -1109,6 +1129,45 @@ func RegisterRepairGauges(snapshot func() RepairSnapshot) (func() error, error) 
 			return nil
 		},
 		repairPending, repairRepaired, repairFailed, repairPasses,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return reg.Unregister, nil
+}
+
+// ReaperSnapshot is what the reaper sweep reports about its passes. Pending is
+// the one to watch: it counts tombstones the last completed pass could not
+// reclaim, so a cluster sitting above zero has shards a delete named still
+// waiting on a node that was unreachable.
+type ReaperSnapshot struct {
+	Pending   int64
+	Reclaimed int64
+	Failed    int64
+	Passes    int64
+}
+
+// RegisterReaperGauges observes the reaper sweep. It runs unasked, the same as
+// repair, so its progress has to be visible without an operator having opted
+// into anything.
+func RegisterReaperGauges(snapshot func() ReaperSnapshot) (func() error, error) {
+	instruments()
+	if meter == nil {
+		return func() error { return nil }, nil
+	}
+
+	reg, err := meter.RegisterCallback(
+		func(_ context.Context, o metric.Observer) error {
+			s := snapshot()
+			o.ObserveInt64(reaperPending, s.Pending)
+			o.ObserveInt64(reaperReclaimed, s.Reclaimed)
+			o.ObserveInt64(reaperFailed, s.Failed)
+			o.ObserveInt64(reaperPasses, s.Passes)
+
+			return nil
+		},
+		reaperPending, reaperReclaimed, reaperFailed, reaperPasses,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -1142,6 +1142,14 @@ func recordEveryInstrument(t *testing.T) map[string]metricdata.Aggregation {
 	}
 	t.Cleanup(func() { _ = unregisterRepair() })
 
+	unregisterReaper, err := RegisterReaperGauges(func() ReaperSnapshot {
+		return ReaperSnapshot{Pending: 2, Reclaimed: 6, Failed: 1, Passes: 3}
+	})
+	if err != nil {
+		t.Fatalf("register reaper: %v", err)
+	}
+	t.Cleanup(func() { _ = unregisterReaper() })
+
 	return collect(t, reader)
 }
 

--- a/scripts/s3-tests-baseline.txt
+++ b/scripts/s3-tests-baseline.txt
@@ -586,10 +586,10 @@ PASS|s3tests/functional/test_s3.py::test_list_multipart_upload
 FAIL|s3tests/functional/test_s3.py::test_list_multipart_upload_owner
 SKIP|s3tests/functional/test_s3.py::test_list_object_versions_restore_status
 SKIP|s3tests/functional/test_s3.py::test_list_objects_restore_status
-FAIL|s3tests/functional/test_s3.py::test_multi_object_delete
+PASS|s3tests/functional/test_s3.py::test_multi_object_delete
 FAIL|s3tests/functional/test_s3.py::test_multi_object_delete_key_limit
-FAIL|s3tests/functional/test_s3.py::test_multi_objectv2_delete
-FAIL|s3tests/functional/test_s3.py::test_multi_objectv2_delete_key_limit
+PASS|s3tests/functional/test_s3.py::test_multi_objectv2_delete
+PASS|s3tests/functional/test_s3.py::test_multi_objectv2_delete_key_limit
 FAIL|s3tests/functional/test_s3.py::test_multipart_checksum_sha256
 FAIL|s3tests/functional/test_s3.py::test_multipart_copy_improper_range
 FAIL|s3tests/functional/test_s3.py::test_multipart_copy_invalid_range

--- a/scripts/smoke-baseline.txt
+++ b/scripts/smoke-baseline.txt
@@ -14,7 +14,7 @@ PASS|Multipart upload (16 MiB)
 PASS|ListObjectsV2 pagination
 PASS|ETag is the body MD5
 PASS|CopyObject (server-side)
-FAIL|DeleteObjects (bulk)
+PASS|DeleteObjects (bulk)
 PASS|DeleteObject (single)
 PASS|Presigned GET
 PASS|rclone mkdir


### PR DESCRIPTION
`POST /{bucket}?delete=` returned 405 because no route existed. Every client that empties a bucket in batches — `aws s3 rm --recursive`, rclone `purge`, the s3-tests teardown, the docker registry's storage driver — fell back to per-key deletes or failed outright.

Plan: `docs/development/feature/predastore-delete-objects.md` in mulga. Bead `mulga-9mled`.

## What it does

The handler reads the `Delete` document, deletes each key, and answers `DeleteResult`. Per-key outcomes are independent: a key that cannot be deleted produces an `Error` entry beside the `Deleted` entries for the rest and never fails the request. `Quiet` suppresses the deleted keys and keeps the errors.

**A key that is not there is reported as deleted.** S3's delete is idempotent in this form and a client emptying a bucket races its own listing. The single-object route keeps its 404, which is a separate conformance gap.

Keys are deleted through a bounded worker pool with results written by index, so the answer follows request order without a lock over it. A batch is up to 1000 keys and each one is a metadata read, a shard fan-out and two metadata writes.

## Authorization

`s3Action` mapped every `POST` to `s3:PutObject`, for multipart uploads. The batch delete addresses no key, so left alone it would have inherited that mapping and a principal holding only `s3:PutObject` could have emptied a bucket. It now maps to `s3:DeleteObject` against `arn:aws:s3:::<bucket>/*`.

The batch is authorized once, as a whole, against the wildcard rather than per key: a caller who may delete only some of the named keys is denied the entire batch. That is the fail-closed direction, and per-key evaluation would mean handing the policy evaluator to the handler, which no handler does today. `TestEvaluateS3Access_BulkDelete` asserts all three cases.

## Bounds

More than 1000 keys, or none, is `MalformedXML`. The body is read under a `MaxBytesReader` at four times the largest legitimate document.

`Content-MD5` is not required. AWS requires it here; predastore verifies `x-amz-content-sha256` over the same bytes on every signed request, which is the stronger check, and rejecting an otherwise valid signed request for a missing legacy header would break clients that sign correctly.

## Verified

Live, on a single-node cluster:

- **Smoke suite: `DeleteObjects (bulk)` passes**, taking this branch to 30/36. `scripts/smoke-baseline.txt` re-recorded.
- **Conformance: three cases fixed** — `test_multi_object_delete`, `test_multi_objectv2_delete`, `test_multi_objectv2_delete_key_limit`. `test_multi_object_delete_key_limit` still fails: it pages the bucket with the v1 `Marker`, which is a separate known gap.
- **The whole smoke suite is 36/36 with #120 merged in.** `docker push` and `docker pull` were failing on this 405: the registry's `Move` is `CopyObject` plus a prefix `Delete`, and its `Delete` is a batch delete. Verified on a scratch merge of both branches, since docker push needs `CopyObject` as well.

`make preflight` passes.

## One thing to know about the baseline

`scripts/s3-tests-baseline.txt` is edited case by case here rather than re-recorded. Three cases — `test_atomic_dual_write` at 1mb, 4mb and 8mb — regressed on `dev` before this branch, and `make s3-tests-baseline` would have written them in as expected failures. Filed as `mulga-k91ji` (P1); it reproduces both in CI on `dev` and locally.