### PR TITLE
feat: implement UploadPartCopy

### DIFF
--- a/internal/gate/handlers/copy_object.go
+++ b/internal/gate/handlers/copy_object.go
@@ -99,39 +99,19 @@ func CopyObject(mc MetaClient, bc BlobClient, ring *placement.Ring, cache *Bucke
 			return
 		}
 
-		// The source is read stripe by stripe into a pipe and teed into the
-		// digest, the same shape GetObject streams a response body: the
-		// copy's memory footprint is a stripe, not the source object, no
-		// matter how large that object is.
+		// The source is streamed and teed into the digest, so the destination
+		// gets its own content digest and the copy's memory footprint is a
+		// stripe rather than the source object.
 		digest := model.NewPartETagHasher()
-		var written writeResult
-		if srcSize == 0 {
-			// An empty object has no shards to read back, only a placement
-			// record, so there is nothing to stream and no stripe reader to open.
-			written, err = writeObject(ctx, bc, cfg, ring, io.TeeReader(http.NoBody, digest), 0, destHash, place)
-		} else {
-			srcReader, rErr := newStripeReader(ctx, bc, cfg, model.ObjectHash(srcBucket, srcKey), srcPlace, srcHandoff)
-			if rErr != nil {
-				HandleError(w, r, model.NewS3Error(model.ErrInternalError, rErr.Error(), 500))
-				return
-			}
-
-			pr, pw := io.Pipe()
-			done := make(chan struct{})
-			go func() {
-				defer close(done)
-				pw.CloseWithError(pipeObject(ctx, srcReader, pw, srcSize))
-			}()
-
-			written, err = writeObject(ctx, bc, cfg, ring, io.TeeReader(pr, digest), srcSize, destHash, place)
-
-			// Closing the read end unblocks the goroutine if writeObject stopped
-			// short, and waiting for it means the stripe reader is closed by
-			// nobody else while it is still being read.
-			_ = pr.Close()
-			<-done
-			srcReader.close(ctx)
+		stream, err := openCopyStream(ctx, bc, cfg,
+			model.ObjectHash(srcBucket, srcKey), srcPlace, srcHandoff, srcSize, 0, srcSize)
+		if err != nil {
+			HandleError(w, r, model.NewS3Error(model.ErrInternalError, err.Error(), 500))
+			return
 		}
+
+		written, err := writeObject(ctx, bc, cfg, ring, io.TeeReader(stream, digest), srcSize, destHash, place)
+		stream.close(ctx)
 		if err != nil {
 			slog.ErrorContext(ctx, "copyObject: shard distribution failed", "error", err)
 			telemetry.RecordObjectWrite(ctx, telemetry.WriteOutcomeFailed, writeFailureReason(err))

--- a/internal/gate/handlers/multipart.go
+++ b/internal/gate/handlers/multipart.go
@@ -6,11 +6,16 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
 	"sort"
+	"strconv"
 
 	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/mulgadc/predastore/internal/gate/placement"
 	"github.com/mulgadc/predastore/internal/meta"
+	"github.com/mulgadc/predastore/internal/telemetry"
 )
 
 // multipartPartKey generates the key for storing part metadata.
@@ -68,6 +73,99 @@ func requireUpload(ctx context.Context, mc MetaClient, bucket, key, uploadID str
 		return model.NewS3Error(model.ErrInvalidPart, "Bucket or key does not match upload", 400)
 	}
 	return nil
+}
+
+// storePart writes one part of an upload and records it. A part is stored as an
+// object in its own right under a hidden key, so completion is a read-back and
+// concatenation; body must deliver exactly size bytes.
+//
+// verify runs once the payload has landed but before the part is reachable, so
+// a failed check leaves nothing CompleteMultipartUpload can assemble. It is
+// where UploadPart validates the chunked encoding it decoded; a copied part has
+// no client payload to check and passes nil.
+func storePart(
+	ctx context.Context, mc MetaClient, bc BlobClient, ring *placement.Ring, cfg Config,
+	bucket, key, uploadID string, partNumber int, body io.Reader, size int64,
+	verify func() error,
+) (model.PartMetadata, writeResult, error) {
+	partKey := partObjectKey(key, uploadID, partNumber)
+	objectHash := model.ObjectHash(bucket, partKey)
+
+	// The ETag is MD5 over the part, and the write path already reads the part
+	// end to end, so the hash is teed off that read instead of costing a second
+	// pass over a buffered copy.
+	digest := model.NewPartETagHasher()
+
+	// Placement comes from the part's own object hash, so a retried part lands
+	// on the same nodes without anything deterministic on disk. Its epoch is its
+	// own: a part is an object and follows the same rules.
+	place, err := placeShards(ring, cfg, objectHash, size)
+	if err != nil {
+		return model.PartMetadata{}, writeResult{}, model.NewS3Error(model.ErrInternalError, "Failed to get shard placement", 500)
+	}
+
+	written, err := writeObject(ctx, bc, cfg, ring, io.TeeReader(body, digest), size, objectHash, place)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to store part", "uploadID", uploadID, "part", partNumber, "error", err)
+		abortShards(ctx, bc, objectHash, place, written)
+		return model.PartMetadata{}, written, mapPutErr(err)
+	}
+	if verify != nil {
+		if err := verify(); err != nil {
+			abortShards(ctx, bc, objectHash, place, written)
+			return model.PartMetadata{}, written, err
+		}
+	}
+
+	// The part is dated from its own epoch, so ListParts and the placement
+	// record cannot disagree about when it was written.
+	modified, _ := place.ModifiedAt()
+	partMeta := model.PartMetadata{
+		PartNumber:   partNumber,
+		Size:         size,
+		ETag:         model.PartETagFrom(digest),
+		LastModified: modified,
+	}
+
+	var partBuf bytes.Buffer
+	if err := gob.NewEncoder(&partBuf).Encode(partMeta); err != nil {
+		abortShards(ctx, bc, objectHash, place, written)
+		return model.PartMetadata{}, written, model.NewS3Error(model.ErrInternalError, "Failed to encode part metadata", 500)
+	}
+	if err := metaPut(ctx, mc, model.TableParts, multipartPartKey(uploadID, partNumber), partBuf.Bytes()); err != nil {
+		slog.ErrorContext(ctx, "Failed to store part metadata", "uploadID", uploadID, "part", partNumber, "error", err)
+		abortShards(ctx, bc, objectHash, place, written)
+		return model.PartMetadata{}, written, model.NewS3Error(model.ErrInternalError, "Failed to store part metadata", 500)
+	}
+
+	shardRecord, err := EncodePlacement(place)
+	if err != nil {
+		abortShards(ctx, bc, objectHash, place, written)
+		return model.PartMetadata{}, written, model.NewS3Error(model.ErrInternalError, "Failed to encode shard metadata", 500)
+	}
+	if err := metaPut(ctx, mc, model.TableObjects, partShardKey(uploadID, partNumber), shardRecord); err != nil {
+		slog.ErrorContext(ctx, "Failed to store part shard metadata", "uploadID", uploadID, "part", partNumber, "error", err)
+		abortShards(ctx, bc, objectHash, place, written)
+		return model.PartMetadata{}, written, model.NewS3Error(model.ErrInternalError, "Failed to store part shard metadata", 500)
+	}
+
+	commitShards(ctx, bc, objectHash, place, written)
+	telemetry.RecordMultipartPart(ctx, size)
+	slog.DebugContext(ctx, "Part uploaded", "uploadID", uploadID, "partNumber", partNumber,
+		"size", size, "etag", partMeta.ETag)
+
+	return partMeta, written, nil
+}
+
+// writePartHeaders reports what the write cost the part's durability. Neither
+// is an error: the part is stored either way.
+func writePartHeaders(w http.ResponseWriter, written writeResult) {
+	if written.degraded() {
+		w.Header().Set(degradedWriteHeader, strconv.Itoa(len(written.missing)))
+	}
+	if len(written.handoff) > 0 {
+		w.Header().Set(handoffHeader, strconv.Itoa(len(written.handoff)))
+	}
 }
 
 // getStoredParts retrieves all stored parts for an upload, in part order.

--- a/internal/gate/handlers/streamread.go
+++ b/internal/gate/handlers/streamread.go
@@ -566,6 +566,73 @@ func pipeObject(ctx context.Context, r *stripeReader, dst io.Writer, size int64)
 	return drain(ctx, r, dst, first, n, size)
 }
 
+// copyStream reads a byte range of a stored object as a stream. The object is
+// read stripe by stripe into a pipe, so a copy holds a stripe rather than the
+// object however large that object is.
+//
+// Both server-side copy paths use it, which is what keeps a whole-object copy
+// and a ranged part copy reading the source the same way.
+type copyStream struct {
+	pr   *io.PipeReader
+	src  *stripeReader
+	done chan struct{}
+}
+
+// openCopyStream starts streaming length bytes of an object from start. A
+// zero-length window needs no reader and yields EOF immediately, which is also
+// the empty-object case.
+func openCopyStream(
+	ctx context.Context, bc BlobClient, cfg Config,
+	objectHash [32]byte, place ObjectToShardNodes, handoff config.NodeID,
+	size, start, length int64,
+) (*copyStream, error) {
+	if size == 0 || length == 0 {
+		return &copyStream{pr: emptyPipe()}, nil
+	}
+
+	src, err := newStripeReader(ctx, bc, cfg, objectHash, place, handoff)
+	if err != nil {
+		return nil, err
+	}
+
+	pr, pw := io.Pipe()
+	var dst io.Writer = pw
+	if start > 0 || length < size {
+		dst = &windowWriter{dst: pw, skip: start, limit: length}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pw.CloseWithError(pipeObject(ctx, src, dst, size))
+	}()
+
+	return &copyStream{pr: pr, src: src, done: done}, nil
+}
+
+func (c *copyStream) Read(p []byte) (int, error) { return c.pr.Read(p) }
+
+// close releases the pipe and waits for the pump. Closing the read end unblocks
+// a pump whose consumer stopped short, and waiting for it means nothing else
+// closes the stripe reader while it is still being read.
+func (c *copyStream) close(ctx context.Context) {
+	_ = c.pr.Close()
+	if c.done != nil {
+		<-c.done
+	}
+	if c.src != nil {
+		c.src.close(ctx)
+	}
+}
+
+// emptyPipe is a reader already at EOF, in the same pipe type the streaming
+// path returns so the caller has one shape to handle.
+func emptyPipe() *io.PipeReader {
+	pr, pw := io.Pipe()
+	_ = pw.Close()
+	return pr
+}
+
 // windowWriter serves a byte range out of a whole-object stream: it drops the
 // first skip bytes and stops after limit. A negative limit means no limit.
 //

--- a/internal/gate/handlers/upload_part.go
+++ b/internal/gate/handlers/upload_part.go
@@ -1,16 +1,11 @@
 package handlers
 
 import (
-	"bytes"
-	"encoding/gob"
-	"io"
-	"log/slog"
 	"net/http"
 	"strconv"
 
 	"github.com/mulgadc/predastore/internal/gate/model"
 	"github.com/mulgadc/predastore/internal/gate/placement"
-	"github.com/mulgadc/predastore/internal/telemetry"
 )
 
 // UploadPart serves PUT /{bucket}/{key}?partNumber=N&uploadId=X. A part is
@@ -26,15 +21,6 @@ func UploadPart(mc MetaClient, bc BlobClient, ring *placement.Ring, cache *Bucke
 		bucket, key := resource.Bucket.Name, resource.Key
 		uploadID := r.URL.Query().Get("uploadId")
 		partNumber, _ := strconv.Atoi(r.URL.Query().Get("partNumber"))
-
-		// A part carrying x-amz-copy-source is UploadPartCopy, which this
-		// handler does not implement. Falling through would read the empty
-		// request body as the part's content, storing a silently wrong part
-		// rather than refusing the request.
-		if r.Header.Get("X-Amz-Copy-Source") != "" {
-			WriteS3Error(w, r, http.StatusNotImplemented, "NotImplemented", "UploadPartCopy is not implemented")
-			return
-		}
 
 		if err := requireBucket(ctx, mc, cache, bucket); err != nil {
 			HandleError(w, r, err)
@@ -63,87 +49,19 @@ func UploadPart(mc MetaClient, bc BlobClient, ring *placement.Ring, cache *Bucke
 			return
 		}
 
-		partKey := partObjectKey(key, uploadID, partNumber)
-		objectHash := model.ObjectHash(bucket, partKey)
-
-		// The ETag is MD5 over the part, and the write path already reads the
-		// part end to end, so the hash is teed off that read instead of costing
-		// a second pass over a buffered copy.
-		digest := model.NewPartETagHasher()
-
-		// Placement comes from the part's own object hash, so a retried part
-		// lands on the same nodes without anything deterministic on disk. Its
-		// epoch is its own: a part is an object and follows the same rules.
-		place, err := placeShards(ring, cfg, objectHash, partSize)
+		// The payload check runs after the part has landed but before it is
+		// reachable, so a failed check leaves nothing CompleteMultipartUpload
+		// can assemble.
+		partMeta, written, err := storePart(ctx, mc, bc, ring, cfg,
+			bucket, key, uploadID, partNumber, body, partSize,
+			func() error { return finishPayload(r, dec) })
 		if err != nil {
-			HandleError(w, r, model.NewS3Error(model.ErrInternalError, "Failed to get shard placement", 500))
-			return
-		}
-
-		written, err := writeObject(ctx, bc, cfg, ring, io.TeeReader(body, digest), partSize, objectHash, place)
-		if err != nil {
-			slog.ErrorContext(ctx, "Failed to store part", "uploadID", uploadID, "part", partNumber, "error", err)
-			abortShards(ctx, bc, objectHash, place, written)
-			HandleError(w, r, mapPutErr(err))
-			return
-		}
-		// The part is only reachable once its metadata lands below, so a failed
-		// payload check here leaves nothing CompleteMultipartUpload can assemble.
-		if err := finishPayload(r, dec); err != nil {
-			abortShards(ctx, bc, objectHash, place, written)
 			HandleError(w, r, err)
 			return
 		}
 
-		etag := model.PartETagFrom(digest)
-
-		// The part is dated from its own epoch, so ListParts and the placement
-		// record cannot disagree about when it was written.
-		modified, _ := place.ModifiedAt()
-		partMeta := model.PartMetadata{
-			PartNumber:   partNumber,
-			Size:         partSize,
-			ETag:         etag,
-			LastModified: modified,
-		}
-		var partBuf bytes.Buffer
-		if err := gob.NewEncoder(&partBuf).Encode(partMeta); err != nil {
-			abortShards(ctx, bc, objectHash, place, written)
-			HandleError(w, r, model.NewS3Error(model.ErrInternalError, "Failed to encode part metadata", 500))
-			return
-		}
-		if err := metaPut(ctx, mc, model.TableParts, multipartPartKey(uploadID, partNumber), partBuf.Bytes()); err != nil {
-			slog.ErrorContext(ctx, "Failed to store part metadata", "uploadID", uploadID, "part", partNumber, "error", err)
-			abortShards(ctx, bc, objectHash, place, written)
-			HandleError(w, r, model.NewS3Error(model.ErrInternalError, "Failed to store part metadata", 500))
-			return
-		}
-
-		shardRecord, err := EncodePlacement(place)
-		if err != nil {
-			abortShards(ctx, bc, objectHash, place, written)
-			HandleError(w, r, model.NewS3Error(model.ErrInternalError, "Failed to encode shard metadata", 500))
-			return
-		}
-		if err := metaPut(ctx, mc, model.TableObjects, partShardKey(uploadID, partNumber), shardRecord); err != nil {
-			slog.ErrorContext(ctx, "Failed to store part shard metadata", "uploadID", uploadID, "part", partNumber, "error", err)
-			abortShards(ctx, bc, objectHash, place, written)
-			HandleError(w, r, model.NewS3Error(model.ErrInternalError, "Failed to store part shard metadata", 500))
-			return
-		}
-
-		commitShards(ctx, bc, objectHash, place, written)
-
-		telemetry.RecordMultipartPart(ctx, partSize)
-		slog.DebugContext(ctx, "Part uploaded", "uploadID", uploadID, "partNumber", partNumber, "size", partSize, "etag", etag)
-
-		if written.degraded() {
-			w.Header().Set(degradedWriteHeader, strconv.Itoa(len(written.missing)))
-		}
-		if len(written.handoff) > 0 {
-			w.Header().Set(handoffHeader, strconv.Itoa(len(written.handoff)))
-		}
-		w.Header().Set("ETag", etag)
+		writePartHeaders(w, written)
+		w.Header().Set("ETag", partMeta.ETag)
 		w.Header().Set("X-Amz-Server-Side-Encryption", "AES256")
 		w.WriteHeader(http.StatusOK)
 	})

--- a/internal/gate/handlers/upload_part_copy.go
+++ b/internal/gate/handlers/upload_part_copy.go
@@ -1,0 +1,143 @@
+package handlers
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/mulgadc/predastore/internal/gate/placement"
+)
+
+// UploadPartCopy serves PUT /{bucket}/{key}?partNumber=N&uploadId=X carrying
+// x-amz-copy-source: a part whose content is a byte range of an object already
+// stored, rather than a request body.
+//
+// The docker registry's S3 driver finishes every resumed blob upload this way,
+// so without it a push of anything past one request fails.
+func UploadPartCopy(mc MetaClient, bc BlobClient, ring *placement.Ring, cache *BucketCache, cfg Config) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		resource, ok := routedObject(w, r)
+		if !ok {
+			return
+		}
+		bucket, key := resource.Bucket.Name, resource.Key
+		uploadID := r.URL.Query().Get("uploadId")
+		partNumber, _ := strconv.Atoi(r.URL.Query().Get("partNumber"))
+
+		srcBucket, srcKey, versionID, err := parseCopySource(r.Header.Get("X-Amz-Copy-Source"))
+		if err != nil {
+			HandleError(w, r, err)
+			return
+		}
+		if err := (model.Object{Bucket: model.Bucket{Name: srcBucket}, Key: srcKey}).Validate(); err != nil {
+			HandleError(w, r, err)
+			return
+		}
+
+		// Same two refusals CopyObject makes, for the same reason: honouring
+		// neither silently would answer 200 to a request whose terms were
+		// ignored.
+		if versionID != "" && versionID != "null" {
+			WriteS3Error(w, r, http.StatusNotImplemented, "NotImplemented",
+				"Copying a specific object version is not implemented")
+			return
+		}
+		for _, h := range copySourceConditionHeaders {
+			if r.Header.Get(h) != "" {
+				WriteS3Error(w, r, http.StatusNotImplemented, "NotImplemented",
+					"Conditional copy requests are not implemented")
+				return
+			}
+		}
+
+		if err := model.ValidatePartNumber(partNumber); err != nil {
+			HandleError(w, r, err)
+			return
+		}
+		if err := requireBucket(ctx, mc, cache, bucket); err != nil {
+			HandleError(w, r, err)
+			return
+		}
+		if err := requireBucket(ctx, mc, cache, srcBucket); err != nil {
+			HandleError(w, r, err)
+			return
+		}
+		if err := requireUpload(ctx, mc, bucket, key, uploadID); err != nil {
+			HandleError(w, r, err)
+			return
+		}
+
+		srcPlace, srcSize, err := loadPlacement(ctx, mc, ring, cfg, srcBucket, srcKey)
+		if err != nil {
+			HandleError(w, r, model.ErrNoSuchKeyError.WithResource(srcKey))
+			return
+		}
+
+		start, end, err := copySourceRange(r.Header.Get("X-Amz-Copy-Source-Range"), srcSize)
+		if err != nil {
+			HandleError(w, r, err)
+			return
+		}
+		partSize := end - start + 1
+		if partSize > model.MaxPartSize {
+			HandleError(w, r, model.NewS3Error(model.ErrEntityTooLarge, "Part exceeds maximum size", 400))
+			return
+		}
+
+		stream, err := openCopyStream(ctx, bc, cfg,
+			model.ObjectHash(srcBucket, srcKey), srcPlace,
+			handoffNode(ring, cfg, model.ObjectHash(srcBucket, srcKey)),
+			srcSize, start, partSize)
+		if err != nil {
+			HandleError(w, r, model.NewS3Error(model.ErrInternalError, err.Error(), 500))
+			return
+		}
+
+		// A copied part has no client payload to check, so no verify step: the
+		// source is content this gate already accepted and digested.
+		partMeta, written, err := storePart(ctx, mc, bc, ring, cfg,
+			bucket, key, uploadID, partNumber, stream, partSize, nil)
+		stream.close(ctx)
+		if err != nil {
+			HandleError(w, r, err)
+			return
+		}
+
+		writePartHeaders(w, written)
+		w.Header().Set("X-Amz-Server-Side-Encryption", "AES256")
+		if err := writeXML(w, http.StatusOK,
+			CopyPartResult{ETag: partMeta.ETag, LastModified: partMeta.LastModified}); err != nil {
+			slog.DebugContext(ctx, "failed to write XML response", "error", err)
+		}
+	})
+}
+
+// copySourceRange resolves x-amz-copy-source-range against the source size. An
+// absent header copies the whole object; S3 requires both ends when one is
+// given, so a half-open or unparseable spec is refused rather than widened into
+// a copy the caller did not ask for.
+func copySourceRange(header string, size int64) (start, end int64, err error) {
+	if header == "" {
+		if size == 0 {
+			return 0, -1, nil
+		}
+		return 0, size - 1, nil
+	}
+
+	start, end = parseRangeHeader(header)
+	if !strings.HasPrefix(header, "bytes=") || start < 0 || end < 0 {
+		return 0, 0, model.NewS3Error(model.ErrInvalidArgument,
+			"The x-amz-copy-source-range value must be of the form bytes=first-last "+
+				"where first and last are the zero-based offsets of the first and last bytes to copy", 400)
+	}
+
+	start, end, ok := resolveRange(size, start, end)
+	if !ok {
+		return 0, 0, model.ErrInvalidRangeError
+	}
+
+	return start, end, nil
+}

--- a/internal/gate/handlers/upload_part_copy_test.go
+++ b/internal/gate/handlers/upload_part_copy_test.go
@@ -1,0 +1,270 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A copy source is named in a header rather than the path, so unlike every
+// other bucket in these tests it goes through full bucket-name validation and
+// cannot be the one-character name the shared fixture uses.
+const copyTestBucket = "copy-bucket"
+
+func copyTestCache() *BucketCache {
+	return NewBucketCache([]BucketConfig{{Name: copyTestBucket, Region: "ap-southeast-2"}})
+}
+
+// copyObjectRequest carries the resolved resource the router would have
+// attached, against the copy suite's own bucket.
+func copyObjectRequest(method, key, query string) *http.Request {
+	r := httptest.NewRequest(method, "/"+copyTestBucket+"/"+key+"?"+query, nil)
+	return r.WithContext(WithObject(r.Context(), model.Object{
+		Bucket: model.Bucket{Name: copyTestBucket}, Key: key,
+	}))
+}
+
+// seedObject stores a whole object the way PutObject does, so a copy source
+// resolves through the same ARN and placement records production writes.
+func (f writeFixture) seedObject(t *testing.T, key string, body []byte) {
+	t.Helper()
+	ctx := context.Background()
+
+	objectHash := model.ObjectHash(copyTestBucket, key)
+	place, _, err := f.write(ctx, objectHash, bytes.NewReader(body), int64(len(body)))
+	require.NoError(t, err)
+	f.publish(t, objectHash, place)
+	require.NoError(t, metaPut(ctx, f.mc, model.TableObjects, objectARN(copyTestBucket, key), objectHash[:]))
+}
+
+// seedEmptyUpload records an upload with no parts, which is the state a client
+// is in when it starts copying parts into one.
+func (f writeFixture) seedEmptyUpload(t *testing.T, key, uploadID string) {
+	t.Helper()
+
+	var meta bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&meta).Encode(model.UploadMetadata{
+		UploadID: uploadID, Bucket: copyTestBucket, Key: key, CreatedAt: time.Now(),
+	}))
+	require.NoError(t, metaPut(context.Background(), f.mc, model.TableMultipart, uploadID, meta.Bytes()))
+}
+
+// copyPartRequest builds an UploadPartCopy the way the router dispatches one:
+// a part number and upload id in the query, the source in the header.
+func copyPartRequest(key, uploadID string, partNumber int, source, sourceRange string) *http.Request {
+	r := copyObjectRequest(http.MethodPut, key,
+		fmt.Sprintf("partNumber=%d&uploadId=%s", partNumber, uploadID))
+	r.Header.Set("X-Amz-Copy-Source", source)
+	if sourceRange != "" {
+		r.Header.Set("X-Amz-Copy-Source-Range", sourceRange)
+	}
+	return r
+}
+
+// readStoredPart reads a part back through the placement UploadPartCopy
+// recorded, which is the only thing that proves the part is retrievable.
+func (f writeFixture) readStoredPart(t *testing.T, key, uploadID string, partNumber int) []byte {
+	t.Helper()
+	ctx := context.Background()
+
+	record, err := metaGet(ctx, f.mc, model.TableObjects, partShardKey(uploadID, partNumber))
+	require.NoError(t, err)
+	place, err := DecodePlacement(record)
+	require.NoError(t, err)
+
+	partKey := partObjectKey(key, uploadID, partNumber)
+	got, _, err := readObject(ctx, f.bc, f.cfg, copyTestBucket, partKey, place, place.Size, 0)
+	require.NoError(t, err)
+	return got
+}
+
+// partETag derives the expected ETag through the same hasher the write path
+// uses, so the test asserts the value a client would compare against rather
+// than a second opinion about how a part ETag is formed.
+func partETag(t *testing.T, body []byte) string {
+	t.Helper()
+	h := model.NewPartETagHasher()
+	_, err := h.Write(body)
+	require.NoError(t, err)
+	return model.PartETagFrom(h)
+}
+
+// The docker registry finishes every resumed blob upload by copying the object
+// it just completed back in as a part. Without this the push fails on any blob
+// written across more than one request.
+func TestUploadPartCopyStoresTheWholeSource(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(2, 1)
+	source := randomBytes(t, 1<<18)
+	f.seedObject(t, "src", source)
+	f.seedEmptyUpload(t, "dst", "u1")
+
+	w := httptest.NewRecorder()
+	UploadPartCopy(f.mc, f.bc, f.ring, copyTestCache(), f.cfg).
+		ServeHTTP(w, copyPartRequest("dst", "u1", 1, "/"+copyTestBucket+"/src", ""))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// The ETag arrives in the body, not the header UploadPart sets: a client
+	// that cannot read it here cannot complete the upload.
+	var got CopyPartResult
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, partETag(t, source), got.ETag)
+	assert.False(t, got.LastModified.IsZero())
+
+	assert.Equal(t, source, f.readStoredPart(t, "dst", "u1", 1))
+}
+
+func TestUploadPartCopyHonoursTheSourceRange(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(2, 1)
+	source := randomBytes(t, 1<<16)
+	f.seedObject(t, "src", source)
+	f.seedEmptyUpload(t, "dst", "u1")
+
+	const start, end = 1000, 40_999
+	w := httptest.NewRecorder()
+	UploadPartCopy(f.mc, f.bc, f.ring, copyTestCache(), f.cfg).ServeHTTP(w,
+		copyPartRequest("dst", "u1", 2, "/"+copyTestBucket+"/src", fmt.Sprintf("bytes=%d-%d", start, end)))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	want := source[start : end+1]
+	assert.Equal(t, want, f.readStoredPart(t, "dst", "u1", 2))
+
+	var got CopyPartResult
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, partETag(t, want), got.ETag)
+}
+
+// An upload assembled entirely from copied parts has to read back byte for
+// byte, which is the property the registry's blob digest check depends on.
+func TestCompletedUploadOfCopiedPartsReadsBack(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(2, 1)
+	// Completion enforces the 5 MiB minimum on every part but the last, so a
+	// copied part is only assemblable at a real part size.
+	source := randomBytes(t, 6<<20)
+	f.seedObject(t, "src", source)
+	f.seedEmptyUpload(t, "dst", "u1")
+
+	const split = int(model.MinPartSize)
+	ranges := []string{fmt.Sprintf("bytes=0-%d", split-1), fmt.Sprintf("bytes=%d-%d", split, len(source)-1)}
+	for i, spec := range ranges {
+		w := httptest.NewRecorder()
+		UploadPartCopy(f.mc, f.bc, f.ring, copyTestCache(), f.cfg).
+			ServeHTTP(w, copyPartRequest("dst", "u1", i+1, "/"+copyTestBucket+"/src", spec))
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	}
+
+	body, err := xml.Marshal(CompleteMultipartUploadRequest{
+		Parts: []MultipartUploadPart{{PartNumber: 1}, {PartNumber: 2}},
+	})
+	require.NoError(t, err)
+
+	complete := httptest.NewRequest(http.MethodPost, "/"+copyTestBucket+"/dst?uploadId=u1", bytes.NewReader(body))
+	complete = complete.WithContext(WithObject(complete.Context(),
+		model.Object{Bucket: model.Bucket{Name: copyTestBucket}, Key: "dst"}))
+
+	w := httptest.NewRecorder()
+	CompleteMultipartUpload(f.mc, f.bc, f.ring, copyTestCache(), f.cfg).ServeHTTP(w, complete)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	place, size, err := loadPlacement(context.Background(), f.mc, f.ring, f.cfg, copyTestBucket, "dst")
+	require.NoError(t, err)
+	require.Equal(t, int64(len(source)), size)
+
+	got, _, err := readObject(context.Background(), f.bc, f.cfg, copyTestBucket, "dst", place, size, 0)
+	require.NoError(t, err)
+	assert.Equal(t, source, got)
+}
+
+func TestUploadPartCopyRefusesRequestsItCannotHonour(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(2, 1)
+	f.seedObject(t, "src", randomBytes(t, 4096))
+	f.seedEmptyUpload(t, "dst", "u1")
+
+	tests := []struct {
+		name        string
+		uploadID    string
+		partNumber  int
+		source      string
+		sourceRange string
+		header      string
+		status      int
+		code        string
+	}{
+		{
+			name: "range past the end of the source", uploadID: "u1", partNumber: 1,
+			source: "/" + copyTestBucket + "/src", sourceRange: "bytes=8000-9000",
+			status: http.StatusRequestedRangeNotSatisfiable, code: "InvalidRange",
+		},
+		{
+			name: "range missing its last byte", uploadID: "u1", partNumber: 1,
+			source: "/" + copyTestBucket + "/src", sourceRange: "bytes=100-",
+			status: http.StatusBadRequest, code: "InvalidArgument",
+		},
+		{
+			name: "source that does not exist", uploadID: "u1", partNumber: 1,
+			source: "/" + copyTestBucket + "/absent",
+			status: http.StatusNotFound, code: "NoSuchKey",
+		},
+		{
+			name: "upload that was never started", uploadID: "u-absent", partNumber: 1,
+			source: "/" + copyTestBucket + "/src",
+			status: http.StatusNotFound, code: "NoSuchUpload",
+		},
+		{
+			name: "part number out of range", uploadID: "u1", partNumber: 20000,
+			source: "/" + copyTestBucket + "/src",
+			status: http.StatusBadRequest, code: "InvalidPart",
+		},
+		{
+			name: "versioned source", uploadID: "u1", partNumber: 1,
+			source: "/" + copyTestBucket + "/src?versionId=v2",
+			status: http.StatusNotImplemented, code: "NotImplemented",
+		},
+		{
+			name: "conditional source", uploadID: "u1", partNumber: 1,
+			source: "/" + copyTestBucket + "/src", header: "X-Amz-Copy-Source-If-Match",
+			status: http.StatusNotImplemented, code: "NotImplemented",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := copyPartRequest("dst", tc.uploadID, tc.partNumber, tc.source, tc.sourceRange)
+			if tc.header != "" {
+				r.Header.Set(tc.header, "\"etag\"")
+			}
+
+			w := httptest.NewRecorder()
+			UploadPartCopy(f.mc, f.bc, f.ring, copyTestCache(), f.cfg).ServeHTTP(w, r)
+			require.Equal(t, tc.status, w.Code, w.Body.String())
+
+			var got S3Error
+			require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &got))
+			assert.Equal(t, tc.code, got.Code)
+
+			// A refused copy must leave no part behind for completion to find.
+			_, err := metaGet(context.Background(), f.mc, model.TableParts,
+				multipartPartKey(tc.uploadID, tc.partNumber))
+			assert.Error(t, err)
+		})
+	}
+}

--- a/internal/gate/handlers/xmltypes.go
+++ b/internal/gate/handlers/xmltypes.go
@@ -159,6 +159,14 @@ type CopyObjectResult struct {
 	LastModified time.Time `xml:"LastModified"`
 }
 
+// CopyPartResult answers a part copy. The part's ETag arrives in the body
+// rather than the header UploadPart sets, and clients read it from there.
+type CopyPartResult struct {
+	XMLName      xml.Name  `xml:"CopyPartResult"`
+	ETag         string    `xml:"ETag"`
+	LastModified time.Time `xml:"LastModified"`
+}
+
 // S3Error is the error document every failed request returns.
 type S3Error struct {
 	XMLName    xml.Name `xml:"Error"`

--- a/internal/gate/routes.go
+++ b/internal/gate/routes.go
@@ -96,8 +96,12 @@ func (s *Server) setupRoutes(ring *placement.Ring) {
 		r.Method(http.MethodGet, "/{bucket}/*", byQuery("uploadId",
 			handlers.ListParts(mc, cache),
 			bulkBody(handlers.GetObject(mc, bc, ring, cache, cfg))))
+		// x-amz-copy-source selects the server-side copy at both levels: with
+		// ?partNumber it is UploadPartCopy, without it CopyObject.
 		r.Method(http.MethodPut, "/{bucket}/*", byQuery("partNumber",
-			bulkBody(handlers.UploadPart(mc, bc, ring, cache, cfg)),
+			byHeader("X-Amz-Copy-Source",
+				bulkBody(handlers.UploadPartCopy(mc, bc, ring, cache, cfg)),
+				bulkBody(handlers.UploadPart(mc, bc, ring, cache, cfg))),
 			byHeader("X-Amz-Copy-Source",
 				bulkBody(handlers.CopyObject(mc, bc, ring, cache, cfg)),
 				bulkBody(handlers.PutObject(mc, bc, ring, cache, cfg)))))


### PR DESCRIPTION
## Problem

`docker push` of anything larger than a trivial image fails against a predastore-backed registry.

The docker distribution S3 driver buffers a blob into multipart parts, and a resumed `PATCH` reopens the upload in append mode. When what it holds is below the 5 MiB minimum part size it cannot simply add another part, so it completes the current upload into an object, starts a new one, and pulls that object back in as part 1 with `UploadPartCopy`. Every push whose blob is written across more than one request takes that path, and predastore answered 501:

```
level=error msg="unknown error completing upload: s3aws: NotImplemented:
UploadPartCopy is not implemented\n\tstatus code: 501"
```

The `s3aws: Path not found: …/_uploads/<id>/data` the client sees is the cascade after the driver cancels the upload it could not complete.

## Change

Serve `PUT /{bucket}/{key}?partNumber=N&uploadId=X` carrying `x-amz-copy-source`, streaming the requested byte range of the source rather than reading a request body.

Rather than adding a third copy of machinery that already exists twice, both halves are extracted and shared:

- `openCopyStream` in `streamread.go` owns the stripe reader, pipe, goroutine and close lifecycle for a ranged source read. `CopyObject` moves onto it, which also absorbs its `srcSize == 0` special case.
- `storePart` in `multipart.go` owns the part write: `placeShards`, `writeObject` teed into the part ETag hasher, an optional payload check, the part metadata and shard records, then `commitShards`. `UploadPart` moves onto it and loses its 501 guard, which the router now makes unreachable.

`routes.go` nests the existing `byHeader("X-Amz-Copy-Source", …)` inside the `?partNumber` branch, so `x-amz-copy-source` selects the server-side copy at both the object and the part level.

A versioned or conditional source is refused with `NotImplemented`, matching `CopyObject`: answering 200 to a request whose terms were ignored is worse than refusing it. An unsatisfiable `x-amz-copy-source-range` is `InvalidRange`, and a half-open or unparseable one is `InvalidArgument` rather than being widened into a copy the caller did not ask for.

## Testing

Unit (`upload_part_copy_test.go`): a whole-object copy stores the source bytes and answers a `CopyPartResult` body rather than an `ETag` header; a ranged copy stores exactly the requested window; an upload assembled from two copied parts completes and reads back byte-identical; and seven refusals each return the right status and code and leave no part behind for completion to find.

`make preflight` passes — 0 lint issues, diff coverage 68.5%.

Live, against a single-node predastore rebuilt from this branch: the 120 MB single-layer push that previously failed with the 501 above now succeeds in ~4.6s, and the pulled layer unpacks to a file whose sha256 equals the source bytes exactly. `./scripts/smoke.sh registry` passes 5/5.

## Not in this PR

The registry smoke suite pushes `hello-world` (~14 kB), which is one blob and one part, so it passed throughout while this defect was live. Closing that fixture gap needs a change in `predastore-docker`, a separate repo.
