### PR TITLE
chore: re-record the smoke baseline for docker push and pull

### DIFF
--- a/scripts/smoke-baseline.txt
+++ b/scripts/smoke-baseline.txt
@@ -33,6 +33,6 @@ PASS|restic backup (2nd, dedup)
 PASS|restic forget --prune
 PASS|registry bucket
 PASS|registry starts on predastore
-FAIL|docker push
-FAIL|docker pull
+PASS|docker push
+PASS|docker pull
 PASS|registry catalog


### PR DESCRIPTION
`docker push` and `docker pull` were the only two failing checks in the smoke suite. Both now pass, so the committed baseline no longer describes the build and the suite cannot fail on a regression in either.

Re-recorded against `dev` at `d1c5109` on the four-host `deploy/compose.cluster.yml` topology. The suite ran 36/36 twice: once comparing against the committed baseline, and again under `PREDA_WRITE_BASELINE` to record it. The diff is the two expected lines and nothing else.

The likely cause of the fix is #120: the docker registry S3 driver depends on a content-derived ETag and on CopyObject, and that PR landed both.

After this merges the two checks become gating, which is the intent.