### PR TITLE
fix: stop caller cancellations evicting healthy connections

### DIFF
--- a/internal/blob/client.go
+++ b/internal/blob/client.go
@@ -238,7 +238,16 @@ func (c *Client) awaitEnvelopeWithin(
 ) (*Response, error) {
 	respCtx, cancel := context.WithTimeout(ctx, within)
 	defer cancel()
-	stop := context.AfterFunc(respCtx, func() { stream.CancelRead(0) })
+	// Both our deadline and the caller's cancellation land here, and only here
+	// are both in scope to tell apart. Ours is the peer failing to answer; the
+	// caller's is no verdict on the peer at all.
+	stop := context.AfterFunc(respCtx, func() {
+		if ctx.Err() != nil {
+			stream.CancelRead(transport.StreamCodeCallerGone)
+			return
+		}
+		stream.CancelRead(0)
+	})
 	defer stop()
 
 	resp, err := readEnvelope(br)
@@ -487,7 +496,9 @@ func (c *Client) Get(ctx context.Context, nodeID config.NodeID, req GetRequest) 
 		stream:    stream,
 		remaining: resp.BodyLen,
 	}
-	body.stopCaller = context.AfterFunc(ctx, func() { stream.CancelRead(0) })
+	body.stopCaller = context.AfterFunc(ctx, func() {
+		stream.CancelRead(transport.StreamCodeCallerGone)
+	})
 	return body, nil
 }
 
@@ -521,8 +532,9 @@ func (s *bodyReadCloser) Close() error {
 	if s.stopCaller != nil {
 		s.stopCaller()
 	}
-	// Abort the read side in case the body was not fully drained; the
-	// write side is already closed.
-	s.stream.CancelRead(0)
+	// Abort the read side in case the body was not fully drained; the write
+	// side is already closed. A caller closing early is abandoning the shard,
+	// not reporting one, which is how a hedge stops evicting the loser.
+	s.stream.CancelRead(transport.StreamCodeCallerGone)
 	return nil
 }

--- a/internal/blob/engine/compaction.go
+++ b/internal/blob/engine/compaction.go
@@ -152,7 +152,14 @@ func (store *Store) compactOnce() error {
 	for _, num := range candidates {
 		segStart := time.Now()
 		stats, err := store.compactSegment(num)
-		if err != nil {
+		switch {
+		// A reader or writer still holds the segment. Its extents have already
+		// been relocated, so the next cycle finds nothing to move and only
+		// retries the drop.
+		case errors.Is(err, errSegmentBusy):
+			slog.Info("compaction deferred segment", "segNum", num)
+			continue
+		case err != nil:
 			// One bad segment must not strand the rest of the cycle: log it
 			// loudly and move on rather than aborting every other candidate.
 			slog.Error("compaction skipped segment", "segNum", num, "error", err)

--- a/internal/blob/engine/compaction_busy_segment_internal_test.go
+++ b/internal/blob/engine/compaction_busy_segment_internal_test.go
@@ -1,0 +1,88 @@
+package engine
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// A reader holds a reference to its segment until it is closed, and a reader
+// blocked on a peer that stopped draining holds one indefinitely. Waiting for
+// that reference under store.mutex would stall every other read and write on
+// the node, so a busy segment is deferred to the next cycle instead.
+func TestCompactionDefersSegmentWithLiveReader(t *testing.T) {
+	st, dir, oh := segment0LayoutStore(t)
+
+	if seg := extentOf(t, st, oh, 1).SegNum; seg != 0 {
+		t.Fatalf("expected value 1 in segment 0, got %d", seg)
+	}
+
+	held, err := st.Lookup(oh, 1)
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+
+	if _, err := st.Delete(oh, 0); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- st.compactOnce() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("compact: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("compactOnce blocked on a segment with a live reader")
+	}
+
+	seg0 := filepath.Join(dir, fmt.Sprintf(segFilename, 0))
+	if _, err := os.Stat(seg0); err != nil {
+		t.Fatalf("segment 0 should survive while a reader holds it: %v", err)
+	}
+
+	// The store must still be usable: the deferred drop is only correct if it
+	// released the lock every other caller needs.
+	if got := readValue(t, st, oh, 2); len(got) == 0 {
+		t.Fatal("read of an unrelated value returned nothing")
+	}
+	putValue(t, st, oh, 9, bytes.Repeat([]byte{0x5a}, KiB))
+
+	if err := held.Close(); err != nil {
+		t.Fatalf("close held reader: %v", err)
+	}
+
+	if err := st.compactOnce(); err != nil {
+		t.Fatalf("second compact: %v", err)
+	}
+	if _, err := os.Stat(seg0); !os.IsNotExist(err) {
+		t.Errorf("segment 0 should be dropped once its reader closed, stat err=%v", err)
+	}
+}
+
+// dropSegment must decline rather than wait, so the decision is exact under
+// the caller's lock and never turns into a blocking one.
+func TestDropSegmentReportsBusyWithoutWaiting(t *testing.T) {
+	st, _, oh := segment0LayoutStore(t)
+
+	held, err := st.Lookup(oh, 1)
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	defer held.Close()
+
+	st.mutex.Lock()
+	err = st.dropSegment(0)
+	st.mutex.Unlock()
+
+	if err == nil {
+		t.Fatal("dropSegment dropped a segment with a live reader")
+	}
+	if _, ok := st.segCache[0]; !ok {
+		t.Error("a declined drop must leave the segment cached")
+	}
+}

--- a/internal/blob/engine/segment.go
+++ b/internal/blob/engine/segment.go
@@ -8,13 +8,27 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"sync"
 	"sync/atomic"
+	"time"
 )
 
 const (
 	segFilename    = "%016d.seg"
 	idxSegFilename = "%016d.idx"
+)
+
+// errSegmentBusy reports a drop declined because the segment still has live
+// readers or writers. Not a failure: the caller retries on its next cycle.
+var errSegmentBusy = errors.New("segment still referenced")
+
+const (
+	// segRefPollInterval is how often the close path rechecks a segment's
+	// reference count.
+	segRefPollInterval = 20 * time.Millisecond
+
+	// closeRefDrainBudget bounds how long Close waits for one segment's readers
+	// and writers to finish before closing the fd out from under them.
+	closeRefDrainBudget = 10 * time.Second
 )
 
 // idxEntry is one row of a segment's append-only reverse sidecar (.idx), written
@@ -154,19 +168,34 @@ type segment struct {
 	idxSize int64  // .idx append cursor, guarded by store.mutex
 	num     uint64 // for unlink paths on drop
 
-	// Active readers and writers, drained before the fd closes. Safe as a
-	// WaitGroup because addRef only runs from Lookup/Append under store.mutex,
-	// and Close flips store.closed under that same mutex before waiting — so no
-	// addRef can race a Wait.
-	refs sync.WaitGroup
+	// Active readers and writers, drained before the fd closes. A counter
+	// rather than a WaitGroup so it can be tested without blocking: addRef only
+	// runs from Lookup/Append under store.mutex, so a zero read under that same
+	// lock is exact — no new reference can appear while it is held.
+	refs atomic.Int64
 
 	// Caches the on-disk full flag, sparing the hot Append path a ReadAt.
 	full atomic.Bool
 }
 
-func (seg *segment) addRef()      { seg.refs.Add(1) }
-func (seg *segment) releaseRef()  { seg.refs.Done() }
-func (seg *segment) waitForRefs() { seg.refs.Wait() }
+func (seg *segment) addRef()     { seg.refs.Add(1) }
+func (seg *segment) releaseRef() { seg.refs.Add(-1) }
+func (seg *segment) busy() bool  { return seg.refs.Load() > 0 }
+
+// waitForRefs drains active references, giving up after budget and reporting
+// whether it drained. Only the close path waits: a reader wedged against a peer
+// that stopped reading must not hold shutdown open indefinitely, and a segment
+// closed under one fails that read rather than stalling the process.
+func (seg *segment) waitForRefs(budget time.Duration) bool {
+	deadline := time.Now().Add(budget)
+	for seg.busy() {
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(segRefPollInterval)
+	}
+	return true
+}
 
 // appendIdx writes one row at the .idx append cursor and advances it. Caller
 // holds store.mutex.
@@ -183,14 +212,21 @@ func (seg *segment) syncIdx() error { return seg.idx.Sync() }
 // dropSegment unlinks a drained segment and its sidecar. Caller holds
 // store.mutex. Safe only once every live extent it held has been committed
 // elsewhere.
+//
+// A segment with live references is left in place and reported busy. Waiting
+// for them here would hold store.mutex across a wait no reader bounds, so a
+// single wedged reader would stall every other read and write on the node.
+// Deferring costs nothing but the dead space until the next cycle.
 func (store *Store) dropSegment(num uint64) error {
 	seg, ok := store.segCache[num]
 	if !ok {
 		return nil
 	}
+	if seg.busy() {
+		return fmt.Errorf("%w: segment %d", errSegmentBusy, num)
+	}
 	delete(store.segCache, num)
 	store.stats.liveSegments--
-	seg.waitForRefs()
 
 	var errs []error
 	if err := seg.Close(); err != nil {

--- a/internal/blob/engine/store.go
+++ b/internal/blob/engine/store.go
@@ -930,7 +930,10 @@ func (store *Store) Close() error {
 	}
 
 	for num, seg := range store.segCache {
-		seg.waitForRefs()
+		if !seg.waitForRefs(closeRefDrainBudget) {
+			slog.Warn("closing segment with live references",
+				"segNum", num, "refs", seg.refs.Load())
+		}
 
 		if err := seg.Close(); err != nil {
 			errs = append(errs, fmt.Errorf("close segment %d: %w", num, err))

--- a/internal/blob/server.go
+++ b/internal/blob/server.go
@@ -61,10 +61,19 @@ type Config struct {
 	// fills. Zero uses the engine's default interval.
 	Compaction time.Duration
 
+	// BodyIdleTimeout bounds a response body whose peer has stopped reading.
+	// Zero uses DefaultBodyIdleTimeout.
+	BodyIdleTimeout time.Duration
+
 	// Store stands in for the engine that would be opened at DataDir. Test
 	// seam: production leaves it nil.
 	Store Store
 }
+
+// DefaultBodyIdleTimeout bounds a get body that stops moving. It is deliberately
+// longer than the client's own idle timeout so a caller that gives up aborts its
+// own stream first; this is the backstop for one that vanishes without aborting.
+const DefaultBodyIdleTimeout = 60 * time.Second
 
 // Server serves rpc requests for one blob node. A process running several
 // nodes builds one Server per node, each with its own rpc server, so the
@@ -91,6 +100,9 @@ func New(cfg Config) (*Server, error) {
 	// than leaving a process holding an open store no peer can dial.
 	if len(cfg.Listeners) == 0 {
 		return nil, fmt.Errorf("node %d has no listeners", cfg.NodeID)
+	}
+	if cfg.BodyIdleTimeout <= 0 {
+		cfg.BodyIdleTimeout = DefaultBodyIdleTimeout
 	}
 	return &Server{cfg: cfg}, nil
 }
@@ -336,7 +348,18 @@ func (s *Server) handleGet(ctx context.Context, h Request, stream transport.Stre
 	if err := respond(stream, &Response{BodyLen: responseSize}); err != nil {
 		return fmt.Errorf("write envelope: %w", err)
 	}
-	if _, err := stream.ReadFrom(io.NewSectionReader(reader, rangeStart, responseSize)); err != nil {
+	// Guarded because the reader holds a reference to its segment until it is
+	// closed. A peer that stops draining without aborting would otherwise pin
+	// that reference for as long as its connection survives, and compaction
+	// blocks on exactly those references.
+	guard := transport.NewWriteGuard(
+		io.NewSectionReader(reader, rangeStart, responseSize), stream, s.cfg.BodyIdleTimeout)
+	defer guard.Stop()
+
+	if _, err := stream.ReadFrom(guard); err != nil {
+		if guard.Expired() {
+			return fmt.Errorf("stream body: %w", transport.ErrIdleTimeout)
+		}
 		return fmt.Errorf("stream body: %w", err)
 	}
 	return nil

--- a/internal/blob/server.go
+++ b/internal/blob/server.go
@@ -233,6 +233,14 @@ func (s *Server) handlePut(ctx context.Context, h Request, stream transport.Stre
 	}
 
 	if _, err := writer.ReadFrom(io.LimitReader(stream, h.Size)); err != nil {
+		// Close is what releases the segment reference Append took, so a failed
+		// body must still close or that reference is held for the life of the
+		// process. What it prepares is never published and is reaped in turn.
+		if closeErr := writer.Close(); closeErr != nil {
+			slog.Warn("close writer after failed body", "node", s.cfg.NodeID, "error", closeErr)
+		} else if abortErr := st.Abort(h.Key, h.Index, h.Epoch); abortErr != nil {
+			slog.Warn("abort partial write", "node", s.cfg.NodeID, "error", abortErr)
+		}
 		return respond(stream, &Response{Err: fmt.Sprintf("write: %v", err)})
 	}
 	// Closing prepares the extent rather than publishing it: the shard is

--- a/internal/blob/server_body_stall_internal_test.go
+++ b/internal/blob/server_body_stall_internal_test.go
@@ -101,3 +101,50 @@ func TestHandleGetAbortsAStalledBody(t *testing.T) {
 		t.Error("the reader must be closed, or its segment stays pinned")
 	}
 }
+
+// failingWriter models a put whose body never arrives.
+type failingWriter struct {
+	closed atomic.Bool
+}
+
+func (w *failingWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (w *failingWriter) Close() error                { w.closed.Store(true); return nil }
+
+func (w *failingWriter) ReadFrom(io.Reader) (int64, error) {
+	return 0, errors.New("connection reset")
+}
+
+type putStore struct {
+	Store
+
+	writer  *failingWriter
+	aborted atomic.Bool
+}
+
+func (s *putStore) Append(_ [32]byte, _ uint32, _ int64, _ uint64) (engine.Writer, error) {
+	return s.writer, nil
+}
+
+func (s *putStore) Abort(_ [32]byte, _ uint32, _ uint64) error {
+	s.aborted.Store(true)
+	return nil
+}
+
+// Close is the only thing that releases the segment reference Append took, so
+// a put whose body fails must still close its writer. Skipping it pins the
+// segment for the life of the process, which is what compaction then waits on.
+func TestHandlePutClosesWriterOnFailedBody(t *testing.T) {
+	store := &putStore{writer: &failingWriter{}}
+	srv := &Server{cfg: Config{NodeID: 1}, store: store}
+	stream := &stallStream{cancelled: make(chan struct{})}
+
+	if err := srv.handlePut(context.Background(), Request{Size: 16, Epoch: 7}, stream); err != nil {
+		t.Fatalf("handlePut: %v", err)
+	}
+	if !store.writer.closed.Load() {
+		t.Error("a failed body must still close the writer, or its segment stays pinned")
+	}
+	if !store.aborted.Load() {
+		t.Error("the prepared extent of a failed put should be aborted")
+	}
+}

--- a/internal/blob/server_body_stall_internal_test.go
+++ b/internal/blob/server_body_stall_internal_test.go
@@ -1,0 +1,103 @@
+package blob
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore/internal/blob/engine"
+	"github.com/mulgadc/predastore/internal/transport"
+)
+
+// stallReader is a value the store hands out. Close records that it ran, which
+// is what releases the segment reference in the real engine.
+type stallReader struct {
+	*bytes.Reader
+
+	closed atomic.Bool
+}
+
+func (r *stallReader) Close() error  { r.closed.Store(true); return nil }
+func (r *stallReader) Size() int64   { return r.Reader.Size() }
+func (r *stallReader) Epoch() uint64 { return 1 }
+func (r *stallReader) WriteTo(w io.Writer) (int64, error) {
+	return io.Copy(w, r.Reader)
+}
+
+type stallStore struct {
+	Store
+
+	reader *stallReader
+}
+
+func (s *stallStore) Lookup(_ [32]byte, _ uint32) (engine.Reader, error) { return s.reader, nil }
+
+// stallStream models a peer that stops draining the body without aborting the
+// stream: the envelope is accepted, then the copy never completes.
+type stallStream struct {
+	transport.Stream
+
+	envelope  bytes.Buffer
+	cancelled chan struct{}
+	once      atomic.Bool
+}
+
+func (s *stallStream) Write(p []byte) (int, error) { return s.envelope.Write(p) }
+
+func (s *stallStream) ReadFrom(r io.Reader) (int64, error) {
+	// One read to arm the guard, then block as a stalled flow-control window
+	// does, until the guard aborts the write.
+	if _, err := r.Read(make([]byte, 1)); err != nil {
+		return 0, err
+	}
+	<-s.cancelled
+	return 0, errors.New("stream reset")
+}
+
+func (s *stallStream) CancelWrite(transport.StreamErrorCode) {
+	if s.once.CompareAndSwap(false, true) {
+		close(s.cancelled)
+	}
+}
+
+func (s *stallStream) CancelRead(transport.StreamErrorCode) {}
+func (s *stallStream) Close() error                         { return nil }
+func (s *stallStream) LocalAddr() net.Addr                  { return nil }
+func (s *stallStream) RemoteAddr() net.Addr                 { return nil }
+func (s *stallStream) Read([]byte) (int, error)             { return 0, io.EOF }
+func (s *stallStream) WriteTo(io.Writer) (int64, error)     { return 0, io.EOF }
+
+// A get whose peer stops reading must be abandoned rather than held open. The
+// reader pins its segment until it closes, and compaction defers every segment
+// that is pinned, so an unbounded body write is an unbounded compaction stall.
+func TestHandleGetAbortsAStalledBody(t *testing.T) {
+	reader := &stallReader{Reader: bytes.NewReader(bytes.Repeat([]byte{0x7}, 64*1024))}
+	srv := &Server{
+		cfg:   Config{NodeID: 1, BodyIdleTimeout: 100 * time.Millisecond},
+		store: &stallStore{reader: reader},
+	}
+	stream := &stallStream{cancelled: make(chan struct{})}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.handleGet(context.Background(), Request{RangeStart: -1, RangeEnd: -1}, stream)
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, transport.ErrIdleTimeout) {
+			t.Fatalf("want idle timeout, got %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("handleGet never returned on a stalled body write")
+	}
+
+	if !reader.closed.Load() {
+		t.Error("the reader must be closed, or its segment stays pinned")
+	}
+}

--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -97,6 +97,21 @@ type healthStream struct {
 	// of them keeps its count, which is the leak the gauge exists to show.
 	release  func()
 	released atomic.Bool
+
+	// abandoned records that this side ended the stream for its own reasons.
+	// The read that follows fails, but the failure is ours and says nothing
+	// about whether the peer is serving.
+	abandoned atomic.Bool
+}
+
+// abandon marks a teardown the caller asked for, so the failed read it causes
+// is not charged to the peer. Only that one code qualifies: an idle abort and
+// an expired envelope deadline are both the peer failing to answer, which is
+// exactly the stall the pool needs to hear about.
+func (s *healthStream) abandon(code transport.StreamErrorCode) {
+	if code == transport.StreamCodeCallerGone {
+		s.abandoned.Store(true)
+	}
 }
 
 // done releases the stream from the gauge exactly once, whichever teardown
@@ -107,17 +122,25 @@ func (s *healthStream) done() {
 	}
 }
 
+// Close half-closes the write side and leaves the response still to be read,
+// so it is not an abandonment and must not suppress anything.
 func (s *healthStream) Close() error {
 	s.done()
 	return s.Stream.Close()
 }
 
+// CancelRead and CancelWrite mark the stream before tearing it down, so a read
+// already blocked on it cannot unblock and report the resulting error before
+// the mark lands.
+
 func (s *healthStream) CancelRead(code transport.StreamErrorCode) {
+	s.abandon(code)
 	s.done()
 	s.Stream.CancelRead(code)
 }
 
 func (s *healthStream) CancelWrite(code transport.StreamErrorCode) {
+	s.abandon(code)
 	s.done()
 	s.Stream.CancelWrite(code)
 }
@@ -130,6 +153,11 @@ func (s *healthStream) note(n int64, err error) {
 		if s.reported.CompareAndSwap(false, true) {
 			s.pool.noteProgress(s.conn)
 		}
+	// A read the caller gave up on is not evidence about the peer. Charging it
+	// lets an expiring shard deadline or an abandoned hedge evict a healthy
+	// connection, and the colder replacement is then abandoned the same way.
+	case s.abandoned.Load():
+		return
 	case err != nil:
 		if s.reported.CompareAndSwap(false, true) {
 			s.pool.noteStall(s.conn)

--- a/internal/rpc/pool_test.go
+++ b/internal/rpc/pool_test.go
@@ -366,9 +366,10 @@ func TestStalledStreamsEvictConnection(t *testing.T) {
 		if err != nil {
 			t.Fatalf("open stream: %v", err)
 		}
-		// Aborting the read is what a caller's expiring deadline does, so the
-		// stream ends without a byte of response.
-		stream.CancelRead(0)
+		// The idle guard aborting the read is what a peer that has stopped
+		// making progress looks like, so the stream ends without a byte of
+		// response and the connection is charged for it.
+		stream.CancelRead(transport.StreamCodeIdle)
 		if _, err := io.ReadAll(stream); err == nil {
 			t.Fatal("read from an aborted stream succeeded")
 		}
@@ -396,5 +397,50 @@ func TestStalledStreamsEvictConnection(t *testing.T) {
 	// The pool must be usable again: the next call dials a replacement.
 	if got, err := ping(ctx, caller, peer.id); err != nil || got != "pong:hello" {
 		t.Fatalf("ping after eviction returned %q, %v", got, err)
+	}
+}
+
+// TestAbandonedStreamsDoNotEvictConnection is the other half of the stall rule.
+// A caller abandons streams routinely — an open deadline expires, a hedged
+// shard is dropped once a faster copy lands — and each one ends in a failed
+// read. Charging those to the peer evicts connections that are serving
+// perfectly, and the colder replacement is abandoned the same way, so the
+// eviction repeats for as long as the caller keeps hedging.
+func TestAbandonedStreamsDoNotEvictConnection(t *testing.T) {
+	nodes := newTestCluster(t, 1, 2)
+	caller, peer := nodes[1], nodes[2]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	conn, err := caller.pool.Dial(ctx, peer.id)
+	if err != nil {
+		t.Fatalf("dial node %d: %v", peer.id, err)
+	}
+
+	abandon := func() {
+		t.Helper()
+		stream, err := OpenStream(ctx, caller.client, peer.id, opPing, &pingHeader{Name: "hello"})
+		if err != nil {
+			t.Fatalf("open stream: %v", err)
+		}
+		stream.CancelRead(transport.StreamCodeCallerGone)
+		if _, err := io.ReadAll(stream); err == nil {
+			t.Fatal("read from an abandoned stream succeeded")
+		}
+	}
+
+	// Well past maxStreamStalls, so a connection charged for these would be
+	// long gone by the time the loop ends.
+	for range maxStreamStalls * 3 {
+		abandon()
+	}
+	if held, _ := caller.pool.held(peer.id); held != conn {
+		t.Fatalf("connection evicted after %d abandoned streams", maxStreamStalls*3)
+	}
+
+	// And the connection is still the one being used, not merely still listed.
+	if got, err := ping(ctx, caller, peer.id); err != nil || got != "pong:hello" {
+		t.Fatalf("ping over the retained connection returned %q, %v", got, err)
 	}
 }

--- a/internal/transport/deadline.go
+++ b/internal/transport/deadline.go
@@ -15,6 +15,12 @@ var ErrIdleTimeout = errors.New("transfer stalled: idle timeout")
 // StreamCodeIdle is sent to the peer when an idle timeout aborts a stream.
 const StreamCodeIdle StreamErrorCode = 2
 
+// StreamCodeCallerGone aborts a stream the caller no longer wants: a deadline
+// it set itself, or a result it has already got elsewhere. It is distinct from
+// every other abort because it is the one that carries no verdict on the peer,
+// which is what stops a caller's own timeouts being read as peer failures.
+const StreamCodeCallerGone StreamErrorCode = 3
+
 // IdleGuard bounds a transfer by progress rather than by total duration. It
 // wraps the reader driving the transfer and aborts the stream when a single
 // read makes no progress within the idle timeout.


### PR DESCRIPTION
## Problem

`healthStream` reports the outcome of the first read on a stream back to the connection pool, and a failed read is charged to the peer as a stall. Three in a row evict the connection.

A caller abandons streams routinely, and every abandonment ends in a failed read:

- the gate bounds a shard open with `time.AfterFunc(shardOpenTimeout, cancel)`, and the cancel aborts the stream
- the hedge closes the loser's body deliberately once a faster copy lands

Both were counted against a peer that was serving perfectly. The replacement connection is colder than the one it replaced, so it is abandoned the same way, and the eviction repeats for as long as the caller keeps hedging.

On dev-prod this ran at **65 evictions per 15 minutes on an idle cluster**, and under load it made AMI documents unreadable and blocked instance launches.

Evidence the aborts were local rather than the peer: `io: read/write on closed pipe` (a pipe this side closed), `stream error: code 0` (a clean local reset), `duration_ms=0` on the read, and request `duration_ms=5002` matching `shardOpenTimeout` exactly.

## Change

The blob client already tells its own envelope deadline from the caller's cancellation — `awaitEnvelopeWithin` checks `respCtx.Err() != nil && ctx.Err() == nil` to decide which error to report — but it had no way to pass that distinction down to the pool, because every abort used code 0.

`transport.StreamCodeCallerGone` marks the aborts that carry no verdict on the peer, and `healthStream` declines to report those. It is emitted at the three caller-cancellation sites: the caller-gone branch of the envelope wait, the body's caller-cancellation hook, and `bodyReadCloser.Close`.

What still counts is unchanged and deliberate:

- an idle abort (`StreamCodeIdle`) is the peer failing to make progress
- an expired envelope deadline is the peer failing to answer
- a stream that will not open at all still goes through `noteFailure`, so a wedged replica that accepts no streams is evicted as before

## Tests

- `TestAbandonedStreamsDoNotEvictConnection` — new. Abandons `maxStreamStalls * 3` streams with `StreamCodeCallerGone` and asserts the connection is still pooled and still serving.
- `TestStalledStreamsEvictConnection` — its `stall()` helper simulated a stall with `CancelRead(0)`, described in its own comment as "what a caller's expiring deadline does". That is the case this PR says must not count, so the helper now uses `StreamCodeIdle`, which is what a peer that has stopped making progress actually looks like. The assertions are unchanged.
- `TestUnopenableStreamsEvictConnection` passes unchanged, which is the guard that the wedged-replica path was not weakened.

`make preflight` passes.

## Verified on dev-prod

Deployed to bottlebrush/ironbark/casuarina at `v1.18.0-123-gbaf84499`.

| | before | after |
|---|---|---|
| evictions, idle | 65 / 15 min | 0 |
| evictions, under load | 70 / 15 min | 0 |
| S3 5xx under load | 19 / 15 min | 0 |
| instance launch | blocked on unreadable AMI documents | succeeds |

Load was 4046 operations — 2023 PUTs and 2023 GETs of 8 MiB, 12 workers spread across all three gates over 10 minutes. Zero client-visible errors. The only 5xx in the whole window are in the 66 seconds after startup, where northstar reads its zone files before the buckets are ready; that is a separate pre-existing issue and is unrelated to this change.