### PR TITLE
fix: report a failed round trip as a failure

### DIFF
--- a/scripts/bench/e2e-stress.sh
+++ b/scripts/bench/e2e-stress.sh
@@ -267,13 +267,33 @@ round_trip() {
     local endpoint="$1" label="$2"
     local bucket="stress-${label}-${RUN_ID}"
     local src="$WORK_DIR/$label.bin" dst="$WORK_DIR/$label.out"
+    local failed=""
 
-    openssl rand -out "$src" 1048576
-    aws_s3 "$endpoint" s3 mb "s3://$bucket" >/dev/null
-    aws_s3 "$endpoint" s3api put-object --bucket "$bucket" --key rt.bin --body "$src" >/dev/null
-    aws_s3 "$endpoint" s3 cp "s3://$bucket/rt.bin" "$dst" --only-show-errors
-    diff -q "$src" "$dst" >/dev/null
-    aws_s3 "$endpoint" s3 rb "s3://$bucket" --force >/dev/null
+    # set -e does not apply inside a function called on the left of ||, so
+    # every step is checked here and the first one to fail is what the trip
+    # reports.
+    if ! openssl rand -out "$src" 1048576; then
+        failed="source generation"
+    elif ! aws_s3 "$endpoint" s3 mb "s3://$bucket" >/dev/null; then
+        failed="bucket create"
+    elif ! aws_s3 "$endpoint" s3api put-object --bucket "$bucket" --key rt.bin --body "$src" >/dev/null; then
+        failed="PUT"
+    elif ! aws_s3 "$endpoint" s3 cp "s3://$bucket/rt.bin" "$dst" --only-show-errors; then
+        failed="GET"
+    elif ! diff -q "$src" "$dst" >/dev/null; then
+        failed="byte comparison"
+    fi
+
+    # Removal is best effort and never the result. It succeeds on the empty
+    # bucket a failed PUT leaves behind, which is what let a wholly failed
+    # trip report the removal's success as its own.
+    aws_s3 "$endpoint" s3 rb "s3://$bucket" --force >/dev/null || true
+
+    if [ -n "$failed" ]; then
+        log "round-trip $label: $failed failed"
+        return 1
+    fi
+    return 0
 }
 
 # Placement follows the object hash, which is derived from bucket and key


### PR DESCRIPTION
## Summary

`round_trip` in `scripts/bench/e2e-stress.sh` reported success on a round trip that wholly failed, so `make e2e-stress` could exit 0 on a run it did not have. It had no explicit return, which made its status that of the trailing `s3 rb --force` — and that removal succeeds against the empty bucket a failed PUT leaves behind. `set -e` does not apply inside a function called on the left of `||`, so the PUT, the GET and the byte comparison could each fail without stopping the function.

This is what let the freeze scenario's closing round trip fail with `InsufficientStorage` on 2026-09-01 while the run still exited 0 and logged no FAIL. It matters beyond that one assertion: a harness that can report a green run it did not have undermines every scenario in the file. It also blocks the hardware verification `mulga-fnsp1` still needs, since no e2e-stress pass counts as evidence until the harness is honest.

Closes `mulga-2du0o`.

## Changes

- `round_trip` checks every step explicitly and returns on the first failure, naming the failing step in the log.
- Bucket removal still runs so a retry is not blocked, but its status is discarded rather than returned, so it can neither mask a failure nor rescue one.
- No call site changed. All five already used `|| fail`; the defect was entirely inside the function.

## Testing

The function was extracted from the committed script and driven with stubs, so the exercise runs the real source rather than a copy. Forcing a failure at each step:

| Forced failure | This branch | `dev` |
|---|---|---|
| none (healthy path) | 0 | 0 |
| PUT | 1 | **0** |
| GET | 1 | **0** |
| byte comparison | 1 | **0** |
| bucket create | 1 | **0** |

The `dev` column is the defect: every forced failure returns 0, so `|| fail` never fires. Bucket removal was confirmed to run in all five cases.

`make preflight` passes. The change is shell only, and preflight reports no new or modified Go source lines.