### PR TITLE
test: re-record s3-tests baseline after UploadPartCopy

### DIFF
--- a/scripts/s3-tests-baseline.txt
+++ b/scripts/s3-tests-baseline.txt
@@ -593,11 +593,11 @@ PASS|s3tests/functional/test_s3.py::test_multi_objectv2_delete_key_limit
 FAIL|s3tests/functional/test_s3.py::test_multipart_checksum_sha256
 FAIL|s3tests/functional/test_s3.py::test_multipart_copy_improper_range
 FAIL|s3tests/functional/test_s3.py::test_multipart_copy_invalid_range
-FAIL|s3tests/functional/test_s3.py::test_multipart_copy_multiple_sizes
-FAIL|s3tests/functional/test_s3.py::test_multipart_copy_small
+PASS|s3tests/functional/test_s3.py::test_multipart_copy_multiple_sizes
+PASS|s3tests/functional/test_s3.py::test_multipart_copy_small
 FAIL|s3tests/functional/test_s3.py::test_multipart_copy_special_names
 FAIL|s3tests/functional/test_s3.py::test_multipart_copy_versioned
-FAIL|s3tests/functional/test_s3.py::test_multipart_copy_without_range
+PASS|s3tests/functional/test_s3.py::test_multipart_copy_without_range
 FAIL|s3tests/functional/test_s3.py::test_multipart_get_part
 FAIL|s3tests/functional/test_s3.py::test_multipart_put_current_object_if_match
 FAIL|s3tests/functional/test_s3.py::test_multipart_put_current_object_if_none_match


### PR DESCRIPTION
## Summary

PR #131 (c43dde6) implemented `UploadPartCopy` but did not re-record `scripts/s3-tests-baseline.txt`. The baseline still recorded the pre-UploadPartCopy counts from PR #133 (886 cases: 197 pass, 197 fail, 492 skip, 0 error), which understated compatibility — the harness only fails a run on regression, so newly-passing cases sit unrecorded.

A fresh `make s3-tests` run against `origin/dev` HEAD `c43dde6` measured 886 cases: 200 pass, 194 fail, 492 skip, 0 error. Zero regressions. Three cases moved FAIL -> PASS:

- `s3tests/functional/test_s3.py::test_multipart_copy_multiple_sizes`
- `s3tests/functional/test_s3.py::test_multipart_copy_small`
- `s3tests/functional/test_s3.py::test_multipart_copy_without_range`

No other case changed state in either direction.

Of the seven `test_multipart_copy_*` cases the old baseline recorded as FAIL, four still fail for reasons unrelated to whole-object copy, confirmed individually under pytest:

- `test_multipart_copy_invalid_range` / `test_multipart_copy_improper_range`: predastore does not validate `CopySourceRange` — malformed or out-of-bounds ranges (e.g. a range past the source object's length, or a header missing the `bytes=` prefix) are accepted instead of rejected with a `ClientError`.
- `test_multipart_copy_special_names`: `UploadPartCopy` returns `InvalidArgument: x-amz-copy-source must be of the form /bucket/key` when the source key contains a URL-encoded `?` (e.g. `?versionId`).
- `test_multipart_copy_versioned`: fails in test setup, not in the copy path — `GetBucketVersioning` returns `NotImplemented: Versioning is not implemented`. Bucket versioning is unimplemented, so this case never reaches `UploadPartCopy`.

Re-recorded the baseline with `make s3-tests-baseline` (the repo's own mechanism) and re-ran `make s3-tests` once more to confirm it comes back clean against the new baseline.

## Test plan
- [x] `make s3-tests` against `origin/dev` HEAD `c43dde6` — 886 cases: 200 pass, 194 fail, 492 skip, 0 error, no regression
- [x] `make s3-tests-baseline` to re-record
- [x] `make s3-tests` again — clean, no diffs against the new baseline
- [x] `make preflight` — passed