### PR TITLE
ci: run S3 conformance on pull requests and fail on unrecorded fixes

### DIFF
--- a/.github/workflows/predastore-conformance.yml
+++ b/.github/workflows/predastore-conformance.yml
@@ -1,0 +1,102 @@
+# S3 conformance (ceph/s3-tests) against predastore.
+#
+# Split out of predastore-e2e.yml so it also runs on a pull request: the
+# suite drives the gate over HTTP, so any code in the built binary can flip a
+# case -- routing, internal/meta and the blob engine have each done so -- which
+# is why the path filter below is any Go change rather than an enumerated "S3
+# surface" that would silently miss one. *_test.go is excluded because test
+# files do not change the shipped binary. deploy/** and Dockerfile are
+# deliberately absent: this job runs bare-process via ./scripts/start.sh -w
+# s3tests against config/s3tests.toml, not the container.
+name: Conformance
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+    paths:
+      - "**/*.go"
+      - "!**/*_test.go"
+      - go.mod
+      - go.sum
+      - Makefile
+      - "config/**"
+      - "scripts/**"
+      - .github/workflows/predastore-conformance.yml
+  push:
+    branches:
+      - main
+      - dev
+    paths:
+      - "**/*.go"
+      - "!**/*_test.go"
+      - go.mod
+      - go.sum
+      - Makefile
+      - "config/**"
+      - "scripts/**"
+      - .github/workflows/predastore-conformance.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    name: S3 Conformance (ceph/s3-tests)
+    runs-on: ubuntu-26.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          cache-dependency-path: "go.sum"
+          go-version-file: "go.mod"
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Build
+        run: make build
+
+      # No container here. The suite needs the three accounts and the us-east-1
+      # region that only config/s3tests.toml carries, and render-config.sh emits
+      # exactly one account, so the image cannot serve this run without being
+      # handed a mounted profile.
+      - name: Start Cluster
+        run: ./scripts/start.sh -w s3tests
+
+      # Comparison, never strict. Predastore fails a large part of s3-tests and
+      # will for a long while, so the question this job answers is whether the
+      # branch moved anything, not whether the suite is green.
+      #
+      # Bounded below the job timeout on purpose: a job that hits its own
+      # timeout skips every later step, including the manifest upload, so the
+      # one artefact that would explain the failure is never produced.
+      - name: Conformance Suite
+        timeout-minutes: 20
+        run: make s3-tests
+
+      - name: Upload Manifest
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: s3-tests-manifest
+          path: /tmp/predastore-s3-tests/manifest.txt
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Cluster Logs
+        if: failure()
+        run: tail -n 200 /tmp/predastore/s3tests/logs/*.log
+
+      - name: Stop Cluster
+        if: always()
+        run: ./scripts/stop.sh s3tests

--- a/.github/workflows/predastore-e2e.yml
+++ b/.github/workflows/predastore-e2e.yml
@@ -2,7 +2,9 @@
 #
 # Split out of Build and Test so a pull request is not gated on a four-node
 # cluster, and so the two suites that already existed but were invoked by no
-# workflow finally run somewhere.
+# workflow finally run somewhere. Conformance split out again into
+# predastore-conformance.yml, so ceph/s3-tests also runs on a pull request
+# instead of only after merge.
 #
 # Build and Test keeps a trimmed compatibility job on the pull-request path.
 # The point of the split is to move the slow half, not to stop checking the S3
@@ -91,64 +93,6 @@ jobs:
       - name: Stop Cluster
         if: always()
         run: make compose-down
-
-  conformance:
-    name: S3 Conformance (ceph/s3-tests)
-    runs-on: ubuntu-26.04
-    timeout-minutes: 45
-
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
-
-      - name: Setup Go
-        uses: actions/setup-go@v7
-        with:
-          cache-dependency-path: "go.sum"
-          go-version-file: "go.mod"
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Build
-        run: make build
-
-      # No container here. The suite needs the three accounts and the us-east-1
-      # region that only config/s3tests.toml carries, and render-config.sh emits
-      # exactly one account, so the image cannot serve this run without being
-      # handed a mounted profile.
-      - name: Start Cluster
-        run: ./scripts/start.sh -w s3tests
-
-      # Comparison, never strict. Predastore fails a large part of s3-tests and
-      # will for a long while, so the question this job answers is whether the
-      # branch moved anything, not whether the suite is green.
-      #
-      # Bounded below the job timeout on purpose: a job that hits its own
-      # timeout skips every later step, including the manifest upload, so the
-      # one artefact that would explain the failure is never produced.
-      - name: Conformance Suite
-        timeout-minutes: 20
-        run: make s3-tests
-
-      - name: Upload Manifest
-        if: always()
-        uses: actions/upload-artifact@v5
-        with:
-          name: s3-tests-manifest
-          path: /tmp/predastore-s3-tests/manifest.txt
-          if-no-files-found: warn
-          retention-days: 30
-
-      - name: Cluster Logs
-        if: failure()
-        run: tail -n 200 /tmp/predastore/s3tests/logs/*.log
-
-      - name: Stop Cluster
-        if: always()
-        run: ./scripts/stop.sh s3tests
 
   # The scenario list is a job rather than a literal in the matrix so the
   # dispatch input can still name the two the default set leaves out.

--- a/scripts/s3tests/manifest.py
+++ b/scripts/s3tests/manifest.py
@@ -106,13 +106,18 @@ def compare(baseline_path, current_path, strict):
     show('REGRESSED -- these passed in the baseline', regressed)
     show('VANISHED -- in the baseline, not in this run', vanished)
     show('FIXED -- re-record the baseline in the same change', fixed)
+    if fixed:
+        print('\nRun `make s3-tests-baseline` to re-record it. CI uploads the '
+              'regenerated manifest as the s3-tests-manifest artifact, byte-'
+              'identical to the baseline, so an author who cannot run the '
+              'suite locally can download and commit it directly.')
     show('NEW -- not in the baseline', new)
 
-    # A regression and a vanished case are both failures of the comparison
-    # itself. Everything else is reported and does not fail the run, because a
-    # branch must not be red for gaps it did not introduce.
+    # Regressed, vanished, and fixed are all outcomes this branch caused, so
+    # each fails the comparison. NEW and strict-mode FAILING are not caused by
+    # this branch, so they are reported and left green.
     status = 0
-    if regressed or vanished:
+    if regressed or vanished or fixed:
         status = 1
     if strict and failing:
         show('FAILING -- strict mode fails on any of these', failing)


### PR DESCRIPTION
## Summary

Two causes of baseline drift, both fixed here because neither works alone:

1. **The conformance job never ran on a pull request.** It lived in `predastore-e2e.yml`, triggered only on push to `main`/`dev`, so the suite first ran after merge and an author had no way to include a baseline update in their PR. This splits it into its own `predastore-conformance.yml`, triggered on `pull_request`, `push` to `main`/`dev` (keeping the post-merge run), and `workflow_dispatch`. Path filter is any Go source change (excluding `*_test.go`), `go.mod`/`go.sum`, `Makefile`, `config/**`, `scripts/**`, and the workflow file itself — the suite drives the gate over HTTP, so routing, `internal/meta`, or the blob engine can each flip a case, which is why the filter is any Go change rather than an enumerated "S3 surface" that would silently miss one.

2. **A newly-passing case did not fail the run.** `scripts/s3tests/manifest.py` `compare()` computed `fixed` but only `regressed`/`vanished` set a non-zero exit status. Now `fixed` fails the comparison too, with actionable output naming `make s3-tests-baseline` and the `s3-tests-manifest` CI artifact (byte-identical to the baseline) as the two ways to re-record it.

Landing only (1) would just surface FIXED cases with no gate; landing only (2) alone would turn `dev` red after every improving merge with no way for the author to fix it in the same PR. They have to land together.

**Cost**: this adds ~20 minutes to any PR that touches the path filter above (Go source outside tests, config, scripts, Makefile, go.mod/go.sum).

**Sequencing**: #137 is open and re-records the baseline after `UploadPartCopy`. It should merge before or alongside this — otherwise the first PR to run under the new gate will fail on the three already-fixed `test_multipart_copy_*` cases through no fault of its own author.

## Test plan

- [x] `make preflight` passes
- [x] Both workflow YAML files parse (`actionlint`, plus `yaml.safe_load`)
- [x] `manifest.py compare` exercised directly against small fixture manifests: exit 1 for a FAIL→PASS case (fixed), exit 1 for a PASS→FAIL case (regressed), exit 1 for a vanished case, exit 0 when nothing changed
- [ ] Full `make s3-tests` run (intentionally not run here — ~20 minutes, not what this change is about)