### PR TITLE
fix: stop discarding the payload check on the CreateBucket body

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/raft-boltdb/v2 v2.3.1
 	github.com/klauspost/reedsolomon v1.14.2
 	github.com/minio/crc64nvme v1.1.1
-	github.com/mulgadc/bluebottle v1.18.1-0.20260903003911-3d26c3a8def8
+	github.com/mulgadc/bluebottle v1.18.1-0.20260903012122-3621f6fceeb1
 	github.com/nats-io/nats.go v1.53.1
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/quic-go/quic-go v0.61.0

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/mulgadc/bluebottle v1.18.1-0.20260903003911-3d26c3a8def8 h1:eTOKjTcXmX6i9CSzrFhjtc/bpfy6bRizmIiPoVmVask=
-github.com/mulgadc/bluebottle v1.18.1-0.20260903003911-3d26c3a8def8/go.mod h1:XBIMI+G2s3wuJNiEdYtlGDvCacw82OXEw50RIQhowYg=
+github.com/mulgadc/bluebottle v1.18.1-0.20260903012122-3621f6fceeb1 h1:dqxj7umc858KKBq2CrXr/wrCzT1pcbj4sqGooV6qTWQ=
+github.com/mulgadc/bluebottle v1.18.1-0.20260903012122-3621f6fceeb1/go.mod h1:XBIMI+G2s3wuJNiEdYtlGDvCacw82OXEw50RIQhowYg=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nats-io/nats.go v1.53.1 h1:Otsq3uLc/kLdjmkNHkXH0jBqwUquwdKFoe3fq6/3/Xo=

--- a/internal/gate/handlers/create_bucket.go
+++ b/internal/gate/handlers/create_bucket.go
@@ -47,12 +47,15 @@ func CreateBucket(mc MetaClient, cache *BucketCache, cfg Config) http.Handler {
 			// its error would apply a location the client never signed for.
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
+				// A rewritten body keeps its own error rather than being reported as a
+				// configuration the handler could not parse.
 				if errors.Is(err, sigv4.ErrContentSHA256Mismatch) {
-					HandleError(w, r, model.ErrContentSHA256MismatchError)
+					HandleError(w, r, err)
 					return
 				}
 
-				HandleError(w, r, model.NewS3Error(model.ErrMalformedXML, "failed to read bucket configuration: "+err.Error(), http.StatusBadRequest))
+				HandleError(w, r, model.NewS3Error(model.ErrMalformedXML,
+					"The bucket configuration could not be read", http.StatusBadRequest))
 				return
 			}
 			if xml.Unmarshal(body, &config) == nil && config.LocationConstraint != "" {

--- a/internal/gate/handlers/create_bucket.go
+++ b/internal/gate/handlers/create_bucket.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"encoding/gob"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"time"
 
+	"github.com/mulgadc/bluebottle/pkg/sigv4"
 	"github.com/mulgadc/predastore/internal/gate/auth"
 	"github.com/mulgadc/predastore/internal/gate/model"
 )
@@ -41,7 +43,18 @@ func CreateBucket(mc MetaClient, cache *BucketCache, cfg Config) http.Handler {
 		region := cfg.Region
 		if r.ContentLength > 0 {
 			var config CreateBucketConfiguration
-			body, _ := io.ReadAll(r.Body)
+			// The read carries the SigV4 payload check on a streamed body, so discarding
+			// its error would apply a location the client never signed for.
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				if errors.Is(err, sigv4.ErrContentSHA256Mismatch) {
+					HandleError(w, r, model.ErrContentSHA256MismatchError)
+					return
+				}
+
+				HandleError(w, r, model.NewS3Error(model.ErrMalformedXML, "failed to read bucket configuration: "+err.Error(), http.StatusBadRequest))
+				return
+			}
 			if xml.Unmarshal(body, &config) == nil && config.LocationConstraint != "" {
 				region = config.LocationConstraint
 			}

--- a/internal/gate/handlers/create_bucket_test.go
+++ b/internal/gate/handlers/create_bucket_test.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	"encoding/xml"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mulgadc/bluebottle/pkg/sigv4"
+	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errBody fails every read, standing in for the SigV4-verified body that reports a rewritten
+// payload to whoever reads it.
+type errBody struct{ err error }
+
+func (b errBody) Read([]byte) (int, error) { return 0, b.err }
+func (b errBody) Close() error             { return nil }
+
+// TestCreateBucketRejectsUnreadableConfiguration covers the read that carries the payload
+// check. Discarding its error created the bucket under a location constraint that failed its
+// signed digest, or under none at all when the body never arrived.
+func TestCreateBucketRejectsUnreadableConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		code string
+	}{
+		{name: "payload digest mismatch", err: sigv4.ErrContentSHA256Mismatch, code: "XAmzContentSHA256Mismatch"},
+		{name: "read failure", err: errors.New("connection reset by peer"), code: "MalformedXML"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPut, "/"+testBucket, errBody{err: tc.err})
+			req.ContentLength = 128
+			req = req.WithContext(WithBucket(req.Context(), model.Bucket{Name: testBucket}))
+			w := httptest.NewRecorder()
+
+			// The nil MetaClient is the assertion: reaching the store at all means the
+			// handler carried on past a body it could not read.
+			CreateBucket(nil, testCache(), Config{Region: "ap-southeast-2"}).ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+
+			var s3err S3Error
+			require.NoError(t, xml.NewDecoder(w.Body).Decode(&s3err))
+			assert.Equal(t, tc.code, s3err.Code)
+		})
+	}
+}

--- a/internal/gate/handlers/delete_objects.go
+++ b/internal/gate/handlers/delete_objects.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/mulgadc/bluebottle/pkg/sigv4"
 	"github.com/mulgadc/predastore/internal/gate/model"
 )
 
@@ -53,6 +54,12 @@ func DeleteObjects(mc MetaClient, bc BlobClient, cache *BucketCache) http.Handle
 
 		body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, deleteObjectsBodyLimit))
 		if err != nil {
+			// A rewritten body keeps its own error rather than being reported as bad XML.
+			if errors.Is(err, sigv4.ErrContentSHA256Mismatch) {
+				HandleError(w, r, err)
+				return
+			}
+
 			HandleError(w, r, model.NewS3Error(model.ErrMalformedXML,
 				"The delete request could not be read", 400))
 			return

--- a/internal/gate/handlers/put_object.go
+++ b/internal/gate/handlers/put_object.go
@@ -158,11 +158,7 @@ func recordPhase(ctx context.Context, op, phase string, start time.Time) time.Ti
 	return now
 }
 
-// finishPayload completes the SigV4 payload check on a body large enough that sigv4
-// verifies it as it streams: the signed digest is only compared at EOF, and the write
-// path stops at the declared length. Draining the remainder forces the comparison, so a
-// rewritten body is caught before the write is committed to global state.
-// It also finishes a framed body, where the remainder is the terminating chunk
+// finishPayload finishes a framed body, where the remainder is the terminating chunk
 // and the trailers: the write path stops at the decoded length, so without this
 // the chunk signature closing the chain and the trailing checksum are never
 // read. Draining has to go through the decoder for that reason — draining
@@ -178,10 +174,6 @@ func finishPayload(r *http.Request, dec *chunked.Decoder) error {
 	}
 
 	if _, err := io.Copy(io.Discard, rest); err != nil {
-		if errors.Is(err, sigv4.ErrContentSHA256Mismatch) {
-			return model.ErrContentSHA256MismatchError
-		}
-
 		return mapChunkedErr(err)
 	}
 
@@ -222,6 +214,8 @@ func mapChecksumErr(err error) error {
 // framing is a malformed request. Neither is a 500: both are the client's.
 func mapChunkedErr(err error) error {
 	switch {
+	case errors.Is(err, sigv4.ErrContentSHA256Mismatch):
+		return model.ErrContentSHA256MismatchError
 	case errors.Is(err, chunked.ErrChunkSignature):
 		return model.ErrSignatureDoesNotMatchError
 	case errors.Is(err, chunked.ErrMalformedFraming):

--- a/internal/gate/handlers/put_object_payload_test.go
+++ b/internal/gate/handlers/put_object_payload_test.go
@@ -90,8 +90,11 @@ func TestFinishPayload(t *testing.T) {
 	t.Run("rewritten body", func(t *testing.T) {
 		req := verifiedPut(t, large, bytes.Repeat([]byte("b"), len(large)))
 
+		// The declared length ends the body, so the write path's own read fails on the
+		// last byte: the rewrite is caught before the drain rather than by it.
 		_, err := io.CopyN(io.Discard, req.Body, int64(len(large)))
-		require.NoError(t, err)
+		require.ErrorIs(t, err, sigv4.ErrContentSHA256Mismatch)
+		require.ErrorIs(t, mapPutErr(err), model.ErrContentSHA256MismatchError)
 
 		require.ErrorIs(t, finishPayload(req, nil), model.ErrContentSHA256MismatchError)
 	})

--- a/internal/gate/handlers/respond.go
+++ b/internal/gate/handlers/respond.go
@@ -132,6 +132,19 @@ func HandleError(w http.ResponseWriter, r *http.Request, err error) {
 		s3error.Message = opErr.Message
 	} else {
 		switch {
+		// The SigV4 payload check rides on the read a handler makes of the request body, so
+		// this arrives here rather than from the middleware door. It is the client's error.
+		case errors.Is(err, sigv4.ErrContentSHA256Mismatch):
+			slog.WarnContext(r.Context(), "Request body does not match the signed payload hash",
+				"accessKeyID", auth.AccessKeyID(r.Context()),
+				"method", r.Method,
+				"path", r.URL.Path,
+				"payloadHashHeader", r.Header.Get("X-Amz-Content-Sha256"),
+				"remoteAddr", r.RemoteAddr,
+			)
+			statusCode = model.ErrContentSHA256MismatchError.StatusCode
+			s3error.Code = string(model.ErrContentSHA256MismatchError.Code)
+			s3error.Message = model.ErrContentSHA256MismatchError.Message
 		case strings.Contains(err.Error(), "NoSuchBucket") || strings.Contains(err.Error(), "Bucket not found"):
 			statusCode = http.StatusNotFound
 			s3error.Code = "NoSuchBucket"

--- a/internal/gate/handlers/shards.go
+++ b/internal/gate/handlers/shards.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/klauspost/reedsolomon"
+	"github.com/mulgadc/bluebottle/pkg/sigv4"
 	"github.com/mulgadc/predastore/internal/blob"
 	"github.com/mulgadc/predastore/internal/blob/engine"
 	"github.com/mulgadc/predastore/internal/config"
@@ -157,7 +158,8 @@ func writeFailureReason(err error) string {
 	switch {
 	case errors.Is(err, engine.ErrStoreFull):
 		return telemetry.WriteReasonStoreFull
-	case errors.Is(err, chunked.ErrChunkSignature),
+	case errors.Is(err, sigv4.ErrContentSHA256Mismatch),
+		errors.Is(err, chunked.ErrChunkSignature),
 		errors.Is(err, chunked.ErrMalformedFraming):
 		return telemetry.WriteReasonBadRequest
 	default:


### PR DESCRIPTION
## Problem

`CreateBucket` read its configuration with `body, _ := io.ReadAll(r.Body)` and unmarshalled the bytes regardless. On the streaming path that read is what performs the SigV4 payload check, so a `CreateBucketConfiguration` over 10 MiB that failed its signed digest still set `LocationConstraint`. Low impact in itself, but it was the proof that the "the consumer must read to EOF" contract did not hold in practice.

Review turned up the same shape at the other body-reading doors. `HandleError` has no arm for the sigv4 sentinel, so a mismatch that surfaces from a handler's own read falls through the `strings.Contains` ladder to `InternalError`/500 — booked against the error budget, and retried by an SDK on a request that can never succeed. `CompleteMultipartUpload` passed the raw error and answered exactly that; `DeleteObjects` flattened it to `MalformedXML`, sending whoever read the log looking for an XML bug.

## Change

- `HandleError` maps `sigv4.ErrContentSHA256Mismatch` to `XAmzContentSHA256Mismatch`/400, logged with the access key the way `RespondSigV4Error` logs it at the middleware door. `CompleteMultipartUpload` inherits this with no change of its own.
- `CreateBucket` and `DeleteObjects` check the sentinel before falling back to `MalformedXML`, so their own answer for an unreadable body cannot mask it.
- Companion to mulgadc/bluebottle#18, which settles the digest at the declared length. A rewritten body now surfaces from the write path's own read rather than from the drain that follows it, so `mapChunkedErr` maps it — keeping the answer a 400 rather than the 500 that read would otherwise take — and `writeFailureReason` counts it as a bad request rather than a shard-write failure.
- `finishPayload` loses its duplicate mismatch branch. The drain stays: it is still what reads the terminating chunk and trailers on a framed body.

## Landing order

`go.mod` pins a bluebottle that predates the fix, so this branch is red on its own — `GOWORK=off go test ./internal/gate/handlers/` fails `TestFinishPayload/rewritten_body`. bluebottle#18 lands first, then the `require` bump, then this.

## Tests

New `create_bucket_test.go` covers the digest mismatch and a generic read failure, with a nil `MetaClient` so reaching the store fails the test. `TestFinishPayload/rewritten_body` is updated to the new contract: `io.CopyN` fails on the last byte, so the rewrite is caught before the drain rather than by it, and `mapPutErr` is asserted to give the 400.

## Known gaps, not addressed here

- `TestMapPutErr` has rows for the chunked sentinels but none for sigv4, so the `mapChunkedErr` and `writeFailureReason` additions are unpinned.
- `create_bucket_test.go`'s stub fails on the first read, where a real `verifiedBody` returns data and fails on the read that completes the length.
- `mapChunkedErr` now maps a non-framing error and its name and doc no longer say so.
- Pre-existing and out of scope: the unbounded `io.ReadAll` in `create_bucket.go` (the sibling in `delete_objects.go` uses `MaxBytesReader`), and the discarded `xml.Unmarshal` error one line below the fix.

`make preflight` passes. Closes mulga-922lo with bluebottle#18; the unsized-body remainder is mulga-azlq0.