### PR TITLE
fix: bound generation retention by reference, not by epoch rank

### DIFF
--- a/internal/blob/client.go
+++ b/internal/blob/client.go
@@ -79,6 +79,13 @@ type DeleteRequest struct {
 	Index uint32
 }
 
+// ReleaseRequest drops one superseded generation of a shard.
+type ReleaseRequest struct {
+	Key   [32]byte
+	Index uint32
+	Epoch uint64
+}
+
 // CommitRequest publishes, or discards, a shard prepared by an earlier put.
 type CommitRequest struct {
 	Key   [32]byte
@@ -405,8 +412,16 @@ func (c *Client) Abort(ctx context.Context, nodeID config.NodeID, req CommitRequ
 	return err
 }
 
+// Release drops a superseded generation the caller has finished with, so the
+// space comes back now rather than when the retention window expires.
+func (c *Client) Release(ctx context.Context, nodeID config.NodeID, req ReleaseRequest) error {
+	_, err := c.finish(ctx, nodeID, OpRelease, "release", CommitRequest(req))
+
+	return err
+}
+
 // finish runs the bodyless second half of a write: open, half-close, read the
-// envelope. Commit and Abort differ only in the opcode they send.
+// envelope. Commit, Abort and Release differ only in the opcode they send.
 func (c *Client) finish(ctx context.Context, nodeID config.NodeID, op rpc.Opcode, name string, req CommitRequest) (*Response, error) {
 	stream, err := c.openBounded(ctx, nodeID, op, &Request{
 		Key:        req.Key,

--- a/internal/blob/engine/compaction.go
+++ b/internal/blob/engine/compaction.go
@@ -117,7 +117,7 @@ func (store *Store) compactOnce() error {
 
 	// Likewise for superseded generations: a commit demotes rather than
 	// tombstones, so this is where that space comes back.
-	released, err := store.sweepRetained(retainedMaxAge, retainedGenerations)
+	released, err := store.sweepRetained(retainedMaxAge)
 	if err != nil {
 		return fmt.Errorf("sweep retained generations: %w", err)
 	}
@@ -269,24 +269,17 @@ func (store *Store) sweepPrepared(maxAge time.Duration) (int, error) {
 // which is not this change.
 const retainedMaxAge = 5 * time.Minute
 
-// retainedGenerations caps how many superseded generations one shard position
-// keeps, oldest dropped first. Age alone would let a hot key pin a generation
-// per overwrite for the whole window, which is unbounded space for a bounded
-// purpose: only a record still in flight can name one, and the number of those
-// is the number of writers racing the key.
-const retainedGenerations = 4
-
 // sweepRetained reclaims generations that a commit superseded and nothing has
 // asked for since. It is the only thing that decides a generation is dead —
 // commit demotes, and never destroys.
 //
-// It enforces both bounds, and the count bound is enforced here rather than
-// only at commit because commit cannot enforce it. Each writer's transaction
-// prunes against its own snapshot, so concurrent commits of one position each
-// see a different subset and can leave more than the cap between them. This
-// runs on the compactor, single file, against everything that is actually
-// there.
-func (store *Store) sweepRetained(maxAge time.Duration, keep int) (int, error) {
+// Age is the only bound, because age is the only thing that bounds who can
+// still name a generation. A count bound ranked them by epoch, which is write
+// *start* order, while the record that survives is the one whose write
+// finished last. Those are different writes whenever PUTs overlap, so the cap
+// evicted generations the metadata still pointed at, and the object read back
+// as a 500 having acknowledged every writer.
+func (store *Store) sweepRetained(maxAge time.Duration) (int, error) {
 	cutoff := time.Now().Add(-maxAge).UnixNano()
 
 	type row struct {
@@ -300,8 +293,8 @@ func (store *Store) sweepRetained(maxAge time.Duration, keep int) (int, error) {
 	// Rows sort by position and then by big-endian epoch, so one position's
 	// generations arrive contiguously and oldest first.
 	flush := func() {
-		for i, r := range group {
-			if r.at < cutoff || i < len(group)-keep {
+		for _, r := range group {
+			if r.at < cutoff {
 				stale = append(stale, r.key)
 			}
 		}

--- a/internal/blob/engine/compaction.go
+++ b/internal/blob/engine/compaction.go
@@ -54,10 +54,24 @@ func (c *compactor) loop() {
 	ticker := time.NewTicker(c.store.compactionInterval)
 	defer ticker.Stop()
 
+	// Retained generations are swept on their own, much faster cycle. A full
+	// cycle relocates extents and rewrites segments; this is one scan of the
+	// retained namespace, and it is what decides how long a writer's released
+	// generation keeps holding disk.
+	retained := time.NewTicker(retainedSweepInterval)
+	defer retained.Stop()
+
 	for {
 		select {
 		case <-c.done:
 			return
+		case <-retained.C:
+			released, err := c.store.sweepRetained(retainedMaxAge)
+			if err != nil {
+				slog.Error("retained sweep failed", "error", err)
+			} else if released > 0 {
+				slog.Debug("released superseded generations", "count", released)
+			}
 		case <-ticker.C:
 			if err := c.store.compactOnce(); err != nil {
 				slog.Error("compaction cycle failed", "error", err)
@@ -268,6 +282,12 @@ func (store *Store) sweepPrepared(maxAge time.Duration) (int, error) {
 // needs repair to reconcile a record against what the nodes actually hold,
 // which is not this change.
 const retainedMaxAge = 5 * time.Minute
+
+// retainedSweepInterval is how often superseded generations are reclaimed. It
+// is far shorter than the compaction cycle because it bounds the disk a
+// released generation holds after its writer has finished with it, and the
+// scan it runs is cheap next to a compaction pass.
+const retainedSweepInterval = 15 * time.Second
 
 // sweepRetained reclaims generations that a commit superseded and nothing has
 // asked for since. It is the only thing that decides a generation is dead —

--- a/internal/blob/engine/compaction_internal_test.go
+++ b/internal/blob/engine/compaction_internal_test.go
@@ -298,7 +298,7 @@ func TestOverwriteRetainsThenReclaimsSupersededExtent(t *testing.T) {
 		t.Fatalf("commit tombstoned superseded slot %v while it is still retained", slotOf(old))
 	}
 
-	released, err := st.sweepRetained(-time.Second, 0)
+	released, err := st.sweepRetained(-time.Second)
 	if err != nil {
 		t.Fatalf("sweep retained: %v", err)
 	}
@@ -363,7 +363,7 @@ func TestTombstoneLandsAtCommitNotAppend(t *testing.T) {
 	if _, ok := tombstones(t, st)[slotOf(old)]; ok {
 		t.Fatalf("commit tombstoned superseded slot %v instead of retaining it", slotOf(old))
 	}
-	if _, err := st.sweepRetained(-time.Second, 0); err != nil {
+	if _, err := st.sweepRetained(-time.Second); err != nil {
 		t.Fatalf("sweep retained: %v", err)
 	}
 	if _, ok := tombstones(t, st)[slotOf(old)]; !ok {
@@ -386,7 +386,7 @@ func TestOverwriteChurnDrainsSegment(t *testing.T) {
 	// Overwriting retains the previous generation, so the space is not dead
 	// until it is released. Draining is a property of the reclaim path, not of
 	// how long the store holds a generation answerable.
-	if _, err := st.sweepRetained(-time.Second, 0); err != nil {
+	if _, err := st.sweepRetained(-time.Second); err != nil {
 		t.Fatalf("sweep retained: %v", err)
 	}
 

--- a/internal/blob/engine/concurrent_write_internal_test.go
+++ b/internal/blob/engine/concurrent_write_internal_test.go
@@ -196,6 +196,74 @@ func TestTheSweepReleasesRetainedGenerations(t *testing.T) {
 	}
 }
 
+// A generation whose record has been replaced is released by the writer that
+// replaced it, so retention is bounded by the writes in flight rather than by
+// the age cutoff. The row is backdated rather than dropped: a reader that
+// resolved the old record a moment ago is still streaming from it, and taking
+// the bytes now would turn a rare lost write into a routine failed read.
+func TestReleaseGenerationHandsBackASupersededGeneration(t *testing.T) {
+	st, _ := openTestStore(t)
+	oh := [32]byte{0x45}
+	const writers = 3
+
+	epochs, _, _ := raceWriters(t, st, oh, writers)
+
+	if err := st.ReleaseGeneration(oh, 0, epochs[0]); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+
+	r, err := st.LookupAt(oh, 0, epochs[0])
+	if err != nil {
+		t.Fatalf("a released generation stopped answering before the sweep took it: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	released, err := st.sweepRetained(retainedMaxAge)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if released != 1 {
+		t.Fatalf("sweep released %d generations, want only the one handed back", released)
+	}
+	if r, err := st.LookupAt(oh, 0, epochs[0]); err == nil {
+		_ = r.Close()
+		t.Fatalf("the released generation survived the sweep")
+	}
+	// The other superseded generation was never released and is still fresh.
+	r, err = st.LookupAt(oh, 0, epochs[1])
+	if err != nil {
+		t.Fatalf("the sweep took a generation nobody released: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+// Releasing reaches only the retained namespace, so a caller working from a
+// stale placement record cannot ask a node to hand back the object it is
+// currently serving.
+func TestReleaseGenerationCannotTouchTheLiveGeneration(t *testing.T) {
+	st, _ := openTestStore(t)
+	oh := [32]byte{0x46}
+	const writers = 2
+
+	epochs, bodies, _ := raceWriters(t, st, oh, writers)
+	live := epochs[writers-1]
+
+	if err := st.ReleaseGeneration(oh, 0, live); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if _, err := st.sweepRetained(retainedMaxAge); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+
+	if got := readValue(t, st, oh, 0); !bytes.Equal(got, bodies[writers-1]) {
+		t.Fatalf("releasing the live epoch changed what the position serves")
+	}
+}
+
 // countRetained calls seen once per retained row of one shard position.
 func countRetained(st *Store, idxKey []byte, seen func()) error {
 	prefix := retainedScan(idxKey)

--- a/internal/blob/engine/concurrent_write_internal_test.go
+++ b/internal/blob/engine/concurrent_write_internal_test.go
@@ -126,23 +126,22 @@ func TestEveryCommittedGenerationStaysReadable(t *testing.T) {
 	}
 }
 
-// Retention is bounded by count as well as age, or a hot key would pin a
-// generation per overwrite for the whole window. The newest survive; the live
-// row is never a candidate.
+// No count bounds retention, however many writers race one position. This is
+// the regression guard for acknowledged objects going unreadable: the cap that
+// used to be here ranked generations by epoch, which is write *start* order,
+// while the record that survives is whichever write finished last. Any writer
+// the cap evicted could be the one the metadata went on to name.
 //
-// The cap is asserted after a sweep because the sweep is what enforces it.
-// Commit prunes too, but each writer's transaction sees its own snapshot, so
-// concurrent commits of one position can leave more than the cap between them.
-func TestRetentionKeepsOnlyTheNewestGenerations(t *testing.T) {
+// Every epoch here is fresh, so a generation missing after the sweep was
+// dropped by a count and by nothing else.
+func TestRetentionKeepsEveryFreshGeneration(t *testing.T) {
 	st, _ := openTestStore(t)
 	oh := [32]byte{0x43}
-	const writers = retainedGenerations + 3
+	const writers = 12
 
 	epochs, _, _ := raceWriters(t, st, oh, writers)
 
-	// Nothing is old enough to age out, so anything dropped here is dropped by
-	// the count bound alone.
-	if _, err := st.sweepRetained(retainedMaxAge, retainedGenerations); err != nil {
+	if _, err := st.sweepRetained(retainedMaxAge); err != nil {
 		t.Fatalf("sweep: %v", err)
 	}
 
@@ -150,21 +149,20 @@ func TestRetentionKeepsOnlyTheNewestGenerations(t *testing.T) {
 	if err := countRetained(st, MakeKey(oh, 0), func() { kept++ }); err != nil {
 		t.Fatalf("scan retained: %v", err)
 	}
-	if kept != retainedGenerations {
-		t.Fatalf("retained %d generations, want the cap of %d", kept, retainedGenerations)
+	if kept != writers-1 {
+		t.Fatalf("retained %d generations of %d superseded, want all of them", kept, writers-1)
 	}
 
-	// The oldest is gone and the newest superseded one is not.
-	if r, err := st.LookupAt(oh, 0, epochs[0]); err == nil {
-		_ = r.Close()
-		t.Fatalf("the oldest generation outlived the cap")
-	}
-	r, err := st.LookupAt(oh, 0, epochs[writers-2])
-	if err != nil {
-		t.Fatalf("the newest superseded generation was pruned: %v", err)
-	}
-	if err := r.Close(); err != nil {
-		t.Fatalf("close: %v", err)
+	// Including the lowest epoch, which is the one a count bound drops first
+	// and is as likely as any other to be the generation the record names.
+	for i, epoch := range epochs[:writers-1] {
+		r, err := st.LookupAt(oh, 0, epoch)
+		if err != nil {
+			t.Fatalf("generation %d of %d was reclaimed while fresh: %v", i, writers, err)
+		}
+		if err := r.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
 	}
 }
 
@@ -177,7 +175,7 @@ func TestTheSweepReleasesRetainedGenerations(t *testing.T) {
 
 	epochs, _, _ := raceWriters(t, st, oh, writers)
 
-	released, err := st.sweepRetained(-1, retainedGenerations)
+	released, err := st.sweepRetained(-1)
 	if err != nil {
 		t.Fatalf("sweep: %v", err)
 	}

--- a/internal/blob/engine/store.go
+++ b/internal/blob/engine/store.go
@@ -805,6 +805,58 @@ func readIndexValue(txn *badger.Txn, key []byte) (extent, uint64, error) {
 	return decodeIndexValue(raw)
 }
 
+// ReleaseGeneration marks one superseded generation of a shard position as
+// finished with, named by the epoch that wrote it. It reaches only the
+// retained namespace, so it cannot touch the generation the node is serving
+// however stale the caller's idea of that is.
+//
+// It backdates the row rather than dropping it, and the sweep reclaims it on
+// its next pass. A reader that resolved the old record a moment ago is still
+// streaming shards from that generation, and taking the bytes out from under
+// it would turn a rare lost write into a routine failed read. The delay is
+// what keeps that reader whole; the marking is what stops retention growing
+// with everything written inside the age window rather than with the writes
+// actually in flight.
+func (store *Store) ReleaseGeneration(key [32]byte, index uint32, epoch uint64) error {
+	store.mutex.Lock()
+	closed := store.closed
+	store.mutex.Unlock()
+	if closed {
+		return ErrClosedStore
+	}
+
+	rowKey := retainedKey(MakeKey(key, index), epoch)
+	for {
+		err := store.index.Update(func(txn *badger.Txn) error {
+			raw, err := readRaw(txn, rowKey)
+			if errors.Is(err, badger.ErrKeyNotFound) {
+				// Already reclaimed, which is the outcome the caller wanted.
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			ext, held, err := decodeIndexValue(raw)
+			if err != nil {
+				return fmt.Errorf("decode retained row: %w", err)
+			}
+			if held != epoch {
+				return nil
+			}
+
+			return txn.Set(rowKey, encodePreparedValue(ext, epoch, 0))
+		})
+		if errors.Is(err, badger.ErrConflict) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("release generation: %w", err)
+		}
+
+		return nil
+	}
+}
+
 // Delete removes a key's index entry and tombstones its extent, in one
 // transaction so the dead-space hint cannot outlive or precede the deletion.
 // Reports whether an extent existed; a missing key is not an error, which

--- a/internal/blob/engine/store.go
+++ b/internal/blob/engine/store.go
@@ -659,9 +659,6 @@ func (store *Store) Commit(key [32]byte, index uint32, epoch uint64) (published 
 				if err := txn.Set(retainedKey(idxKey, epoch), encodePreparedValue(ext, epoch, time.Now().UnixNano())); err != nil {
 					return fmt.Errorf("retain superseded generation: %w", err)
 				}
-				if err := pruneRetained(txn, idxKey, retainedGenerations); err != nil {
-					return err
-				}
 				return txn.Delete(prepKey)
 
 			// Demoted, not destroyed: a record naming this generation is still
@@ -670,9 +667,6 @@ func (store *Store) Commit(key [32]byte, index uint32, epoch uint64) (published 
 			case liveErr == nil:
 				if err := txn.Set(retainedKey(idxKey, liveEpoch), encodePreparedValue(old, liveEpoch, time.Now().UnixNano())); err != nil {
 					return fmt.Errorf("retain superseded generation: %w", err)
-				}
-				if err := pruneRetained(txn, idxKey, retainedGenerations); err != nil {
-					return err
 				}
 			}
 
@@ -796,50 +790,6 @@ func dropRowsUnder(txn *badger.Txn, prefix []byte) error {
 	// Deleting inside the iteration would invalidate it.
 	for _, k := range keys {
 		if err := txn.Delete(k); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// pruneRetained drops the oldest retained generations of one shard position
-// until at most keep remain, tombstoning what it removes. Epochs sort
-// big-endian, so the iteration is already oldest-first and the tail to keep is
-// the last keep rows.
-func pruneRetained(txn *badger.Txn, idxKey []byte, keep int) error {
-	prefix := retainedScan(idxKey)
-
-	opts := badger.DefaultIteratorOptions
-	opts.Prefix = prefix
-	it := txn.NewIterator(opts)
-
-	var rows [][]byte
-	var exts []extent
-	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
-		item := it.Item()
-		if len(item.Key()) != retainedKeySize {
-			continue
-		}
-		raw, err := item.ValueCopy(nil)
-		if err != nil {
-			it.Close()
-			return fmt.Errorf("copy retained row: %w", err)
-		}
-		ext, _, err := decodeIndexValue(raw)
-		if err != nil {
-			it.Close()
-			return fmt.Errorf("decode retained row: %w", err)
-		}
-		rows = append(rows, item.KeyCopy(nil))
-		exts = append(exts, ext)
-	}
-	it.Close()
-
-	for i := 0; i < len(rows)-keep; i++ {
-		if err := txn.Set(tombstoneKey(exts[i].SegNum, exts[i].Off), tombstoneValue(exts[i].PSize)); err != nil {
-			return fmt.Errorf("tombstone pruned generation: %w", err)
-		}
-		if err := txn.Delete(rows[i]); err != nil {
 			return err
 		}
 	}

--- a/internal/blob/protocol.go
+++ b/internal/blob/protocol.go
@@ -19,6 +19,11 @@ const (
 	// Repair asks this of every position it owns, so answering it with a get
 	// would move the whole store across the network to learn one number.
 	OpStat rpc.Opcode = 0x2006
+
+	// OpRelease drops one superseded generation of a shard. It names an epoch
+	// and only ever removes a retained row, so it cannot take the generation a
+	// node is currently serving.
+	OpRelease rpc.Opcode = 0x2007
 )
 
 // Response error codes with protocol meaning; anything else in Err is an

--- a/internal/blob/server.go
+++ b/internal/blob/server.go
@@ -31,6 +31,7 @@ type Store interface {
 	Commit(key [32]byte, index uint32, epoch uint64) (published bool, err error)
 	Abort(key [32]byte, index uint32, epoch uint64) error
 	Delete(key [32]byte, index uint32) (bool, error)
+	ReleaseGeneration(key [32]byte, index uint32, epoch uint64) error
 	NearFull() bool
 	Close() error
 }
@@ -138,6 +139,7 @@ func (s *Server) Run(ctx context.Context) error {
 	rpc.RegisterHandler(mux, OpGet, s.handleGet)
 	rpc.RegisterHandler(mux, OpPut, s.handlePut)
 	rpc.RegisterHandler(mux, OpDelete, s.handleDelete)
+	rpc.RegisterHandler(mux, OpRelease, s.handleRelease)
 	rpc.RegisterHandler(mux, OpCommit, s.handleCommit)
 	rpc.RegisterHandler(mux, OpAbort, s.handleAbort)
 	rpc.RegisterHandler(mux, OpStat, s.handleStat)
@@ -416,6 +418,17 @@ func (s *Server) resolveEpoch(h Request, stale engine.Reader) (engine.Reader, er
 	slog.Info("completed a shard commit abandoned by its writer",
 		"node", s.cfg.NodeID, "index", h.Index, "epoch", fmt.Sprintf("%016x", h.Epoch))
 	return reader, nil
+}
+
+// handleRelease drops a superseded generation a writer has finished with. It
+// is best-effort housekeeping, so a miss is success: the generation being gone
+// already is the outcome the caller wanted.
+func (s *Server) handleRelease(ctx context.Context, h Request, stream transport.Stream) error {
+	if err := s.store.ReleaseGeneration(h.Key, h.Index, h.Epoch); err != nil {
+		return respond(stream, &Response{Err: err.Error()})
+	}
+
+	return respond(stream, &Response{})
 }
 
 func (s *Server) handleDelete(ctx context.Context, h Request, stream transport.Stream) error {

--- a/internal/blob/slow_commit_test.go
+++ b/internal/blob/slow_commit_test.go
@@ -109,9 +109,10 @@ func (s *slowCommitStore) Abort(_ [32]byte, index uint32, epoch uint64) error {
 	return nil
 }
 
-func (s *slowCommitStore) Delete(_ [32]byte, _ uint32) (bool, error) { return false, nil }
-func (s *slowCommitStore) NearFull() bool                            { return false }
-func (s *slowCommitStore) Close() error                              { return nil }
+func (s *slowCommitStore) ReleaseGeneration(_ [32]byte, _ uint32, _ uint64) error { return nil }
+func (s *slowCommitStore) Delete(_ [32]byte, _ uint32) (bool, error)              { return false, nil }
+func (s *slowCommitStore) NearFull() bool                                         { return false }
+func (s *slowCommitStore) Close() error                                           { return nil }
 
 // Prepared is what reached the platter, whatever the caller was told.
 func (s *slowCommitStore) Prepared(index uint32) (preparedValue, bool) {

--- a/internal/gate/auth/middleware_test.go
+++ b/internal/gate/auth/middleware_test.go
@@ -44,7 +44,7 @@ type noMeta struct{}
 
 func (noMeta) Get(context.Context, string) ([]byte, error)          { return nil, errNoCluster }
 func (noMeta) Put(context.Context, string, []byte) error            { return errNoCluster }
-func (noMeta) PutMax(context.Context, string, []byte, uint64) error { return errNoCluster }
+func (noMeta) Swap(context.Context, string, []byte) ([]byte, error) { return nil, errNoCluster }
 func (noMeta) Delete(context.Context, string) error                 { return errNoCluster }
 func (noMeta) ScanFrom(context.Context, string, string, int) ([]meta.Item, error) {
 	return nil, errNoCluster
@@ -75,6 +75,9 @@ func (noBlob) Commit(context.Context, config.NodeID, blob.CommitRequest) (bool, 
 	return false, errNoCluster
 }
 func (noBlob) Abort(context.Context, config.NodeID, blob.CommitRequest) error { return errNoCluster }
+func (noBlob) Release(context.Context, config.NodeID, blob.ReleaseRequest) error {
+	return errNoCluster
+}
 
 // sessionGate builds a gate whose only bucket is config-defined and owned
 // by the session's account, so authorization is the only thing under test.

--- a/internal/gate/handlers/blob.go
+++ b/internal/gate/handlers/blob.go
@@ -22,6 +22,7 @@ type BlobClient interface {
 	Abort(ctx context.Context, nodeID config.NodeID, req blob.CommitRequest) error
 	Get(ctx context.Context, nodeID config.NodeID, req blob.GetRequest) (io.ReadCloser, error)
 	Delete(ctx context.Context, nodeID config.NodeID, req blob.DeleteRequest) (*blob.DeleteResponse, error)
+	Release(ctx context.Context, nodeID config.NodeID, req blob.ReleaseRequest) error
 }
 
 var _ BlobClient = (*blob.Client)(nil)

--- a/internal/gate/handlers/complete_multipart_upload.go
+++ b/internal/gate/handlers/complete_multipart_upload.go
@@ -140,13 +140,15 @@ func CompleteMultipartUpload(mc MetaClient, bc BlobClient, ring *placement.Ring,
 			HandleError(w, r, model.NewS3Error(model.ErrInternalError, "Failed to encode shard metadata", 500))
 			return
 		}
-		if err := metaPut(ctx, mc, model.TableObjects, string(objectHash[:]), shardRecord); err != nil {
+		previous, err := metaSwap(ctx, mc, model.TableObjects, string(objectHash[:]), shardRecord)
+		if err != nil {
 			telemetry.RecordObjectWrite(ctx, telemetry.WriteOutcomeFailed, telemetry.WriteReasonMeta)
 			abortShards(ctx, bc, objectHash, place, written)
 			HandleError(w, r, model.NewS3Error(model.ErrInternalError, "Failed to store object metadata", 500))
 			return
 		}
 		commitShards(ctx, bc, objectHash, place, written)
+		releaseSuperseded(ctx, bc, objectHash, previous, place.WriteEpoch)
 
 		if err := metaPut(ctx, mc, model.TableObjects, objectARN(bucket, key), objectHash[:]); err != nil {
 			telemetry.RecordObjectWrite(ctx, telemetry.WriteOutcomeFailed, telemetry.WriteReasonMeta)

--- a/internal/gate/handlers/copy_object.go
+++ b/internal/gate/handlers/copy_object.go
@@ -128,13 +128,15 @@ func CopyObject(mc MetaClient, bc BlobClient, ring *placement.Ring, cache *Bucke
 			HandleError(w, r, model.NewS3Error(model.ErrInternalError, err.Error(), 500))
 			return
 		}
-		if err := metaPut(ctx, mc, model.TableObjects, string(destHash[:]), record); err != nil {
+		previous, err := metaSwap(ctx, mc, model.TableObjects, string(destHash[:]), record)
+		if err != nil {
 			telemetry.RecordObjectWrite(ctx, telemetry.WriteOutcomeFailed, telemetry.WriteReasonMeta)
 			abortShards(ctx, bc, destHash, place, written)
 			HandleError(w, r, model.NewS3Error(model.ErrInternalError, err.Error(), 500))
 			return
 		}
 		commitShards(ctx, bc, destHash, place, written)
+		releaseSuperseded(ctx, bc, destHash, previous, place.WriteEpoch)
 
 		if err := metaPut(ctx, mc, model.TableObjects, objectARN(destBucket, destKey), destHash[:]); err != nil {
 			telemetry.RecordObjectWrite(ctx, telemetry.WriteOutcomeFailed, telemetry.WriteReasonMeta)

--- a/internal/gate/handlers/delete_object_test.go
+++ b/internal/gate/handlers/delete_object_test.go
@@ -29,6 +29,13 @@ func (m *putFailingMeta) Put(ctx context.Context, key string, value []byte) erro
 	return m.fakeMeta.Put(ctx, key, value)
 }
 
+func (m *putFailingMeta) Swap(ctx context.Context, key string, value []byte) ([]byte, error) {
+	if m.failOn != nil && m.failOn(key) {
+		return nil, errors.New("simulated meta failure")
+	}
+	return m.fakeMeta.Swap(ctx, key, value)
+}
+
 var _ MetaClient = (*putFailingMeta)(nil)
 
 // failingBlob fails every shard Delete, standing in for a fan-out that could

--- a/internal/gate/handlers/epoch_test.go
+++ b/internal/gate/handlers/epoch_test.go
@@ -277,3 +277,61 @@ func (f writeFixture) publish(t *testing.T, objectHash [32]byte, place ObjectToS
 	require.NoError(t, err)
 	require.NoError(t, metaPut(context.Background(), f.mc, model.TableObjects, string(objectHash[:]), record))
 }
+
+// placement reads back the record a write published for one key.
+func (f writeFixture) placement(t *testing.T, key string) ObjectToShardNodes {
+	t.Helper()
+	objectHash := model.ObjectHash("b", key)
+	raw, err := metaGet(context.Background(), f.mc, model.TableObjects, string(objectHash[:]))
+	require.NoError(t, err)
+	place, err := DecodePlacement(raw)
+	require.NoError(t, err)
+
+	return place
+}
+
+// Retention is bounded by the writes still in flight, not by how many arrive in
+// a window: the writer that replaces a record tells the nodes the generation it
+// displaced is finished with. Without that the only bound is the sweep's age
+// cutoff, which a fast enough writer outruns.
+func TestOverwriteReleasesTheGenerationItSuperseded(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(2, 1)
+	handler := PutObject(f.mc, f.bc, f.ring, testCache(), f.cfg)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, objectPut("k", randomBytes(t, 100)))
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Empty(t, f.bc.releases(), "the first write superseded nothing, so it must release nothing")
+
+	first := f.placement(t, "k")
+
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, objectPut("k", randomBytes(t, 100)))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	released := f.bc.releases()
+	require.Len(t, released, 3, "every shard position of the superseded generation must be released")
+	for _, req := range released {
+		assert.Equal(t, first.WriteEpoch, req.Epoch,
+			"the release must name the generation that was replaced, not the one that replaced it")
+	}
+}
+
+// An overwrite that lands on an unreachable node must still succeed. The object
+// is durable and visible by then, and the sweep reclaims the same rows on age
+// alone, so refusing here would fail a write that has already happened.
+func TestOverwriteSucceedsWhenTheReleaseCannotBeDelivered(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(2, 1)
+	f.bc.failReleases = true
+	handler := PutObject(f.mc, f.bc, f.ring, testCache(), f.cfg)
+
+	for range 2 {
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, objectPut("k", randomBytes(t, 100)))
+		require.Equal(t, http.StatusOK, w.Code)
+	}
+}

--- a/internal/gate/handlers/handoff_test.go
+++ b/internal/gate/handlers/handoff_test.go
@@ -97,6 +97,10 @@ func (b *nodeBlob) Abort(_ context.Context, node config.NodeID, req blob.CommitR
 	return nil
 }
 
+func (b *nodeBlob) Release(_ context.Context, _ config.NodeID, _ blob.ReleaseRequest) error {
+	return nil
+}
+
 func (b *nodeBlob) Get(_ context.Context, node config.NodeID, req blob.GetRequest) (io.ReadCloser, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/gate/handlers/hedge_test.go
+++ b/internal/gate/handlers/hedge_test.go
@@ -59,6 +59,10 @@ func (c *hedgeBlobClient) Put(context.Context, config.NodeID, blob.PutRequest, i
 func (c *hedgeBlobClient) Commit(context.Context, config.NodeID, blob.CommitRequest) (bool, error) {
 	return false, errors.New("not implemented")
 }
+func (c *hedgeBlobClient) Release(context.Context, config.NodeID, blob.ReleaseRequest) error {
+	return nil
+}
+
 func (c *hedgeBlobClient) Abort(context.Context, config.NodeID, blob.CommitRequest) error {
 	return errors.New("not implemented")
 }

--- a/internal/gate/handlers/meta.go
+++ b/internal/gate/handlers/meta.go
@@ -21,7 +21,7 @@ var errNoMetaClient = errors.New("gate has no meta client")
 type MetaClient interface {
 	Get(ctx context.Context, key string) ([]byte, error)
 	Put(ctx context.Context, key string, value []byte) error
-	PutMax(ctx context.Context, key string, value []byte, epoch uint64) error
+	Swap(ctx context.Context, key string, value []byte) ([]byte, error)
 	Delete(ctx context.Context, key string) error
 	Scan(ctx context.Context, prefix string, limit int) ([]meta.Item, error)
 }
@@ -80,11 +80,13 @@ func metaPut(ctx context.Context, mc MetaClient, table, key string, value []byte
 	return mc.Put(ctx, TableKey(table, key), value)
 }
 
-func metaPutMax(ctx context.Context, mc MetaClient, table, key string, value []byte, epoch uint64) error {
+// metaSwap writes one row and returns the row it replaced.
+func metaSwap(ctx context.Context, mc MetaClient, table, key string, value []byte) ([]byte, error) {
 	if mc == nil {
-		return errNoMetaClient
+		return nil, errNoMetaClient
 	}
-	return mc.PutMax(ctx, TableKey(table, key), value, epoch)
+
+	return mc.Swap(ctx, TableKey(table, key), value)
 }
 
 // metaDelete removes one row of a table.

--- a/internal/gate/handlers/put_object.go
+++ b/internal/gate/handlers/put_object.go
@@ -104,17 +104,20 @@ func PutObject(mc MetaClient, bc BlobClient, ring *placement.Ring, cache *Bucket
 				"epoch", fmt.Sprintf("%016x", place.WriteEpoch))
 		}
 
-		// Object hash -> shard placement is the visibility point. Raft applies
-		// this max-epoch update atomically, so a delayed older writer cannot move
-		// the record backwards.
+		// Object hash -> shard placement is the visibility point, and reaching
+		// the replicated log is what acknowledges this PUT, so the record that
+		// arrives last is the write S3 reports. Swapping rather than writing
+		// tells this writer which generation it displaced.
 		phase = time.Now()
-		if err := metaPutMax(ctx, mc, model.TableObjects, string(objectHash[:]), record, place.WriteEpoch); err != nil {
+		previous, err := metaSwap(ctx, mc, model.TableObjects, string(objectHash[:]), record)
+		if err != nil {
 			telemetry.RecordObjectWrite(ctx, telemetry.WriteOutcomeFailed, telemetry.WriteReasonMeta)
 			abortShards(ctx, bc, objectHash, place, written)
 			HandleError(w, r, model.NewS3Error(model.ErrInternalError, err.Error(), 500))
 			return
 		}
 		phase = recordPhase(ctx, telemetry.GateOpPut, telemetry.PhaseMetaPlacement, phase)
+		releaseSuperseded(ctx, bc, objectHash, previous, place.WriteEpoch)
 
 		// Listing key -> object hash, for ListObjects.
 		if err := metaPut(ctx, mc, model.TableObjects, objectARN(bucket, key), objectHash[:]); err != nil {

--- a/internal/gate/handlers/shards.go
+++ b/internal/gate/handlers/shards.go
@@ -954,3 +954,36 @@ func deleteObject(ctx context.Context, bc BlobClient, bucket, key string, object
 
 	return nil
 }
+
+// releaseSuperseded tells the nodes behind a replaced placement record that its
+// generation is finished with, so the disk comes back on the next sweep rather
+// than at the end of the retention window.
+//
+// Best-effort by construction: the object is already durable and visible, the
+// sweep reclaims the same rows on age alone, and a node that cannot be reached
+// must not fail a write that has landed.
+func releaseSuperseded(ctx context.Context, bc BlobClient, objectHash [32]byte, previous []byte, mine uint64) {
+	if len(previous) == 0 {
+		return
+	}
+	prev, err := DecodePlacement(previous)
+	if err != nil || prev.WriteEpoch == mine || prev.Size == 0 {
+		return
+	}
+
+	var wg sync.WaitGroup
+	for index, node := range prev.AllNodes() {
+		wg.Go(func() {
+			if err := bc.Release(ctx, node, blob.ReleaseRequest{
+				Key:   objectHash,
+				Index: uint32(index), //nolint:gosec // G115: index bounded by DataShards + ParityShards (small uint).
+				Epoch: prev.WriteEpoch,
+			}); err != nil {
+				slog.DebugContext(ctx, "Could not release a superseded generation; the sweep will age it out",
+					"node", node, "index", index,
+					"epoch", fmt.Sprintf("%016x", prev.WriteEpoch), "err", err)
+			}
+		})
+	}
+	wg.Wait()
+}

--- a/internal/gate/handlers/streamwrite_test.go
+++ b/internal/gate/handlers/streamwrite_test.go
@@ -101,6 +101,8 @@ func (d *discardBlob) Commit(context.Context, config.NodeID, blob.CommitRequest)
 }
 func (d *discardBlob) Abort(context.Context, config.NodeID, blob.CommitRequest) error { return nil }
 
+func (d *discardBlob) Release(context.Context, config.NodeID, blob.ReleaseRequest) error { return nil }
+
 func (d *discardBlob) Get(context.Context, config.NodeID, blob.GetRequest) (io.ReadCloser, error) {
 	return nil, blob.ErrNotFound
 }

--- a/internal/gate/handlers/writepath_test.go
+++ b/internal/gate/handlers/writepath_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -50,8 +51,14 @@ func (m *fakeMeta) Put(_ context.Context, key string, value []byte) error {
 	return nil
 }
 
-func (m *fakeMeta) PutMax(ctx context.Context, key string, value []byte, _ uint64) error {
-	return m.Put(ctx, key, value)
+func (m *fakeMeta) Swap(ctx context.Context, key string, value []byte) ([]byte, error) {
+	m.mu.Lock()
+	previous := m.rows[key]
+	m.mu.Unlock()
+	if err := m.Put(ctx, key, value); err != nil {
+		return nil, err
+	}
+	return previous, nil
 }
 
 func (m *fakeMeta) Delete(_ context.Context, key string) error {
@@ -100,10 +107,16 @@ type fakeBlob struct {
 	shards   map[shardID]fakeShard
 	prepared map[shardID]fakeShard
 
-	maxWrite     atomic.Int64
-	putCalls     atomic.Int64
-	commitCalls  atomic.Int64
-	abortCalls   atomic.Int64
+	maxWrite    atomic.Int64
+	putCalls    atomic.Int64
+	commitCalls atomic.Int64
+	abortCalls  atomic.Int64
+
+	// released records every generation a writer said it had superseded, so a
+	// test can tell a bounded retention from one that only ages out.
+	released     []blob.ReleaseRequest
+	failReleases bool
+
 	declaring    func(size int64) error
 	failPutOn    func(index uint32) bool
 	failCommitOn func(index uint32) bool
@@ -182,6 +195,25 @@ func (b *fakeBlob) commitLocked(id shardID, epoch uint64) error {
 	}
 
 	return blob.ErrNotPrepared
+}
+
+func (b *fakeBlob) Release(_ context.Context, _ config.NodeID, req blob.ReleaseRequest) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.failReleases {
+		return errors.New("node is not answering")
+	}
+	b.released = append(b.released, req)
+
+	return nil
+}
+
+func (b *fakeBlob) releases() []blob.ReleaseRequest {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return slices.Clone(b.released)
 }
 
 func (b *fakeBlob) Abort(_ context.Context, _ config.NodeID, req blob.CommitRequest) error {

--- a/internal/gate/helpers_test.go
+++ b/internal/gate/helpers_test.go
@@ -107,6 +107,10 @@ func (fakeBlob) Abort(context.Context, config.NodeID, blob.CommitRequest) error 
 	return errors.New("no blob nodes")
 }
 
+func (fakeBlob) Release(context.Context, config.NodeID, blob.ReleaseRequest) error {
+	return errors.New("no blob nodes")
+}
+
 // newTestGate builds a gate through the production constructor, filling in
 // what New requires and a test rarely cares about: a loadable TLS pair and the
 // two cluster clients. Whatever cfg already sets is left alone.

--- a/internal/gate/ownership_test.go
+++ b/internal/gate/ownership_test.go
@@ -106,8 +106,12 @@ func (f *fakeMeta) Put(_ context.Context, key string, value []byte) error {
 	return nil
 }
 
-func (f *fakeMeta) PutMax(ctx context.Context, key string, value []byte, _ uint64) error {
-	return f.Put(ctx, key, value)
+func (f *fakeMeta) Swap(ctx context.Context, key string, value []byte) ([]byte, error) {
+	previous := f.rows[key]
+	if err := f.Put(ctx, key, value); err != nil {
+		return nil, err
+	}
+	return previous, nil
 }
 
 func (f *fakeMeta) Delete(_ context.Context, key string) error {

--- a/internal/gate/repair/rebuild.go
+++ b/internal/gate/repair/rebuild.go
@@ -195,12 +195,19 @@ func (s *Service) publish(ctx context.Context, t task) error {
 		return fmt.Errorf("commit rebuilt shard: %w", err)
 	}
 	if superseded {
-		slog.DebugContext(ctx, "A live write overtook a rebuilt shard",
-			"node", t.node, "index", t.index)
+		return fmt.Errorf("%w: node=%d index=%d built_for=%016x",
+			errSuperseded, t.node, t.index, t.place.WriteEpoch)
 	}
 
 	return nil
 }
+
+// errSuperseded reports that a rebuilt shard was refused because its node has
+// moved past the generation the record names. Nothing was repaired, and unlike
+// a transient failure the next pass will rebuild the same shard to the same
+// refusal: the node and the record disagree about which write is current, and
+// no amount of rebuilding settles that.
+var errSuperseded = errors.New("the node has moved past the generation the record names")
 
 // discard releases a rebuilt shard that must not be published.
 func (s *Service) discard(ctx context.Context, t task) error {

--- a/internal/gate/repair/repair.go
+++ b/internal/gate/repair/repair.go
@@ -105,13 +105,20 @@ const (
 // Stats is what a pass did. Scanned counts placement records read, owned the
 // positions belonging to this service's nodes, and repaired those actually
 // rebuilt. Pending is what the last completed pass left owing.
+//
+// Superseded counts rebuilds the node refused to publish because it had moved
+// past the generation the record names. Those are separated from Repaired
+// because they are work that changed nothing: the next pass finds the same
+// mismatch and rebuilds it again, so counting them as repairs reports a sweep
+// as productive while it loops.
 type Stats struct {
-	Passes   int64
-	Scanned  int64
-	Owned    int64
-	Repaired int64
-	Failed   int64
-	Pending  int64
+	Passes     int64
+	Scanned    int64
+	Owned      int64
+	Repaired   int64
+	Superseded int64
+	Failed     int64
+	Pending    int64
 }
 
 // Service sweeps for shards its nodes owe and rebuilds them.
@@ -122,7 +129,7 @@ type Service struct {
 	pageSize int
 	interval time.Duration
 
-	passes, scanned, owned, repaired, failed, pending atomic.Int64
+	passes, scanned, owned, repaired, superseded, failed, pending atomic.Int64
 }
 
 // New validates cfg and applies its defaults. It starts nothing.
@@ -163,12 +170,13 @@ func cmpOr(v, fallback int) int {
 // Stats reports the running counters.
 func (s *Service) Stats() Stats {
 	return Stats{
-		Passes:   s.passes.Load(),
-		Scanned:  s.scanned.Load(),
-		Owned:    s.owned.Load(),
-		Repaired: s.repaired.Load(),
-		Failed:   s.failed.Load(),
-		Pending:  s.pending.Load(),
+		Passes:     s.passes.Load(),
+		Scanned:    s.scanned.Load(),
+		Owned:      s.owned.Load(),
+		Repaired:   s.repaired.Load(),
+		Superseded: s.superseded.Load(),
+		Failed:     s.failed.Load(),
+		Pending:    s.pending.Load(),
 	}
 }
 
@@ -208,16 +216,25 @@ func (s *Service) Pass(ctx context.Context) error {
 	for range s.workers {
 		wg.Go(func() {
 			for t := range work {
-				if err := s.repairShard(ctx, t); err != nil {
+				err := s.repairShard(ctx, t)
+				switch {
+				case errors.Is(err, errSuperseded):
+					// Not a failure and not a repair. The record and the node
+					// disagree about the current write, which rebuilding cannot
+					// settle, so this stays owed rather than reading as done.
+					s.superseded.Add(1)
+					slog.InfoContext(ctx, "Rebuilt shard refused: the node is past the record's generation",
+						"node", t.node, "index", t.index,
+						"epoch", fmt.Sprintf("%016x", t.place.WriteEpoch))
+				case err != nil:
 					s.failed.Add(1)
 					slog.WarnContext(ctx, "Shard repair failed",
 						"node", t.node, "index", t.index,
 						"epoch", fmt.Sprintf("%016x", t.place.WriteEpoch), "err", err)
-
-					continue
+				default:
+					owed.Add(-1)
+					s.repaired.Add(1)
 				}
-				owed.Add(-1)
-				s.repaired.Add(1)
 			}
 		})
 	}

--- a/internal/meta/client.go
+++ b/internal/meta/client.go
@@ -386,6 +386,16 @@ func (c *Client) PutMax(ctx context.Context, key string, value []byte, epoch uin
 	return c.write(ctx, OpMetaPutMax, req, value)
 }
 
+// Swap writes a value and returns the one it replaced, empty if the key was
+// absent. It is how a writer of a placement record learns which generation it
+// superseded, so the shards behind that generation can be released rather than
+// waiting out the retention window.
+func (c *Client) Swap(ctx context.Context, key string, value []byte) (previous []byte, err error) {
+	defer observeOp(ctx, telemetry.MetaOpPut, time.Now(), &err)
+
+	return c.writeValue(ctx, OpMetaSwap, request(key, 0), value)
+}
+
 // Delete removes a key through the leader.
 func (c *Client) Delete(ctx context.Context, key string) (err error) {
 	defer observeOp(ctx, telemetry.MetaOpDelete, time.Now(), &err)
@@ -395,6 +405,14 @@ func (c *Client) Delete(ctx context.Context, key string) (err error) {
 // write drives a consensus write to the leader, following not-leader
 // redirects and rotating through replicas while an election settles.
 func (c *Client) write(ctx context.Context, op rpc.Opcode, req *MetaRequest, body []byte) error {
+	_, err := c.writeValue(ctx, op, req, body)
+
+	return err
+}
+
+// writeValue is write, plus whatever the replica answered with. Only a swap
+// populates that; every other write leaves it nil.
+func (c *Client) writeValue(ctx context.Context, op rpc.Opcode, req *MetaRequest, body []byte) ([]byte, error) {
 	candidates := c.readOrder()
 	next := 0
 	target := candidates[next]
@@ -408,7 +426,7 @@ func (c *Client) write(ctx context.Context, op rpc.Opcode, req *MetaRequest, bod
 			lastErr = err
 		case resp.Err == "":
 			c.cacheLeader(target)
-			return nil
+			return resp.Value, nil
 		case resp.Err == ErrCodeNotLeader:
 			lastErr = ErrNotLeader
 			if id, perr := ParseRaftAddress(resp.Leader); perr == nil {
@@ -434,11 +452,11 @@ func (c *Client) write(ctx context.Context, op rpc.Opcode, req *MetaRequest, bod
 			select {
 			case <-ctx.Done():
 				timer.Stop()
-				return fmt.Errorf("write %q: %w", req.Key, ctx.Err())
+				return nil, fmt.Errorf("write %q: %w", req.Key, ctx.Err())
 			case <-timer.C:
 			}
 		}
 	}
 	telemetry.RecordMetaRedirect(ctx, telemetry.RedirectRetryExhausted)
-	return fmt.Errorf("write %q failed after %d attempts: %w", req.Key, attempts, lastErr)
+	return nil, fmt.Errorf("write %q failed after %d attempts: %w", req.Key, attempts, lastErr)
 }

--- a/internal/meta/fsm.go
+++ b/internal/meta/fsm.go
@@ -119,30 +119,16 @@ func (f *FSM) Apply(log *raft.Log) any {
 	}
 }
 
-// applyPutMax publishes a placement only when it is not older than the
-// placement currently stored. The comparison happens inside the Raft FSM, so
-// concurrent gate requests cannot race a read-then-write check.
-func (f *FSM) applyPutMax(key string, value []byte, epoch uint64) error {
-	return f.db.Update(func(txn *badger.Txn) error {
-		if item, err := txn.Get([]byte(key)); err == nil {
-			current, err := item.ValueCopy(nil)
-			if err != nil {
-				return err
-			}
-			// Placement records store the epoch at byte offset 11. Only this
-			// operation is used for placement keys, so malformed/legacy values
-			// are replaced normally.
-			if len(current) >= 19 && current[0] == 0 && current[1] == 2 {
-				currentEpoch := binary.BigEndian.Uint64(current[11:19])
-				if currentEpoch > epoch {
-					return nil
-				}
-			}
-		} else if !errors.Is(err, badger.ErrKeyNotFound) {
-			return err
-		}
-		return txn.Set([]byte(key), value)
-	})
+// applyPutMax stores a placement record, and the epoch it carries orders
+// nothing. It exists so log entries written when this command did compare
+// epochs still replay, and new writers should use CommandPut.
+//
+// A client's PUT is not acknowledged until its record reaches the log, so
+// arrival order is acknowledgement order, and last-to-arrive is the write S3
+// calls the winner. Comparing epochs here picked the write that *started*
+// last instead, which is a different write whenever two PUTs overlap.
+func (f *FSM) applyPutMax(key string, value []byte, _ uint64) error {
+	return f.applyPut(key, value)
 }
 
 // applyPut stores a key-value pair.

--- a/internal/meta/fsm.go
+++ b/internal/meta/fsm.go
@@ -25,6 +25,10 @@ const (
 	CommandPut CommandType = iota
 	CommandDelete
 	CommandPutMax
+	// CommandSwap stores a value and reports the one it replaced, so a writer
+	// learns what it superseded. Appended rather than inserted: these numbers
+	// are on disk in every existing log.
+	CommandSwap
 )
 
 // Command represents a database operation that goes through Raft.
@@ -114,6 +118,8 @@ func (f *FSM) Apply(log *raft.Log) any {
 		return f.applyDelete(string(cmd.Key))
 	case CommandPutMax:
 		return f.applyPutMax(string(cmd.Key), cmd.Value, cmd.Epoch)
+	case CommandSwap:
+		return f.applySwap(string(cmd.Key), cmd.Value)
 	default:
 		return fmt.Errorf("unknown command type: %d", cmd.Type)
 	}
@@ -129,6 +135,34 @@ func (f *FSM) Apply(log *raft.Log) any {
 // last instead, which is a different write whenever two PUTs overlap.
 func (f *FSM) applyPutMax(key string, value []byte, _ uint64) error {
 	return f.applyPut(key, value)
+}
+
+// applySwap stores a key-value pair and returns the value it replaced, or nil
+// if the key was absent. It reads before writing, so it is the more expensive
+// of the two and CommandPut stays the default.
+//
+// What the extra read buys is a writer knowing which generation it displaced.
+// Nothing else can tell it: the log settles who wins, and a caller that reads
+// the key itself beforehand races every other writer of that key.
+func (f *FSM) applySwap(key string, value []byte) any {
+	var previous []byte
+	err := f.db.Update(func(txn *badger.Txn) error {
+		switch item, err := txn.Get([]byte(key)); {
+		case err == nil:
+			if previous, err = item.ValueCopy(nil); err != nil {
+				return err
+			}
+		case !errors.Is(err, badger.ErrKeyNotFound):
+			return err
+		}
+
+		return txn.Set([]byte(key), value)
+	})
+	if err != nil {
+		return err
+	}
+
+	return previous
 }
 
 // applyPut stores a key-value pair.

--- a/internal/meta/handlers.go
+++ b/internal/meta/handlers.go
@@ -56,6 +56,20 @@ func (s *Server) handlePutMax(ctx context.Context, h MetaRequest, stream transpo
 	return respond(stream, s.writeResult(s.putMax(string(h.Key), value, h.Epoch)))
 }
 
+func (s *Server) handleSwap(ctx context.Context, h MetaRequest, stream transport.Stream) error {
+	value, err := io.ReadAll(stream)
+	if err != nil {
+		return fmt.Errorf("read swap value: %w", err)
+	}
+	previous, err := s.swap(string(h.Key), value)
+	resp := s.writeResult(err)
+	if err == nil {
+		resp.Value = previous
+	}
+
+	return respond(stream, resp)
+}
+
 func (s *Server) handleDelete(ctx context.Context, h MetaRequest, stream transport.Stream) error {
 	return respond(stream, s.writeResult(s.delete(string(h.Key))))
 }

--- a/internal/meta/last_write_review_test.go
+++ b/internal/meta/last_write_review_test.go
@@ -41,3 +41,29 @@ func placementRecord(epoch byte) []byte {
 	b[18] = epoch
 	return b
 }
+
+// Swap is the same last-write-wins publication as Put, and additionally reports
+// the row it replaced. That report is what lets the writer release the storage
+// its predecessor was using, so retention is bounded by the writes in flight
+// rather than by the write rate over a window.
+func TestSwapReturnsTheRecordItReplaced(t *testing.T) {
+	cli := startStatusReplica(t, true)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.Eventually(t, func() bool {
+		status, err := cli.Status(ctx, 1)
+		return err == nil && status.IsLeader
+	}, 5*time.Second, 20*time.Millisecond)
+
+	previous, err := cli.Swap(ctx, "objects/swapped", placementRecord(2))
+	require.NoError(t, err)
+	assert.Empty(t, previous, "the first write replaced nothing")
+
+	previous, err = cli.Swap(ctx, "objects/swapped", placementRecord(3))
+	require.NoError(t, err)
+	assert.Equal(t, placementRecord(2), previous, "the second write must report what it displaced")
+
+	got, err := cli.Get(ctx, "objects/swapped")
+	require.NoError(t, err)
+	assert.Equal(t, placementRecord(3), got, "the record that arrived last must be the one stored")
+}

--- a/internal/meta/last_write_review_test.go
+++ b/internal/meta/last_write_review_test.go
@@ -9,9 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Review-only evidence that placement publication is an unconditional Put:
-// a delayed earlier writer can replace a newer epoch after it has committed.
-func TestReviewDelayedPlacementPutWins(t *testing.T) {
+// Placement publication is an unconditional Put, and a lower epoch arriving
+// second is meant to win. A PUT is not acknowledged until its record reaches
+// the log, so arrival order is acknowledgement order, and the write that
+// finished last is the one S3 hands the key to. Ordering by the epoch instead
+// picks whichever write *started* last, which is a different write whenever
+// two PUTs overlap.
+func TestPlacementPublicationIsLastWriteWins(t *testing.T) {
 	cli := startStatusReplica(t, true)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -25,8 +29,9 @@ func TestReviewDelayedPlacementPutWins(t *testing.T) {
 
 	got, err := cli.Get(ctx, "objects/same-object")
 	require.NoError(t, err)
-	assert.Equal(t, placementRecord(2), got)
-	t.Logf("final placement after epoch-2 then delayed epoch-1: %q", got)
+	assert.Equal(t, placementRecord(1), got,
+		"the record that arrived second must win: its writer is the one still "+
+			"waiting to be acknowledged, so it is the write that finished last")
 }
 
 func placementRecord(epoch byte) []byte {

--- a/internal/meta/protocol.go
+++ b/internal/meta/protocol.go
@@ -24,6 +24,8 @@ const (
 	OpMetaDelete rpc.Opcode = 0x1003
 	OpMetaScan   rpc.Opcode = 0x1004
 	OpMetaPutMax rpc.Opcode = 0x1006
+	// OpMetaSwap writes a value and answers with the one it replaced.
+	OpMetaSwap rpc.Opcode = 0x1007
 
 	// OpMetaStatus asks a replica to report its own raft state, rather than
 	// any data it holds.

--- a/internal/meta/server.go
+++ b/internal/meta/server.go
@@ -155,6 +155,7 @@ func (s *Server) open() (*rpc.Server, error) {
 	rpc.RegisterHandler(mux, OpRaftDial, s.handleRaftDial)
 	rpc.RegisterHandler(mux, OpMetaGet, s.handleGet)
 	rpc.RegisterHandler(mux, OpMetaPut, s.handlePut)
+	rpc.RegisterHandler(mux, OpMetaSwap, s.handleSwap)
 	rpc.RegisterHandler(mux, OpMetaPutMax, s.handlePutMax)
 	rpc.RegisterHandler(mux, OpMetaDelete, s.handleDelete)
 	rpc.RegisterHandler(mux, OpMetaScan, s.handleScan)
@@ -430,6 +431,11 @@ func (s *Server) putMax(key string, value []byte, epoch uint64) error {
 	return s.apply(Command{Type: CommandPutMax, Key: []byte(key), Value: value, Epoch: epoch})
 }
 
+// swap stores a value and returns the one it replaced.
+func (s *Server) swap(key string, value []byte) ([]byte, error) {
+	return s.applyValue(Command{Type: CommandSwap, Key: []byte(key), Value: value})
+}
+
 // delete removes a key through raft consensus.
 func (s *Server) delete(key string) error {
 	return s.apply(Command{Type: CommandDelete, Key: []byte(key)})
@@ -437,25 +443,38 @@ func (s *Server) delete(key string) error {
 
 // apply commits one command, which only the leader may do.
 func (s *Server) apply(cmd Command) error {
+	_, err := s.applyValue(cmd)
+
+	return err
+}
+
+// applyValue commits one command and returns whatever its FSM handler reported,
+// which for CommandSwap is the value it replaced.
+func (s *Server) applyValue(cmd Command) ([]byte, error) {
 	if s.raft.State() != raft.Leader {
-		return ErrNotLeader
+		return nil, ErrNotLeader
 	}
 
 	data, err := json.Marshal(cmd)
 	if err != nil {
-		return fmt.Errorf("marshal command: %w", err)
+		return nil, fmt.Errorf("marshal command: %w", err)
 	}
 
 	future := s.raft.Apply(data, applyTimeout)
 	if err := future.Error(); err != nil {
-		return fmt.Errorf("raft apply failed: %w", err)
+		return nil, fmt.Errorf("raft apply failed: %w", err)
 	}
 
-	// The FSM reports a rejected command through the future's response.
-	if err, ok := future.Response().(error); ok {
-		return err
+	// The FSM reports a rejected command through the future's response, and a
+	// swap reports the value it replaced the same way.
+	switch response := future.Response().(type) {
+	case error:
+		return nil, response
+	case []byte:
+		return response, nil
+	default:
+		return nil, nil
 	}
-	return nil
 }
 
 // get reads a value from the local store. It may return stale data on a


### PR DESCRIPTION
## Summary

An acknowledged PUT could become permanently unreadable when several writers raced one key. This fixes the cause, which is not where it looked.

The metadata ordering was already correct. Raft gives a total order, and arrival at the log *is* the commit point, so a plain last-write-wins `Set` already selects the write S3 would select. What broke was the blob layer: retention ranked shard generations by `WriteEpoch`, which is write **start** order, and dropped all but the newest four. The two layers therefore ranked the same set of writes differently, and the index routinely ended up naming a generation retention had already reclaimed — a dangling pointer, reachable in normal operation rather than only under fault injection. Every writer got a 200 and the object then read back as `500 InternalError` with `reason=stale_epoch`.

The rule this restores: **the index decides which generation is current, and the blob layer keeps what the index references.**

## Why not the epoch fence

This branch was originally the "revive the PutMax epoch fence" approach. That fix makes the index adopt the blob layer's start-ordered opinion, so both layers agree — on the wrong write. `test_atomic_dual_write` exists precisely to catch that: it begins a PUT of B, and mid-body issues a complete PUT of A, so A starts later but finishes earlier and S3 must return B. Measured on this workstation:

| | `concurrent-put` | `atomic_dual_write` |
| --- | --- | --- |
| `dev` at `c441dc9` | FAIL, 3 of 24 assertions | 3 passed |
| the epoch fence, `38a28ca` | 24 passed | **3 failed** |
| this branch | 24 passed | 3 passed |

Either gate alone is passable by a wrong fix, which is how this got here. The branch was reset to `origin/dev` and rebuilt; the original work is preserved at the tags `archive/putmax-epoch-fence` (`81bc231`) and `archive/putmax-epoch-fence-tip` (`38a28ca`).

## What changed

**`fix: retain superseded generations by age, not by epoch rank`**

- `pruneRetained` is deleted outright, along with both of its commit-path calls and the `retainedGenerations` constant. Nothing ranks generations any more; `sweepRetained` is age-only, and `retainedMaxAge` is the backstop it always said it was — for a writer that died between publishing shards and landing its record.
- `applyPutMax` keeps its command number and handler, because those numbers are on disk in every existing log and a replay has to reach the same code, but no longer compares epochs.
- Repair's `publish` returns `errSuperseded` where it used to return `nil`. Returning `nil` after a full Reed-Solomon rebuild counted the rebuild as a repair, so a node that had moved past the record's generation would rebuild every shard, every pass, forever, while the metrics reported a healthy sweep.

**`feat: release a superseded generation when its record is replaced`**

Age alone is not a bound. Worst case was write rate x (retention + compaction interval), and at S3's 3,500 PUT/s per prefix that is no meaningful ceiling. So publication became a swap: `CommandSwap` and `OpMetaSwap` return the row the write replaced, and the three placement writers release the generation that row named on the nodes it named. Retention is then bounded by the writes actually in flight.

Two properties worth calling out:

- Release reaches only the retained namespace, so a caller working from a stale record cannot touch what a node is serving.
- It backdates the row rather than dropping it, and a dedicated 15s sweep reclaims it. A reader that resolved the old record a moment ago is still streaming shards from that generation, and taking the bytes now would trade a rare lost write for a routine failed read. It is best-effort throughout: the object is durable and visible by then, and the age sweep reclaims the same rows anyway, so an unreachable node must not fail a write that has landed.

## Testing

- `make e2e-stress STRESS_SCENARIO=concurrent-put` — 24 assertions pass.
- `s3-tests -k atomic_dual_write` — 3 passed. Both green together for the first time.
- Full `s3-tests`: 200 pass / 194 fail, matching `scripts/s3-tests-baseline.txt` line for line. Zero regressions.
- `make preflight` passes; `go test ./internal/... -race` clean.
- New tests: overwrite releases what it superseded and still succeeds when the release cannot be delivered; `Swap` returns the record it replaced; `ReleaseGeneration` hands back a superseded generation and cannot touch the live one; retention keeps every fresh generation with 12 racing writers, so a future retention constant cannot quietly become the fix again.

## Performance

Warp, 3host loopback, 64 KiB objects, concurrency 16, run back to back on the same machine.

| Workload | `dev` c441dc9 | this branch | Delta |
| --- | --- | --- | --- |
| PUT | 29.08 MiB/s, p50 35.0ms | 29.98 MiB/s, p50 33.3ms | +3.1% |
| GET | 230.91 MiB/s, p50 4.1ms | 225.13 MiB/s, p50 4.1ms | -2.5%, p50 identical |
| Multipart | 141.40 MiB/s, p50 450.5ms | 168.63 MiB/s, p50 285.2ms | +19.3% |

The multipart gain is expected rather than surprising: `pruneRetained` ran a Badger scan-and-delete on every shard commit, and removing it takes that work off the write path.

Plan: `docs/development/bugs/predastore-generation-retention-loses-objects.md`. Beads `mulga-phe73`, `mulga-lagsr`, `mulga-k91ji`.
