### PR TITLE
fix: make stop.sh confirm termination and honour the cluster names it is given

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ The multi-host profiles put every host on one machine behind loopback aliases, s
 Stop, reset or benchmark the cluster with:
 
 ```bash
-./scripts/stop.sh
+./scripts/stop.sh              # every cluster under $PREDA_DIR
+./scripts/stop.sh 3host        # only that one, leaving any others running
 ./scripts/clean.sh
 ./scripts/bench.sh 3host
 ./scripts/bench.sh disk

--- a/README_E2E.md
+++ b/README_E2E.md
@@ -283,10 +283,13 @@ the new hash in the plan doc that changed it. Previous baselines:
 - **A single green run is not evidence** for anything concurrency-related. The
   candidate fix for the concurrent-PUT bug passed twice and was then shown by
   the full gate to still lose objects. Run a racing scenario five times.
-- **`predastore/scripts/stop.sh` never confirms termination.** It sends SIGTERM
-  and deletes the pidfiles regardless, so an `s3d` that ignores the signal keeps
-  its ports and breaks the next run. Check with `pgrep -af '/bin/s3d -config'`
-  before blaming the new run.
+- **`predastore/scripts/stop.sh` now confirms termination**, and fails rather
+  than reporting a stop that did not happen. It waits `STOP_TIMEOUT` (20s) for
+  SIGTERM, escalates to SIGKILL, waits `KILL_TIMEOUT` (5s) more, and exits 1
+  naming anything that survived. A pidfile is removed once its process is gone
+  rather than once it has been signalled. Before this it deleted the pidfiles
+  regardless, so an `s3d` that ignored the signal kept its ports and broke the
+  next run looking like a fault in whatever was just built.
 - **A full disk breaks the linter with an unrelated message** —
   `no go files to analyze: running go mod tidy may solve the problem`. Check
   `df -h` first; `go clean -cache` reclaims several GB.

--- a/README_E2E.md
+++ b/README_E2E.md
@@ -290,6 +290,13 @@ the new hash in the plan doc that changed it. Previous baselines:
   rather than once it has been signalled. Before this it deleted the pidfiles
   regardless, so an `s3d` that ignored the signal kept its ports and broke the
   next run looking like a fault in whatever was just built.
+- **`stop.sh` takes cluster names, and used to ignore them.** `stop.sh 3host`
+  now stops that cluster alone; with no names it sweeps every cluster under
+  `$PREDA_DIR`, which is what `clean.sh` and the benchmark harnesses rely on.
+  Naming a cluster that is not there warns and exits 0, because CI runs its
+  teardown step unconditionally and "already stopped" is a legitimate outcome.
+  `-w` is accepted and ignored for symmetry with `start.sh`. Before this the
+  arguments were silently discarded and every call stopped everything.
 - **A full disk breaks the linter with an unrelated message** —
   `no go files to analyze: running go mod tidy may solve the problem`. Check
   `df -h` first; `go clean -cache` reclaims several GB.

--- a/scripts/bench/e2e-stress.sh
+++ b/scripts/bench/e2e-stress.sh
@@ -176,11 +176,10 @@ log() {
 
 fail() { log "FAIL: $*"; exit 1; }
 
-# stop_clusters takes down every cluster under PREDA_DIR and confirms each node
-# is gone rather than assuming the signal landed: one that outlives the run
-# holds its ports and fails the next one somewhere unrelated. stop.sh removes
-# each pidfile as it signals, so the handles are taken before it runs rather
-# than looked for afterwards.
+# stop_clusters takes down every cluster under PREDA_DIR, which is this run's own
+# private directory, so the unnamed sweep is already scoped to it. stop.sh now
+# confirms each node is gone and escalates on its own; the pids are still
+# collected first so a pidfile it could not attribute is still followed up here.
 stop_clusters() {
     local pidfile pid waited
     local pids=()

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -108,7 +108,7 @@ if [ -d "$PIDS" ]; then
         pid=$(cat "$pidfile")
         if kill -0 "$pid" 2>/dev/null; then
             log_error "Cluster '$CLUSTER_NAME' is already running (PID $pid from $(basename "$pidfile"))"
-            log_error "Run ./scripts/stop.sh first"
+            log_error "Run ./scripts/stop.sh $CLUSTER_NAME first"
             exit 1
         else
             # Stale PID file — clean it up
@@ -295,4 +295,4 @@ log_info "  Base:  $BASE"
 log_info "  Logs:  $LOGS/"
 log_info "  PIDs:  $PIDS/"
 log_info ""
-log_info "Stop with: ./scripts/stop.sh"
+log_info "Stop with: ./scripts/stop.sh $CLUSTER_NAME"

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -2,10 +2,16 @@
 #
 # stop.sh - Stop all running Predastore clusters
 #
-# Scans $PREDA_DIR/*/pids/ and kills any running processes.
+# Scans $PREDA_DIR/*/pids/ and stops any running processes, confirming each one
+# has actually exited before reporting success.
 #
 # Usage:
 #   ./scripts/stop.sh
+#
+# Environment:
+#   PREDA_DIR      cluster root to scan (default /tmp/predastore)
+#   STOP_TIMEOUT   seconds to wait after SIGTERM before SIGKILL (default 20)
+#   KILL_TIMEOUT   seconds to wait after SIGKILL before failing (default 5)
 #
 
 set -euo pipefail
@@ -27,6 +33,7 @@ NC='\033[0m'
 
 log_info()  { echo -e "${GREEN}[INFO]${NC} $1"; }
 log_warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
 
 # A cluster launched against a different PREDA_DIR has no pidfile here, so it
 # survives this script silently and keeps holding its data directory. Report
@@ -48,7 +55,45 @@ if [ ! -d "$BASE_DIR" ]; then
     exit 0
 fi
 
+# How long a signalled process gets before the next signal. A clean shutdown
+# flushes Badger and closes the raft log, which is seconds rather than
+# milliseconds on a cluster that has just been benchmarked.
+STOP_TIMEOUT="${STOP_TIMEOUT:-20}"
+KILL_TIMEOUT="${KILL_TIMEOUT:-5}"
+
+# alive answers whether a pid exists, which is not the same question `kill -0`
+# answers. A process owned by another user fails `kill -0` with EPERM, so a
+# cluster started under sudo or by CI would read as already stopped while it
+# kept its ports. /proc does not confuse the two.
+alive() {
+    if [ -d /proc ]; then
+        [ -d "/proc/$1" ]
+    else
+        kill -0 "$1" 2>/dev/null
+    fi
+}
+
+# wait_for_exit polls the given pids and echoes those still alive when it gives
+# up. Polling is what this needs: the processes are not children of this shell,
+# so there is nothing to `wait` on.
+wait_for_exit() {
+    local deadline=$(( SECONDS + $1 )); shift
+    local pid remaining
+    while :; do
+        remaining=()
+        for pid in "$@"; do
+            alive "$pid" && remaining+=("$pid")
+        done
+        [ ${#remaining[@]} -eq 0 ] && return 0
+        [ "$SECONDS" -ge "$deadline" ] && break
+        sleep 0.2
+    done
+    printf '%s\n' "${remaining[@]}"
+}
+
 stopped=0
+pids=()
+declare -A pid_label=() pid_file=()
 
 for pid_dir in "$BASE_DIR"/*/pids; do
     [ -d "$pid_dir" ] || continue
@@ -59,14 +104,47 @@ for pid_dir in "$BASE_DIR"/*/pids; do
         pid=$(cat "$pidfile")
         node=$(basename "$pidfile" .pid)
 
-        if kill -0 "$pid" 2>/dev/null; then
+        if alive "$pid"; then
             log_info "Stopping $cluster/$node (PID: $pid)"
             kill "$pid" 2>/dev/null || true
+            pids+=("$pid")
+            pid_label[$pid]="$cluster/$node"
+            pid_file[$pid]="$pidfile"
             stopped=$((stopped + 1))
+        else
+            rm -f "$pidfile"
         fi
-        rm -f "$pidfile"
     done
 done
+
+# Signalling is not stopping. An s3d that is slow to close its raft log, or that
+# ignores SIGTERM outright, keeps its listening ports and its data directory, and
+# the next start.sh then fails at readiness looking like a fault in whatever was
+# just built. Deleting the pidfile here is what made that invisible, so it is
+# deleted once the process is gone rather than once it has been signalled.
+if [ ${#pids[@]} -gt 0 ]; then
+    mapfile -t survivors < <(wait_for_exit "$STOP_TIMEOUT" "${pids[@]}")
+
+    if [ ${#survivors[@]} -gt 0 ]; then
+        for pid in "${survivors[@]}"; do
+            log_warn "${pid_label[$pid]} (PID: $pid) ignored SIGTERM after ${STOP_TIMEOUT}s — sending SIGKILL"
+            kill -9 "$pid" 2>/dev/null || true
+        done
+        mapfile -t survivors < <(wait_for_exit "$KILL_TIMEOUT" "${survivors[@]}")
+    fi
+
+    for pid in "${pids[@]}"; do
+        alive "$pid" || rm -f "${pid_file[$pid]}"
+    done
+
+    if [ ${#survivors[@]} -gt 0 ]; then
+        for pid in "${survivors[@]}"; do
+            log_error "${pid_label[$pid]} (PID: $pid) survived SIGKILL and still holds its ports"
+        done
+        log_error "Refusing to report a stop that did not happen. Investigate before starting another cluster."
+        exit 1
+    fi
+fi
 
 # Teardown loopback IPs for each cluster that has a matching config. Only
 # addresses start.sh could have aliased are removed: loopback is the machine's

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,24 +1,38 @@
 #!/bin/bash
 #
-# stop.sh - Stop all running Predastore clusters
+# stop.sh - Stop running Predastore clusters
 #
-# Scans $PREDA_DIR/*/pids/ and stops any running processes, confirming each one
-# has actually exited before reporting success.
+# Reads $PREDA_DIR/<cluster>/pids/ and stops the processes it finds, confirming
+# each one has actually exited before reporting success. With no arguments every
+# cluster under $PREDA_DIR is stopped; naming clusters stops only those and
+# leaves the rest running.
 #
 # Usage:
-#   ./scripts/stop.sh
+#   ./scripts/stop.sh [-w] [clustername ...]
+#
+# Options:
+#   -w    Accepted for symmetry with start.sh and ignored. Stopping always waits
+#         for each process to exit, so there is no other mode to select.
 #
 # Environment:
-#   PREDA_DIR      cluster root to scan (default /tmp/predastore)
-#   STOP_TIMEOUT   seconds to wait after SIGTERM before SIGKILL (default 20)
-#   KILL_TIMEOUT   seconds to wait after SIGKILL before failing (default 5)
+#   PREDA_DIR          cluster root to scan (default /tmp/predastore)
+#   PREDA_CONFIG_DIR   where profiles are read from (default: repo config/)
+#   STOP_TIMEOUT       seconds to wait after SIGTERM before SIGKILL (default 20)
+#   KILL_TIMEOUT       seconds to wait after SIGKILL before failing (default 5)
+#
+# Examples:
+#   ./scripts/stop.sh              # every cluster under $PREDA_DIR
+#   ./scripts/stop.sh s3tests      # only that one
 #
 
 set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 REPO_DIR="$SCRIPT_DIR/.."
-CONFIG_DIR="$REPO_DIR/config"
+# Matches start.sh: a harness that generated its profiles elsewhere aliased the
+# loopback addresses in those, so reading the repo's copy here would tear down
+# addresses from a different profile of the same name.
+CONFIG_DIR="${PREDA_CONFIG_DIR:-$REPO_DIR/config}"
 
 # shellcheck source=scripts/lib.sh
 source "$SCRIPT_DIR/lib.sh"
@@ -34,6 +48,17 @@ NC='\033[0m'
 log_info()  { echo -e "${GREEN}[INFO]${NC} $1"; }
 log_warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+
+# -w means "wait until ready" in start.sh. Here waiting for exit is what the
+# script does in every case, so the flag is taken and ignored rather than
+# rejected — callers pair the two scripts and pass it to both.
+while getopts "w" opt; do
+    case $opt in
+        w) ;;
+        *) log_error "Usage: $0 [-w] [clustername ...]"; exit 1 ;;
+    esac
+done
+shift $((OPTIND - 1))
 
 # A cluster launched against a different PREDA_DIR has no pidfile here, so it
 # survives this script silently and keeps holding its data directory. Report
@@ -51,6 +76,45 @@ report_stray() {
 
 if [ ! -d "$BASE_DIR" ]; then
     log_info "Nothing to stop — $BASE_DIR does not exist"
+    report_stray
+    exit 0
+fi
+
+# Naming clusters is what lets one run tear down its own without stopping a
+# cluster another run is still using. Naming none keeps the sweep, which is what
+# clean.sh and the benchmark harnesses call.
+clusters=()
+missing=()
+if [ $# -gt 0 ]; then
+    for name in "$@"; do
+        if [ -d "$BASE_DIR/$name" ]; then
+            clusters+=("$name")
+        else
+            missing+=("$name")
+        fi
+    done
+else
+    for dir in "$BASE_DIR"/*/; do
+        [ -d "$dir" ] || continue
+        clusters+=("$(basename "$dir")")
+    done
+fi
+
+# Not being there is a legitimate answer to "stop this", and CI runs its
+# teardown step unconditionally, so a miss warns rather than failing. Listing
+# what is present is what keeps a typo from passing silently.
+if [ ${#missing[@]} -gt 0 ]; then
+    present=()
+    for dir in "$BASE_DIR"/*/; do
+        [ -d "$dir" ] || continue
+        present+=("$(basename "$dir")")
+    done
+    log_warn "No cluster directory under $BASE_DIR for: ${missing[*]}"
+    log_warn "Present: ${present[*]:-(none)}"
+fi
+
+if [ ${#clusters[@]} -eq 0 ]; then
+    log_info "No clusters to stop under $BASE_DIR"
     report_stray
     exit 0
 fi
@@ -95,9 +159,9 @@ stopped=0
 pids=()
 declare -A pid_label=() pid_file=()
 
-for pid_dir in "$BASE_DIR"/*/pids; do
+for cluster in "${clusters[@]}"; do
+    pid_dir="$BASE_DIR/$cluster/pids"
     [ -d "$pid_dir" ] || continue
-    cluster=$(basename "$(dirname "$pid_dir")")
 
     for pidfile in "$pid_dir"/*.pid; do
         [ -f "$pidfile" ] || continue
@@ -148,10 +212,10 @@ fi
 
 # Teardown loopback IPs for each cluster that has a matching config. Only
 # addresses start.sh could have aliased are removed: loopback is the machine's
-# own and a single-host profile never aliased anything.
-for cluster_dir in "$BASE_DIR"/*/; do
-    [ -d "$cluster_dir" ] || continue
-    cluster=$(basename "$cluster_dir")
+# own and a single-host profile never aliased anything. Scoped to the clusters
+# actually stopped, so naming one does not pull the addresses out from under
+# another that is still serving on them.
+for cluster in "${clusters[@]}"; do
     config="$CONFIG_DIR/${cluster}.toml"
     [ -f "$config" ] || continue
 


### PR DESCRIPTION
`scripts/stop.sh` had two defects that both made it report a stop it had not performed. They are separate faults with the same symptom, so they are one commit each.

## 1. Signalling was treated as stopping

`stop.sh` sent SIGTERM and deleted the pidfile regardless, returning success without ever checking the process exited. An `s3d` slow to close its raft log, or ignoring SIGTERM outright, kept its listening ports and its data directory. The next `start.sh` then failed at readiness with `Process NNN exited during startup`, which reads as a fault in whatever was just built rather than as a leftover from the previous run.

Hit for real during the retention benchmark work: three `s3d` processes from a failed run survived SIGTERM entirely and had to be SIGKILLed by hand.

Now it waits `STOP_TIMEOUT` (20s), escalates to SIGKILL, waits `KILL_TIMEOUT` (5s) more, and exits 1 naming anything that survived. A pidfile is removed once its process is gone rather than once it has been signalled.

Liveness is checked through `/proc` rather than `kill -0`. They answer different questions: a process owned by another user fails `kill -0` with EPERM, so a cluster started under sudo or by CI would read as already stopped while it kept its ports. This was found while testing the survives-SIGKILL path — the old check reported "No running processes found" and deleted the pidfile of a live process.

## 2. The cluster names it was given were ignored

`stop.sh` took no arguments at all and scanned `$PREDA_DIR` wholesale, so every caller that named a cluster was silently stopping all of them:

- `.github/workflows/predastore-conformance.yml` — `./scripts/stop.sh s3tests`
- `scripts/bench/e2e-stress.sh` (three sites) — `stop.sh -w "$LARGE_CLUSTER"`

Both read as scoped and neither was.

Names now select. With no names the sweep is unchanged, which is what `clean.sh` and the two benchmark harnesses rely on — both point `PREDA_DIR` at their own `mktemp` directory, so the sweep is already scoped for them.

Naming a cluster that is not there warns and exits 0 rather than failing. The conformance teardown step runs with `if: always()`, and "already stopped" is a legitimate answer to a stop request; the warning lists what *is* present so a typo is still visible. `-w` is accepted and ignored, since waiting for exit is now unconditional.

Two things fall out of scoping that would otherwise have been new bugs:

- **Loopback teardown is scoped to the clusters actually stopped.** Otherwise `stop.sh s3tests` would rip the loopback aliases out from under a `3host` still serving on them.
- **`CONFIG_DIR` honours `PREDA_CONFIG_DIR`,** as `start.sh` already does. The profile consulted for those addresses is now the one that aliased them, not the repo's copy of the same name — both benchmark harnesses generate their profiles elsewhere.

## Testing

`make preflight` passes. `shellcheck -x` clean across `stop.sh`, `start.sh`, `clean.sh` and both benchmark harnesses.

Behaviour verified directly:

| Case | Result |
| --- | --- |
| `stop.sh alpha` with alpha and beta both up | alpha stopped, beta untouched, only alpha's pidfile removed |
| `stop.sh nosuch` | warns, lists what is present, exit 0, nothing stopped |
| `stop.sh -w beta` | flag accepted, beta selected and stopped |
| `stop.sh` with no args | both clusters stopped |
| `stop.sh -z alpha` | usage, exit 1 |
| pid that ignores SIGTERM (`SigIgn` bit 15 confirmed set) | SIGTERM warning, SIGKILL escalation, confirmed gone, exit 0 |
| real `s3tests` cluster, exact CI call | stopped, port 8443 released, pidfiles cleared, exit 0 |
| re-running against an already-stopped cluster | exit 0 |

Closes mulga-tzo7y.