### PR TITLE
fix: bound the inbound object body, and run all thirteen stress scenarios

### DIFF
--- a/.github/workflows/predastore-e2e.yml
+++ b/.github/workflows/predastore-e2e.yml
@@ -34,7 +34,7 @@ on:
         required: false
         default: ""
       stress_scenarios:
-        description: "Stress scenarios to run (empty = the eleven this job runs; name partial-put or multipart-upload to add them)"
+        description: "Stress scenarios to run (empty = the twelve this job runs; name partial-put to add it)"
         required: false
         default: ""
       run_performance:
@@ -103,17 +103,22 @@ jobs:
     outputs:
       scenarios: ${{ steps.plan.outputs.scenarios }}
     steps:
-      # Eleven of the thirteen. partial-put fails today on an unbounded inbound
-      # body read, and multipart-upload dies restarting its cluster between
-      # part sizes on about two hosted runs in three. Both are covered by the
-      # spinifex nightly, and either can be named in the dispatch input.
+      # Twelve of the thirteen. Only partial-put is out, and it is out because
+      # it fails: an unbounded inbound body read, mulga-8lxge. It is covered by
+      # the spinifex nightly and can be named in the dispatch input.
+      #
+      # multipart-upload was out too, recorded as dying restarting its cluster
+      # between part sizes. That was never the cause — completion took the CLI's
+      # 60s default while the work measures 63-68s, so it timed out on itself.
+      # With an explicit timeout it is 5 for 5, and it gates here rather than
+      # waiting for the nightly.
       - name: Choose Scenarios
         id: plan
         env:
           REQUESTED: ${{ inputs.stress_scenarios }}
         run: |
           set -euo pipefail
-          default="repair handoff node-rejoin node-resync node-rebuild last-modified large-object concurrent-put torn-overwrite stale-shard freeze"
+          default="repair handoff node-rejoin node-resync node-rebuild last-modified large-object concurrent-put torn-overwrite stale-shard freeze multipart-upload"
           # shellcheck disable=SC2086
           printf '%s\n' ${REQUESTED:-$default} | jq -Rsc 'split("\n") | map(select(length > 0))' \
             | sed 's/^/scenarios=/' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/predastore-e2e.yml
+++ b/.github/workflows/predastore-e2e.yml
@@ -34,7 +34,7 @@ on:
         required: false
         default: ""
       stress_scenarios:
-        description: "Stress scenarios to run (empty = the twelve this job runs; name partial-put to add it)"
+        description: "Stress scenarios to run (empty = all thirteen)"
         required: false
         default: ""
       run_performance:
@@ -95,7 +95,7 @@ jobs:
         run: make compose-down
 
   # The scenario list is a job rather than a literal in the matrix so the
-  # dispatch input can still name the two the default set leaves out.
+  # dispatch input can narrow it to one scenario without editing the workflow.
   stress-plan:
     name: Stress (plan)
     runs-on: ubuntu-26.04
@@ -103,22 +103,21 @@ jobs:
     outputs:
       scenarios: ${{ steps.plan.outputs.scenarios }}
     steps:
-      # Twelve of the thirteen. Only partial-put is out, and it is out because
-      # it fails: an unbounded inbound body read, mulga-8lxge. It is covered by
-      # the spinifex nightly and can be named in the dispatch input.
+      # All thirteen. The two that were excluded both failed for reasons that
+      # had nothing to do with the scenarios: multipart-upload completion took
+      # the AWS CLI's 60s default while the work measures 63-68s, and
+      # partial-put had no bound on the inbound body read at all.
       #
-      # multipart-upload was out too, recorded as dying restarting its cluster
-      # between part sizes. That was never the cause — completion took the CLI's
-      # 60s default while the work measures 63-68s, so it timed out on itself.
-      # With an explicit timeout it is 5 for 5, and it gates here rather than
-      # waiting for the nightly.
+      # Both were recorded as covered by the spinifex nightly. partial-put was
+      # not: it was the one scenario with no branch under SCENARIO=all, which is
+      # what the nightly runs, so it had no coverage anywhere.
       - name: Choose Scenarios
         id: plan
         env:
           REQUESTED: ${{ inputs.stress_scenarios }}
         run: |
           set -euo pipefail
-          default="repair handoff node-rejoin node-resync node-rebuild last-modified large-object concurrent-put torn-overwrite stale-shard freeze multipart-upload"
+          default="repair handoff node-rejoin node-resync node-rebuild last-modified large-object concurrent-put torn-overwrite stale-shard freeze multipart-upload partial-put"
           # shellcheck disable=SC2086
           printf '%s\n' ${REQUESTED:-$default} | jq -Rsc 'split("\n") | map(select(length > 0))' \
             | sed 's/^/scenarios=/' >> "$GITHUB_OUTPUT"

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ e2e-stress: build certs warp-install
 		WARP="$(WARP)" \
 		./scripts/bench/e2e-stress.sh
 
-# Two scenarios fail today, so CI gates on a regression against
+# partial-put fails today, so CI gates on a regression against
 # scripts/stress-baseline.txt rather than on a clean run. STRESS_SCENARIOS
 # narrows it: `make e2e-stress-gate STRESS_SCENARIOS=freeze`.
 STRESS_BASELINE  ?= scripts/stress-baseline.txt
@@ -216,9 +216,9 @@ e2e-stress-gate: build certs warp-install
 		WARP="$(WARP)" \
 		./scripts/bench/stress-gate.sh $(STRESS_SCENARIOS)
 
-# Fails on any failing scenario. Red until torn-overwrite is fixed, which is
-# the point: an overwrite that leaves an object part new and part old is data
-# loss on the ordinary write path.
+# Fails on any failing scenario. Red until partial-put is fixed, which is the
+# point: a client that stops sending mid-body holds the gate until the harness
+# gives up, so one abandoned upload can occupy a handler indefinitely.
 e2e-stress-strict: build certs warp-install
 	@STRESS_CONFIG="$(STRESS_CONFIG)" STRESS_FREEZE="$(STRESS_FREEZE)" \
 		STRESS_HOST="$(STRESS_HOST)" STRESS_BASELINE="$(STRESS_BASELINE)" \

--- a/Makefile
+++ b/Makefile
@@ -173,28 +173,19 @@ e2e-performance-compare: warp-install
 	@test -n "$(PERF_AFTER)" || { echo "PERF_AFTER is required" >&2; exit 2; }
 	@WARP="$(WARP)" ./scripts/bench/compare-performance.sh "$(PERF_BEFORE)" "$(PERF_AFTER)"
 
-# Fault injection on a four-host cluster. Two tests, both run by default, and
-# neither is a benchmark: together they take roughly seven minutes regardless
-# of how fast the machine is.
+# Fault injection on a four-host cluster. Thirteen scenarios, all run by
+# default, and none is a benchmark: the run is mostly deliberate waiting, so it
+# takes about the same wall clock regardless of how fast the machine is.
 #
-# torn-overwrite stops the one host holding a named shard and overwrites the
-# object while it is down. The write fails, as it must with a shard node
-# unreachable, and the run then asks what the object is afterwards. **It
-# currently fails**: an overwrite has no commit point across its shards, so a
-# failed one leaves the object part new and part old, served as a 200 with the
-# right length and ETag. That is silent data loss on the ordinary write path,
-# which is why it runs every time rather than on request.
+# They cover shard repair and handoff, the three node re-entry paths, object
+# size and timestamp semantics, concurrent and torn overwrites, stale shards, a
+# frozen host under load, multipart upload, and a client that stops sending
+# mid-body. STRESS_HOST=leader freezes whichever host raft elected instead,
+# which still fails: a gate keeps the frozen node first in its meta read order
+# and pays the full client timeout per key, so listing slows in proportion to
+# the number of objects.
 #
-# The freeze test then puts the cluster under load, freezes a follower with
-# SIGSTOP and asserts it keeps serving and rejoins. STRESS_HOST=leader freezes
-# whichever host raft elected instead, which also fails: a gate keeps the
-# frozen node first in its meta read order and pays the full client timeout per
-# key, so listing slows in proportion to the number of objects.
-#
-# STRESS_SCENARIO narrows a run to one test. STRESS_SCENARIO=partial-put is a
-# third fault, not in a default run: a client that stops sending mid-body,
-# which is about a stalled upload neither running forever nor damaging the
-# object it is overwriting.
+# STRESS_SCENARIO narrows a run to one of them.
 STRESS_CONFIG   ?= 4host
 STRESS_FREEZE   ?= 90
 STRESS_HOST     ?= follower
@@ -205,9 +196,9 @@ e2e-stress: build certs warp-install
 		WARP="$(WARP)" \
 		./scripts/bench/e2e-stress.sh
 
-# partial-put fails today, so CI gates on a regression against
-# scripts/stress-baseline.txt rather than on a clean run. STRESS_SCENARIOS
-# narrows it: `make e2e-stress-gate STRESS_SCENARIOS=freeze`.
+# CI gates on a regression against scripts/stress-baseline.txt rather than on a
+# clean run, so a branch is not red for a gap it did not introduce.
+# STRESS_SCENARIOS narrows it: `make e2e-stress-gate STRESS_SCENARIOS=freeze`.
 STRESS_BASELINE  ?= scripts/stress-baseline.txt
 STRESS_SCENARIOS ?=
 e2e-stress-gate: build certs warp-install
@@ -216,9 +207,8 @@ e2e-stress-gate: build certs warp-install
 		WARP="$(WARP)" \
 		./scripts/bench/stress-gate.sh $(STRESS_SCENARIOS)
 
-# Fails on any failing scenario. Red until partial-put is fixed, which is the
-# point: a client that stops sending mid-body holds the gate until the harness
-# gives up, so one abandoned upload can occupy a handler indefinitely.
+# Fails on any failing scenario, which is what CI runs. The baseline records
+# every scenario green, so this and the gate above currently agree.
 e2e-stress-strict: build certs warp-install
 	@STRESS_CONFIG="$(STRESS_CONFIG)" STRESS_FREEZE="$(STRESS_FREEZE)" \
 		STRESS_HOST="$(STRESS_HOST)" STRESS_BASELINE="$(STRESS_BASELINE)" \

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ The multi-host profiles put every host on one machine behind loopback aliases, s
 Stop, reset or benchmark the cluster with:
 
 ```bash
-./scripts/stop.sh
+./scripts/stop.sh              # every cluster under $PREDA_DIR
+./scripts/stop.sh 3host        # only that one, leaving any others running
 ./scripts/clean.sh
 ./scripts/bench.sh 3host
 ./scripts/bench.sh disk

--- a/README_E2E.md
+++ b/README_E2E.md
@@ -283,10 +283,13 @@ the new hash in the plan doc that changed it. Previous baselines:
 - **A single green run is not evidence** for anything concurrency-related. The
   candidate fix for the concurrent-PUT bug passed twice and was then shown by
   the full gate to still lose objects. Run a racing scenario five times.
-- **`predastore/scripts/stop.sh` never confirms termination.** It sends SIGTERM
-  and deletes the pidfiles regardless, so an `s3d` that ignores the signal keeps
-  its ports and breaks the next run. Check with `pgrep -af '/bin/s3d -config'`
-  before blaming the new run.
+- **`predastore/scripts/stop.sh` now confirms termination**, and fails rather
+  than reporting a stop that did not happen. It waits `STOP_TIMEOUT` (20s) for
+  SIGTERM, escalates to SIGKILL, waits `KILL_TIMEOUT` (5s) more, and exits 1
+  naming anything that survived. A pidfile is removed once its process is gone
+  rather than once it has been signalled. Before this it deleted the pidfiles
+  regardless, so an `s3d` that ignored the signal kept its ports and broke the
+  next run looking like a fault in whatever was just built.
 - **A full disk breaks the linter with an unrelated message** —
   `no go files to analyze: running go mod tidy may solve the problem`. Check
   `df -h` first; `go clean -cache` reclaims several GB.

--- a/README_E2E.md
+++ b/README_E2E.md
@@ -22,8 +22,8 @@ unrelated, and passing this gate does not put anything on a server.
 
 ## What a default run does
 
-Eleven scenarios in order, then a Warp load test. A default run is about **25
-minutes** and asserts **156** things.
+Twelve scenarios in order, then a Warp load test. A default run is about **30
+minutes** and asserts **162** things.
 
 | Scenario | Asserts | What it does |
 |---|---|---|
@@ -41,7 +41,8 @@ minutes** and asserts **156** things.
 | `freeze` | 6 | Warp GET load while a host is SIGSTOPped; survivors keep serving, frozen host rejoins raft and takes writes |
 
 `partial-put` — a client that stops sending mid-body — exists but is **not** in a
-default run. Name it explicitly.
+default run, because it fails: the inbound body read is unbounded, so the gate
+holds the request until the harness gives up at 170s. Name it explicitly.
 
 **SIGSTOP is the fault worth injecting** because it is the one a healthy
 transport cannot distinguish from a slow peer: the process stays dialable and

--- a/README_E2E.md
+++ b/README_E2E.md
@@ -290,6 +290,13 @@ the new hash in the plan doc that changed it. Previous baselines:
   rather than once it has been signalled. Before this it deleted the pidfiles
   regardless, so an `s3d` that ignored the signal kept its ports and broke the
   next run looking like a fault in whatever was just built.
+- **`stop.sh` takes cluster names, and used to ignore them.** `stop.sh 3host`
+  now stops that cluster alone; with no names it sweeps every cluster under
+  `$PREDA_DIR`, which is what `clean.sh` and the benchmark harnesses rely on.
+  Naming a cluster that is not there warns and exits 0, because CI runs its
+  teardown step unconditionally and "already stopped" is a legitimate outcome.
+  `-w` is accepted and ignored for symmetry with `start.sh`. Before this the
+  arguments were silently discarded and every call stopped everything.
 - **A full disk breaks the linter with an unrelated message** —
   `no go files to analyze: running go mod tidy may solve the problem`. Check
   `df -h` first; `go clean -cache` reclaims several GB.

--- a/README_E2E.md
+++ b/README_E2E.md
@@ -22,8 +22,8 @@ unrelated, and passing this gate does not put anything on a server.
 
 ## What a default run does
 
-Twelve scenarios in order, then a Warp load test. A default run is about **30
-minutes** and asserts **162** things.
+Thirteen scenarios in order, then a Warp load test. A default run is about **35
+minutes** and asserts **180** things.
 
 | Scenario | Asserts | What it does |
 |---|---|---|
@@ -39,10 +39,7 @@ minutes** and asserts **162** things.
 | `torn-overwrite` | 5 | Overwrites with the host holding one named shard stopped; asserts the failed write left the object exactly as it was |
 | `stale-shard` | 48 | Overwrites with a host frozen, asserts no read ever splices generations |
 | `freeze` | 6 | Warp GET load while a host is SIGSTOPped; survivors keep serving, frozen host rejoins raft and takes writes |
-
-`partial-put` — a client that stops sending mid-body — exists but is **not** in a
-default run, because it fails: the inbound body read is unbounded, so the gate
-holds the request until the harness gives up at 170s. Name it explicitly.
+| `partial-put` | 18 | A client that stops sending mid-body, over HTTP/1.1 and h2, killed and stalled; asserts the gate abandons it on its idle bound and the object it overwrites is untouched |
 
 **SIGSTOP is the fault worth injecting** because it is the one a healthy
 transport cannot distinguish from a slow peer: the process stays dialable and

--- a/internal/gate/deadline_test.go
+++ b/internal/gate/deadline_test.go
@@ -7,6 +7,7 @@ package gate
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -123,4 +124,85 @@ func TestServerSetsNoWholeBodyTimeouts(t *testing.T) {
 	assert.NotZero(t, srv.ReadHeaderTimeout, "the header exchange is fixed-size and must stay bounded")
 	assert.NotZero(t, srv.IdleTimeout, "an idle connection must still be reclaimed")
 	assert.NotZero(t, srv.MaxHeaderBytes)
+}
+
+// The bound bulkBody's comment promises. Releasing the total deadline without
+// replacing it left a client that stops mid-body holding a handler until it
+// disconnected, which is a stall the blob client's guard cannot reach: that one
+// aborts a stream to a blob node, not a read on the client's own connection.
+func TestBulkBodyAbandonsABodyThatStopsArriving(t *testing.T) {
+	readErr := make(chan error, 1)
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.Copy(io.Discard, r.Body)
+		readErr <- err
+	})
+
+	srv := httptest.NewServer(requestDeadlineMiddleware(bulkBodyWithin(100*time.Millisecond, inner)))
+	defer srv.Close()
+
+	// Declares more than it sends and then never sends the rest, so the read
+	// blocks on bytes that are still owed rather than on a closed connection.
+	pr, pw := io.Pipe()
+	defer func() { _ = pw.Close() }()
+	go func() { _, _ = pw.Write([]byte("partial")) }()
+
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/b/k", pr)
+	require.NoError(t, err)
+	req.ContentLength = 4096
+	go func() {
+		resp, err := srv.Client().Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	select {
+	case err := <-readErr:
+		require.Error(t, err, "a body that stopped arriving must not read as a complete one")
+	case <-time.After(5 * time.Second):
+		t.Fatal("the gate held a stalled body past its idle bound")
+	}
+}
+
+// The counter-property, and the reason the bound is on progress rather than on
+// total duration: a body that keeps arriving is never cut off, however long it
+// takes in total. Six sends at half the bound run to three times it.
+func TestBulkBodyDoesNotBoundABodyStillArriving(t *testing.T) {
+	const idle = 100 * time.Millisecond
+
+	done := make(chan error, 1)
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.Copy(io.Discard, r.Body)
+		done <- err
+	})
+
+	srv := httptest.NewServer(requestDeadlineMiddleware(bulkBodyWithin(idle, inner)))
+	defer srv.Close()
+
+	pr, pw := io.Pipe()
+	go func() {
+		for range 6 {
+			time.Sleep(idle / 2)
+			if _, err := pw.Write([]byte("chunk")); err != nil {
+				break
+			}
+		}
+		_ = pw.Close()
+	}()
+
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/b/k", pr)
+	require.NoError(t, err)
+	go func() {
+		resp, err := srv.Client().Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, "a body still making progress was cut off")
+	case <-time.After(5 * time.Second):
+		t.Fatal("the body never finished")
+	}
 }

--- a/internal/gate/middleware.go
+++ b/internal/gate/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	"github.com/mulgadc/predastore/internal/gate/auth"
 	"github.com/mulgadc/predastore/internal/gate/chunked"
 	"github.com/mulgadc/predastore/internal/gate/handlers"
+	"github.com/mulgadc/predastore/internal/transport"
 )
 
 // globalSigningRegion is the region clients sign S3's global operations against,
@@ -30,6 +32,11 @@ const globalSigningRegion = "us-east-1"
 // It is a bound on the fixed exchanges, not on object data. A body is bounded
 // by progress instead: see bulkBody.
 const requestDeadline = 50 * time.Second
+
+// bulkBodyIdle is how long an object body may make no progress before the gate
+// abandons it. It matches the blob client's idle timeout, so one stalled
+// transfer is bounded the same however far down the write path it stops.
+const bulkBodyIdle = 30 * time.Second
 
 type deadlineStopperKey struct{}
 
@@ -73,28 +80,59 @@ func deadlineMiddleware(within time.Duration, next http.Handler) http.Handler {
 // error: the context bound still applies, and h2 streams are already bounded
 // by the server's own limits.
 func setConnDeadlines(ctx context.Context, rc *http.ResponseController, t time.Time) {
-	if err := rc.SetReadDeadline(t); err != nil && !errors.Is(err, http.ErrNotSupported) {
-		slog.DebugContext(ctx, "set read deadline", "err", err)
-	}
+	setReadDeadline(ctx, rc, t)
 	if err := rc.SetWriteDeadline(t); err != nil && !errors.Is(err, http.ErrNotSupported) {
 		slog.DebugContext(ctx, "set write deadline", "err", err)
 	}
 }
 
-// bulkBody releases the request deadline for the handlers that move object
-// data. Those bodies are bounded by progress instead, by the blob client's
-// idle guard, because a total cap cannot express "still sending" and a
-// multi-gigabyte transfer is legitimately slow.
+// setReadDeadline moves only the read side, so a body that stops arriving can
+// be abandoned without disturbing the response the handler still has to write.
+func setReadDeadline(ctx context.Context, rc *http.ResponseController, t time.Time) {
+	if err := rc.SetReadDeadline(t); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		slog.DebugContext(ctx, "set read deadline", "err", err)
+	}
+}
+
+// bulkBody swaps the request deadline for a progress bound on the handlers
+// that move object data, because a total cap cannot express "still sending"
+// and a multi-gigabyte transfer is legitimately slow.
+//
+// The bound has to be here rather than on the blob client's guard: that one
+// aborts a stream to a blob node, which cannot interrupt a read blocked on the
+// client's own connection. Releasing the cap without replacing it leaves a
+// client that stops mid-body holding a goroutine until it disconnects.
 //
 // Cancellation survives, so a client that disconnects still stops the work,
 // and the deadline was in force for everything before the handler ran.
 func bulkBody(next http.Handler) http.Handler {
+	return bulkBodyWithin(bulkBodyIdle, next)
+}
+
+func bulkBodyWithin(idle time.Duration, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if stopper, ok := r.Context().Value(deadlineStopperKey{}).(*deadlineStopper); ok {
 			stopper.stop()
 		}
+
+		if r.Body != nil && r.Body != http.NoBody {
+			rc := http.NewResponseController(w)
+			guard := transport.NewAbortGuard(r.Body, func() {
+				setReadDeadline(r.Context(), rc, time.Now())
+			}, idle)
+			defer guard.Stop()
+			r.Body = guardedBody{Reader: guard, Closer: r.Body}
+		}
+
 		next.ServeHTTP(w, r)
 	})
+}
+
+// guardedBody carries the idle bound on reads and leaves Close to the original
+// body, so the server keeps owning the connection's lifecycle.
+type guardedBody struct {
+	io.Reader
+	io.Closer
 }
 
 // setupMiddleware installs the chain that runs before chi has matched a route,

--- a/internal/transport/deadline.go
+++ b/internal/transport/deadline.go
@@ -50,6 +50,13 @@ func NewReadGuard(r io.Reader, stream Stream, idle time.Duration) *IdleGuard {
 	return &IdleGuard{r: r, idle: idle, abort: func() { stream.CancelRead(StreamCodeIdle) }}
 }
 
+// NewAbortGuard guards a body whose stall is ended by something other than a
+// stream: abort must unblock a read already in flight, which for a net/http
+// request body means moving the connection's read deadline into the past.
+func NewAbortGuard(r io.Reader, abort func(), idle time.Duration) *IdleGuard {
+	return &IdleGuard{r: r, idle: idle, abort: abort}
+}
+
 // NewWriteGuard guards a body being written to stream. It wraps the source
 // the copy pulls from: a source read happens only once the previous write has
 // landed, so a write that blocks shows up as a read that never comes. The

--- a/scripts/bench/e2e-stress.sh
+++ b/scripts/bench/e2e-stress.sh
@@ -176,11 +176,10 @@ log() {
 
 fail() { log "FAIL: $*"; exit 1; }
 
-# stop_clusters takes down every cluster under PREDA_DIR and confirms each node
-# is gone rather than assuming the signal landed: one that outlives the run
-# holds its ports and fails the next one somewhere unrelated. stop.sh removes
-# each pidfile as it signals, so the handles are taken before it runs rather
-# than looked for afterwards.
+# stop_clusters takes down every cluster under PREDA_DIR, which is this run's own
+# private directory, so the unnamed sweep is already scoped to it. stop.sh now
+# confirms each node is gone and escalates on its own; the pids are still
+# collected first so a pidfile it could not attribute is still followed up here.
 stop_clusters() {
     local pidfile pid waited
     local pids=()

--- a/scripts/bench/e2e-stress.sh
+++ b/scripts/bench/e2e-stress.sh
@@ -1614,10 +1614,13 @@ run_multipart_upload() {
         printf '{"Parts":[%s]}' "$(paste -sd, "$WORK_DIR/mp-parts-$spec.json.parts")" \
             > "$WORK_DIR/mp-parts-$spec.json"
 
-        # The window this scenario exists for.
+        # The window this scenario exists for. It needs an explicit read timeout:
+        # completing 1GiBx8 measures ~58s on a hosted runner, which straddles the
+        # CLI's 60s default and failed about two runs in three on that alone.
         start_rss_sampler "$WORK_DIR/mp-rss-complete-$spec.txt"
         done_start=$(date +%s)
-        aws_s3 "$gate" s3api complete-multipart-upload --bucket "$MP_BUCKET" --key "$key" \
+        aws_s3 "$gate" --cli-connect-timeout 10 --cli-read-timeout 600 \
+            s3api complete-multipart-upload --bucket "$MP_BUCKET" --key "$key" \
             --upload-id "$upload_id" \
             --multipart-upload "file://$WORK_DIR/mp-parts-$spec.json" >/dev/null \
             || mp_check false "${spec}x${MP_PART_COUNT} complete-multipart-upload failed"

--- a/scripts/bench/e2e-stress.sh
+++ b/scripts/bench/e2e-stress.sh
@@ -23,9 +23,7 @@
 #                      "multipart-upload", "last-modified", "large-object",
 #                      "concurrent-put", "torn-overwrite", "stale-shard",
 #                      "freeze", or "partial-put" — a client that stops sending
-#                      mid-body. Unset runs all of them except partial-put,
-#                      which holds stalled uploads open and is slow enough to
-#                      ask for by name.
+#                      mid-body. Unset runs all thirteen.
 #   STRESS_CONFIG      Profile to run (default: 4host)
 #   STRESS_HOST        "follower" (default), "leader", or an explicit host id.
 #                      The role is resolved against the running cluster, since
@@ -1951,7 +1949,7 @@ meta_status "${META_ALL[@]}" | tee -a "$EVENTS"
 # it a data-loss bug rather than a leak is that the shards of the object being
 # overwritten have already been replaced with the truncated ones, while the
 # metadata record still describes the object that was there before.
-if [ "$SCENARIO" = partial-put ]; then
+if [ "$SCENARIO" = all ] || [ "$SCENARIO" = partial-put ]; then
     PARTIAL_PROBE="$WORK_DIR/partialput"
     go build -o "$PARTIAL_PROBE" "$REPO_DIR/scripts/bench/partialput"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -108,7 +108,7 @@ if [ -d "$PIDS" ]; then
         pid=$(cat "$pidfile")
         if kill -0 "$pid" 2>/dev/null; then
             log_error "Cluster '$CLUSTER_NAME' is already running (PID $pid from $(basename "$pidfile"))"
-            log_error "Run ./scripts/stop.sh first"
+            log_error "Run ./scripts/stop.sh $CLUSTER_NAME first"
             exit 1
         else
             # Stale PID file — clean it up
@@ -295,4 +295,4 @@ log_info "  Base:  $BASE"
 log_info "  Logs:  $LOGS/"
 log_info "  PIDs:  $PIDS/"
 log_info ""
-log_info "Stop with: ./scripts/stop.sh"
+log_info "Stop with: ./scripts/stop.sh $CLUSTER_NAME"

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -2,10 +2,16 @@
 #
 # stop.sh - Stop all running Predastore clusters
 #
-# Scans $PREDA_DIR/*/pids/ and kills any running processes.
+# Scans $PREDA_DIR/*/pids/ and stops any running processes, confirming each one
+# has actually exited before reporting success.
 #
 # Usage:
 #   ./scripts/stop.sh
+#
+# Environment:
+#   PREDA_DIR      cluster root to scan (default /tmp/predastore)
+#   STOP_TIMEOUT   seconds to wait after SIGTERM before SIGKILL (default 20)
+#   KILL_TIMEOUT   seconds to wait after SIGKILL before failing (default 5)
 #
 
 set -euo pipefail
@@ -27,6 +33,7 @@ NC='\033[0m'
 
 log_info()  { echo -e "${GREEN}[INFO]${NC} $1"; }
 log_warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
 
 # A cluster launched against a different PREDA_DIR has no pidfile here, so it
 # survives this script silently and keeps holding its data directory. Report
@@ -48,7 +55,45 @@ if [ ! -d "$BASE_DIR" ]; then
     exit 0
 fi
 
+# How long a signalled process gets before the next signal. A clean shutdown
+# flushes Badger and closes the raft log, which is seconds rather than
+# milliseconds on a cluster that has just been benchmarked.
+STOP_TIMEOUT="${STOP_TIMEOUT:-20}"
+KILL_TIMEOUT="${KILL_TIMEOUT:-5}"
+
+# alive answers whether a pid exists, which is not the same question `kill -0`
+# answers. A process owned by another user fails `kill -0` with EPERM, so a
+# cluster started under sudo or by CI would read as already stopped while it
+# kept its ports. /proc does not confuse the two.
+alive() {
+    if [ -d /proc ]; then
+        [ -d "/proc/$1" ]
+    else
+        kill -0 "$1" 2>/dev/null
+    fi
+}
+
+# wait_for_exit polls the given pids and echoes those still alive when it gives
+# up. Polling is what this needs: the processes are not children of this shell,
+# so there is nothing to `wait` on.
+wait_for_exit() {
+    local deadline=$(( SECONDS + $1 )); shift
+    local pid remaining
+    while :; do
+        remaining=()
+        for pid in "$@"; do
+            alive "$pid" && remaining+=("$pid")
+        done
+        [ ${#remaining[@]} -eq 0 ] && return 0
+        [ "$SECONDS" -ge "$deadline" ] && break
+        sleep 0.2
+    done
+    printf '%s\n' "${remaining[@]}"
+}
+
 stopped=0
+pids=()
+declare -A pid_label=() pid_file=()
 
 for pid_dir in "$BASE_DIR"/*/pids; do
     [ -d "$pid_dir" ] || continue
@@ -59,14 +104,47 @@ for pid_dir in "$BASE_DIR"/*/pids; do
         pid=$(cat "$pidfile")
         node=$(basename "$pidfile" .pid)
 
-        if kill -0 "$pid" 2>/dev/null; then
+        if alive "$pid"; then
             log_info "Stopping $cluster/$node (PID: $pid)"
             kill "$pid" 2>/dev/null || true
+            pids+=("$pid")
+            pid_label[$pid]="$cluster/$node"
+            pid_file[$pid]="$pidfile"
             stopped=$((stopped + 1))
+        else
+            rm -f "$pidfile"
         fi
-        rm -f "$pidfile"
     done
 done
+
+# Signalling is not stopping. An s3d that is slow to close its raft log, or that
+# ignores SIGTERM outright, keeps its listening ports and its data directory, and
+# the next start.sh then fails at readiness looking like a fault in whatever was
+# just built. Deleting the pidfile here is what made that invisible, so it is
+# deleted once the process is gone rather than once it has been signalled.
+if [ ${#pids[@]} -gt 0 ]; then
+    mapfile -t survivors < <(wait_for_exit "$STOP_TIMEOUT" "${pids[@]}")
+
+    if [ ${#survivors[@]} -gt 0 ]; then
+        for pid in "${survivors[@]}"; do
+            log_warn "${pid_label[$pid]} (PID: $pid) ignored SIGTERM after ${STOP_TIMEOUT}s — sending SIGKILL"
+            kill -9 "$pid" 2>/dev/null || true
+        done
+        mapfile -t survivors < <(wait_for_exit "$KILL_TIMEOUT" "${survivors[@]}")
+    fi
+
+    for pid in "${pids[@]}"; do
+        alive "$pid" || rm -f "${pid_file[$pid]}"
+    done
+
+    if [ ${#survivors[@]} -gt 0 ]; then
+        for pid in "${survivors[@]}"; do
+            log_error "${pid_label[$pid]} (PID: $pid) survived SIGKILL and still holds its ports"
+        done
+        log_error "Refusing to report a stop that did not happen. Investigate before starting another cluster."
+        exit 1
+    fi
+fi
 
 # Teardown loopback IPs for each cluster that has a matching config. Only
 # addresses start.sh could have aliased are removed: loopback is the machine's

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,24 +1,38 @@
 #!/bin/bash
 #
-# stop.sh - Stop all running Predastore clusters
+# stop.sh - Stop running Predastore clusters
 #
-# Scans $PREDA_DIR/*/pids/ and stops any running processes, confirming each one
-# has actually exited before reporting success.
+# Reads $PREDA_DIR/<cluster>/pids/ and stops the processes it finds, confirming
+# each one has actually exited before reporting success. With no arguments every
+# cluster under $PREDA_DIR is stopped; naming clusters stops only those and
+# leaves the rest running.
 #
 # Usage:
-#   ./scripts/stop.sh
+#   ./scripts/stop.sh [-w] [clustername ...]
+#
+# Options:
+#   -w    Accepted for symmetry with start.sh and ignored. Stopping always waits
+#         for each process to exit, so there is no other mode to select.
 #
 # Environment:
-#   PREDA_DIR      cluster root to scan (default /tmp/predastore)
-#   STOP_TIMEOUT   seconds to wait after SIGTERM before SIGKILL (default 20)
-#   KILL_TIMEOUT   seconds to wait after SIGKILL before failing (default 5)
+#   PREDA_DIR          cluster root to scan (default /tmp/predastore)
+#   PREDA_CONFIG_DIR   where profiles are read from (default: repo config/)
+#   STOP_TIMEOUT       seconds to wait after SIGTERM before SIGKILL (default 20)
+#   KILL_TIMEOUT       seconds to wait after SIGKILL before failing (default 5)
+#
+# Examples:
+#   ./scripts/stop.sh              # every cluster under $PREDA_DIR
+#   ./scripts/stop.sh s3tests      # only that one
 #
 
 set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 REPO_DIR="$SCRIPT_DIR/.."
-CONFIG_DIR="$REPO_DIR/config"
+# Matches start.sh: a harness that generated its profiles elsewhere aliased the
+# loopback addresses in those, so reading the repo's copy here would tear down
+# addresses from a different profile of the same name.
+CONFIG_DIR="${PREDA_CONFIG_DIR:-$REPO_DIR/config}"
 
 # shellcheck source=scripts/lib.sh
 source "$SCRIPT_DIR/lib.sh"
@@ -34,6 +48,17 @@ NC='\033[0m'
 log_info()  { echo -e "${GREEN}[INFO]${NC} $1"; }
 log_warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+
+# -w means "wait until ready" in start.sh. Here waiting for exit is what the
+# script does in every case, so the flag is taken and ignored rather than
+# rejected — callers pair the two scripts and pass it to both.
+while getopts "w" opt; do
+    case $opt in
+        w) ;;
+        *) log_error "Usage: $0 [-w] [clustername ...]"; exit 1 ;;
+    esac
+done
+shift $((OPTIND - 1))
 
 # A cluster launched against a different PREDA_DIR has no pidfile here, so it
 # survives this script silently and keeps holding its data directory. Report
@@ -51,6 +76,45 @@ report_stray() {
 
 if [ ! -d "$BASE_DIR" ]; then
     log_info "Nothing to stop — $BASE_DIR does not exist"
+    report_stray
+    exit 0
+fi
+
+# Naming clusters is what lets one run tear down its own without stopping a
+# cluster another run is still using. Naming none keeps the sweep, which is what
+# clean.sh and the benchmark harnesses call.
+clusters=()
+missing=()
+if [ $# -gt 0 ]; then
+    for name in "$@"; do
+        if [ -d "$BASE_DIR/$name" ]; then
+            clusters+=("$name")
+        else
+            missing+=("$name")
+        fi
+    done
+else
+    for dir in "$BASE_DIR"/*/; do
+        [ -d "$dir" ] || continue
+        clusters+=("$(basename "$dir")")
+    done
+fi
+
+# Not being there is a legitimate answer to "stop this", and CI runs its
+# teardown step unconditionally, so a miss warns rather than failing. Listing
+# what is present is what keeps a typo from passing silently.
+if [ ${#missing[@]} -gt 0 ]; then
+    present=()
+    for dir in "$BASE_DIR"/*/; do
+        [ -d "$dir" ] || continue
+        present+=("$(basename "$dir")")
+    done
+    log_warn "No cluster directory under $BASE_DIR for: ${missing[*]}"
+    log_warn "Present: ${present[*]:-(none)}"
+fi
+
+if [ ${#clusters[@]} -eq 0 ]; then
+    log_info "No clusters to stop under $BASE_DIR"
     report_stray
     exit 0
 fi
@@ -95,9 +159,9 @@ stopped=0
 pids=()
 declare -A pid_label=() pid_file=()
 
-for pid_dir in "$BASE_DIR"/*/pids; do
+for cluster in "${clusters[@]}"; do
+    pid_dir="$BASE_DIR/$cluster/pids"
     [ -d "$pid_dir" ] || continue
-    cluster=$(basename "$(dirname "$pid_dir")")
 
     for pidfile in "$pid_dir"/*.pid; do
         [ -f "$pidfile" ] || continue
@@ -148,10 +212,10 @@ fi
 
 # Teardown loopback IPs for each cluster that has a matching config. Only
 # addresses start.sh could have aliased are removed: loopback is the machine's
-# own and a single-host profile never aliased anything.
-for cluster_dir in "$BASE_DIR"/*/; do
-    [ -d "$cluster_dir" ] || continue
-    cluster=$(basename "$cluster_dir")
+# own and a single-host profile never aliased anything. Scoped to the clusters
+# actually stopped, so naming one does not pull the addresses out from under
+# another that is still serving on them.
+for cluster in "${clusters[@]}"; do
     config="$CONFIG_DIR/${cluster}.toml"
     [ -f "$config" ] || continue
 

--- a/scripts/stress-baseline.txt
+++ b/scripts/stress-baseline.txt
@@ -9,7 +9,7 @@ PASS|multipart-upload
 PASS|last-modified
 PASS|large-object
 PASS|concurrent-put
-FAIL|partial-put
+PASS|partial-put
 PASS|torn-overwrite
 PASS|stale-shard
 PASS|freeze


### PR DESCRIPTION
## Summary

Two stress scenarios were excluded from the E2E gate. Neither exclusion held up, and one of them was hiding a real regression.

## partial-put: a P1 regression from #112

`bulkBody` releases the 50s `requestDeadline` for the handlers that move object data, and its comment names the blob client's idle guard as the replacement bound. That guard only ever wrapped the **gate to blob node** leg, and it aborts by cancelling a stream to a blob node — which cannot interrupt a read blocked on the client's own connection. Nothing bounded the client-to-gate body at all.

A client declaring 4 MiB, sending 1 MiB and then stopping held a gate goroutine and its connection until it disconnected 180s later. The scenario demonstrates eight concurrently.

**This is a regression, not a pre-existing defect.** `bulkBody` does not appear in `00df3b1^:internal/gate/middleware.go`; #112 introduced it. Before that a flat 50s deadline applied to every request including PutObject, which cut a stalled body off inside the scenario's 90s bound. `scripts/stress-baseline.txt` recorded `PASS|partial-put` at `2d80d9f` on 2026-08-31; #112 landed 09:36 the next day and the baseline was re-recorded `FAIL` at 14:32.

The 50s/170s bimodality noted in `mulga-8lxge` is the same bug in two orderings: ~50002ms is the old deadline winning the race against `stopper.stop()`, ~170007ms is `stopper.stop()` winning. Neither is a timeout value — `inFlightWatch` samples at 5s then every 15s, so 170007ms is just the last sample before the client gave up at 180s.

### The fix

`bulkBody` now **swaps** the total cap for a progress bound rather than dropping it. The body is wrapped in an `IdleGuard` whose abort moves the connection's read deadline into the past, which unblocks a read already in flight. The reason a total cap was wrong in the first place still holds: a transfer that keeps moving is never cut off, however large.

```
before  gate still ran the request at 170007ms, past the 90s bound
after   outcome=responded status=500 elapsed_ms=30009
```

Both protocols — h2 does support `SetReadDeadline`, which the old comment doubted. The client gets a 500 rather than a dropped connection.

Two unit tests, with the negative control checked: `IdleGuard` treats `idle <= 0` as a passthrough, so `bulkBodyWithin(0, ...)` reproduces the pre-fix behaviour exactly and the test fails against it.

## multipart-upload: never flaky

Recorded as dying while restarting its cluster between part sizes. That was never the cause. `complete-multipart-upload` was the only bulk call in the harness without an explicit `--cli-read-timeout`, so it took the AWS CLI's 60s default while the work measures 63-68s.

Five runs on unchanged `dev`: 2 pass / 3 fail, with `Read timeout on endpoint URL` in exactly the three failures. Five runs with the timeout: 5 pass, completions 68/66/63/65/63s — every one above the old default, so all five would have failed without it. The lone earlier pass measured 58s, which is why the failure rate looked like chance.

## The coverage gap, which is the part worth reading

`a4330a3` removed both from the default set citing "the spinifex nightly already runs the full suite". For partial-put that was not true. The nightly runs bare `make e2e-stress`, which is `SCENARIO=all`, and partial-put was the **only** one of the thirteen with no `all` branch — since the day it was written. So from 2026-09-01 it ran nowhere: not in the predastore gate, not in the nightly.

It now has an `all` branch, so `make e2e-stress` and the nightly both cover it.

## Changes

- `internal/gate/middleware.go` — `bulkBody` installs the progress bound; `setReadDeadline` split out so only the read side moves.
- `internal/transport/deadline.go` — `NewAbortGuard`, for a stall ended by something other than a stream.
- `internal/gate/deadline_test.go` — abandons a stalled body; does not bound one still arriving.
- `scripts/bench/e2e-stress.sh` — explicit CLI timeouts on multipart completion; `partial-put` gains its `all` branch.
- `.github/workflows/predastore-e2e.yml` — all thirteen scenarios in the default set.
- `scripts/stress-baseline.txt`, `Makefile`, `README_E2E.md` — baseline records thirteen green; stale comments corrected.

## Verification

E2E run 33920560881: **16/16 green**, all thirteen scenarios plus S3 compatibility and the bare-metal Warp job. `partial-put` also run locally on this workstation, 18/18.

Gate RSS across 8 stalled uploads declaring 512 MiB each is 105 to 111 MB, so reserved is not resident. The declared-`Content-Length` shard pre-allocation is real but not acute; split out as `mulga-egu68`.