### PR TITLE
fix: guard the slow-shard floor, and sweep object sizes from 1 byte to 128 KiB

### DIFF
--- a/.github/workflows/predastore-e2e.yml
+++ b/.github/workflows/predastore-e2e.yml
@@ -34,7 +34,7 @@ on:
         required: false
         default: ""
       stress_scenarios:
-        description: "Stress scenarios to run (empty = all thirteen)"
+        description: "Stress scenarios to run (empty = all fourteen)"
         required: false
         default: ""
       run_performance:
@@ -117,7 +117,7 @@ jobs:
           REQUESTED: ${{ inputs.stress_scenarios }}
         run: |
           set -euo pipefail
-          default="repair handoff node-rejoin node-resync node-rebuild last-modified large-object concurrent-put torn-overwrite stale-shard freeze multipart-upload partial-put"
+          default="repair handoff node-rejoin node-resync node-rebuild last-modified large-object concurrent-put torn-overwrite stale-shard object-sizes freeze multipart-upload partial-put"
           # shellcheck disable=SC2086
           printf '%s\n' ${REQUESTED:-$default} | jq -Rsc 'split("\n") | map(select(length > 0))' \
             | sed 's/^/scenarios=/' >> "$GITHUB_OUTPUT"

--- a/internal/gate/handlers/clock_test.go
+++ b/internal/gate/handlers/clock_test.go
@@ -1,8 +1,13 @@
 package handlers
 
 import (
+	"context"
+	"io"
 	"sync"
 	"time"
+
+	"github.com/mulgadc/predastore/internal/blob"
+	"github.com/mulgadc/predastore/internal/config"
 )
 
 // testClock is a clock that only moves when a test moves it. Time passing then
@@ -170,3 +175,50 @@ func (p *shardPacer) await(self int, ok func(*shardProgress) bool) {
 func frozenClock() stripeOption {
 	return withClock(newTestClock())
 }
+
+// latencyBlob charges a stated latency to every shard body it serves. A small
+// object arrives in one read, so its active window is whatever the machine took
+// to copy a few bytes between goroutines -- somewhere between zero and a
+// microsecond, and different on every run. Charging the latency explicitly makes
+// how fast a shard was delivered a property of the test rather than of the box.
+type latencyBlob struct {
+	*fakeBlob
+
+	clk     *testClock
+	latency time.Duration
+}
+
+func newLatencyBlob(bc *fakeBlob, latency time.Duration) *latencyBlob {
+	return &latencyBlob{fakeBlob: bc, clk: newTestClock(), latency: latency}
+}
+
+func (b *latencyBlob) Get(ctx context.Context, node config.NodeID, req blob.GetRequest) (io.ReadCloser, error) {
+	rc, err := b.fakeBlob.Get(ctx, node, req)
+	if err != nil {
+		return rc, err
+	}
+
+	return &latencyReader{ReadCloser: rc, blob: b}, nil
+}
+
+// latencyReader advances the clock once, on the read that delivers the first
+// bytes. That is the moment progress records as lastAt, so the shard's active
+// window becomes exactly the latency and nothing else.
+type latencyReader struct {
+	io.ReadCloser
+
+	blob    *latencyBlob
+	charged bool
+}
+
+func (r *latencyReader) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	if n > 0 && !r.charged {
+		r.charged = true
+		r.blob.clk.Advance(r.blob.latency)
+	}
+
+	return n, err
+}
+
+var _ BlobClient = (*latencyBlob)(nil)

--- a/internal/gate/handlers/objectsizes_test.go
+++ b/internal/gate/handlers/objectsizes_test.go
@@ -1,0 +1,246 @@
+// The read path had no test below 64 KiB and the write path none between 8 KiB
+// and 1 MiB, so an assumption about what a rate means for a small object went
+// in as a constant with nothing positioned to disagree with it. These are the
+// tests that disagree: a ladder from one byte to 128 KiB through the real write
+// and read paths, and the throughput floor stated exactly rather than observed.
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/predastore/internal/gate/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// objectSizeLadder is chosen rather than stepped. 1-16 sits below and around
+// the shard count, where a data shard can be pure padding; 96, 297 and 489 are
+// the sizes the e2e cells were writing when they produced 195 spurious slow
+// shard warnings between them; the rest are boundaries and their neighbours,
+// doubling to 128 KiB.
+//
+// Nothing here reaches streamBlockSize. Multi-block reads are covered in
+// streamread_test.go, and repeating them would make a millisecond test slow.
+var objectSizeLadder = []int{
+	1, 2, 3, 4, 5, 7, 8, 15, 16,
+	96, 297, 489,
+	511, 512, 1024, 2048,
+	4095, 4096, 4097, 8192,
+	16384, 32768, 65536, 131072,
+}
+
+// objectSizeKeys is how many keys each size is written under. Placement is
+// derived from the object hash, so the key decides which nodes hold the shards:
+// one key exercises one placement and sixteen exercise the ring.
+const objectSizeKeys = 16
+
+// slowShardWarning is the message the floor emits. Named once so the tests that
+// assert on its absence and the one that asserts on its presence cannot drift.
+const slowShardWarning = "Shard delivered below the throughput floor"
+
+// The floor is a rate, and a rate needs a window long enough to be a
+// measurement. For a shard that arrives in one read the window is the round
+// trip, so this states which reads may be judged at all.
+func TestShardBelowFloorIgnoresAShardTooSmallToTime(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		bytes  int64
+		active time.Duration
+		want   bool
+	}{
+		// The field case. One shard of a 297-byte object at RS(2,1) is 149
+		// bytes, and clearing 8 MiB/s on it needs an 18us round trip.
+		{"a shard of a 297 byte object over a LAN round trip", 149, 100 * time.Microsecond, false},
+		{"the same shard over a round trip ten times worse", 149, time.Millisecond, false},
+		{"a four byte object", 2, 50 * time.Microsecond, false},
+		{"a 128 KiB object's shard", 64 << 10, 200 * time.Microsecond, false},
+
+		// The boundary, stated from both sides.
+		{"one byte under the minimum, delivered slowly", slowShardMinBytes - 1, time.Second, false},
+		{"exactly the minimum, delivered slowly", slowShardMinBytes, time.Second, true},
+
+		// Above the minimum the rate is the whole of the decision, which is
+		// what the floor was written to say and still says.
+		{"a large shard delivered fast", 64 << 20, time.Second, false},
+		{"a large shard delivered slowly", 4 << 20, 2 * time.Second, true},
+		{"a large shard exactly at the floor", slowShardFloor, time.Second, false},
+		{"a large shard a hair under the floor", slowShardFloor - 1, time.Second, true},
+
+		// A shard whose window did not register cannot be divided by.
+		{"no measurable window", 4 << 20, 0, false},
+		{"a negative window", 4 << 20, -time.Second, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equalf(t, tc.want, shardBelowFloor(tc.bytes, tc.active),
+				"%d bytes in %s", tc.bytes, tc.active)
+		})
+	}
+}
+
+// The ladder itself, through the real write and read paths. Sixteen keys per
+// size because placement follows the key: this is a sweep over placements as
+// much as over sizes.
+func TestObjectSizeLadderRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	codes := []struct {
+		name         string
+		data, parity int
+	}{
+		// The unencoded fast path, which has to produce what the general path
+		// would at every size and was pinned at five of them.
+		{"RS(1,0)", 1, 0},
+		{"RS(2,1)", 2, 1},
+		{"RS(4,2)", 4, 2},
+	}
+
+	for _, code := range codes {
+		t.Run(code.name, func(t *testing.T) {
+			t.Parallel()
+			for _, size := range objectSizeLadder {
+				t.Run(fmt.Sprintf("%d-bytes", size), func(t *testing.T) {
+					t.Parallel()
+					ctx := context.Background()
+					f := newWriteFixture(code.data, code.parity)
+
+					for i := range objectSizeKeys {
+						key := fmt.Sprintf("prefix-%02d/object-%d.bin", i, size)
+						want := randomBytes(t, size)
+						objectHash := model.ObjectHash("sizes", key)
+
+						place, _, err := f.write(ctx, objectHash, bytes.NewReader(want), int64(size))
+						require.NoErrorf(t, err, "writing %d bytes to %s", size, key)
+						require.Equalf(t, int64(size), place.Size,
+							"the placement of %s records the size written", key)
+
+						got, degraded, err := readObject(ctx, f.bc, f.cfg, "sizes", key, place, place.Size, 0)
+						require.NoErrorf(t, err, "reading %d bytes back from %s", size, key)
+						assert.Zerof(t, degraded, "%s read cleanly, so nothing was reconstructed", key)
+						assert.Equalf(t, want, got, "%d bytes round-tripped through %s", size, key)
+					}
+				})
+			}
+		})
+	}
+}
+
+// The shard arithmetic every size in the ladder rests on, stated separately
+// because a round trip that is wrong in both directions still passes.
+func TestObjectSizeLadderShardsAreExactlyLargeEnough(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(2, 1)
+	ctx := context.Background()
+
+	for _, size := range objectSizeLadder {
+		t.Run(fmt.Sprintf("%d-bytes", size), func(t *testing.T) {
+			t.Parallel()
+			key := fmt.Sprintf("layout/object-%d.bin", size)
+			objectHash := model.ObjectHash("sizes", key)
+			place, _, err := f.write(ctx, objectHash, bytes.NewReader(randomBytes(t, size)), int64(size))
+			require.NoError(t, err)
+
+			lay := newLayout(f.cfg.DataShards, place.Size, place.BlockSize)
+
+			// Every size here is smaller than a block, so each shard is one
+			// block and the shards together cover the object with less than a
+			// shard of padding.
+			assert.Equal(t, lay.shardSize, lay.blockSize, "a sub-block object is one block per shard")
+			assert.GreaterOrEqual(t, lay.shardSize*int64(f.cfg.DataShards), int64(size),
+				"the data shards hold the whole object")
+			assert.Less(t, (lay.shardSize-1)*int64(f.cfg.DataShards), int64(size),
+				"a shard smaller by one would not, so none of them is padding alone")
+		})
+	}
+}
+
+// The regression. Every object in the ladder is delivered at a plausible LAN
+// round trip and none of them may be reported as a slow shard: at these sizes
+// the window the rate is computed over is the round trip itself.
+//
+// Not parallel -- it captures the default logger, which is process-wide.
+func TestASmallObjectDoesNotWarnAboutItsShards(t *testing.T) {
+	logged := captureWarnings(t)
+	ctx := context.Background()
+
+	// Ten times a loopback round trip and still ten times too slow to clear the
+	// floor on any size here, which is the point: no plausible latency lets a
+	// small object pass a throughput bar.
+	const latency = 500 * time.Microsecond
+
+	for _, size := range objectSizeLadder {
+		f := newWriteFixture(2, 1)
+		paced := newLatencyBlob(f.bc, latency)
+
+		for i := range objectSizeKeys {
+			key := fmt.Sprintf("quiet-%02d/object-%d.bin", i, size)
+			want := randomBytes(t, size)
+			objectHash := model.ObjectHash("sizes", key)
+
+			place, _, err := f.write(ctx, objectHash, bytes.NewReader(want), int64(size))
+			require.NoError(t, err)
+
+			got, _, err := readObject(ctx, paced, f.cfg, "sizes", key, place, place.Size, 0,
+				withClock(paced.clk))
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+		}
+
+		assert.Zerof(t, strings.Count(logged.String(), slowShardWarning),
+			"a %d byte object served in %s named a node for being slow:\n%s",
+			size, latency, logged.String())
+		logged.Reset()
+	}
+}
+
+// The other half of the same statement: the floor still fires on a shard large
+// enough for the rate to mean something. Without this the test above passes on
+// a floor that was deleted rather than guarded.
+func TestALargeSlowShardIsStillNamed(t *testing.T) {
+	logged := captureWarnings(t)
+	ctx := context.Background()
+
+	// A shard well past the minimum, delivered over a window long enough that
+	// the rate lands under the floor.
+	const size = 2 << 20
+	f := newWriteFixture(2, 1)
+	paced := newLatencyBlob(f.bc, time.Second)
+
+	key := "slow/object.bin"
+	objectHash := model.ObjectHash("sizes", key)
+	want := randomBytes(t, size)
+	place, _, err := f.write(ctx, objectHash, bytes.NewReader(want), int64(size))
+	require.NoError(t, err)
+
+	got, _, err := readObject(ctx, paced, f.cfg, "sizes", key, place, place.Size, 0, withClock(paced.clk))
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+
+	assert.Containsf(t, logged.String(), slowShardWarning,
+		"a %d byte shard delivered in a second is slow and must say so", size/2)
+}
+
+// captureWarnings redirects the default logger into a buffer for the length of
+// the test. Both callers assert on what the gate did or did not log, which is
+// the only place the throughput floor is observable from.
+func captureWarnings(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var out bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&out, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	return &out
+}

--- a/internal/gate/handlers/shards.go
+++ b/internal/gate/handlers/shards.go
@@ -862,6 +862,25 @@ func reportDegradedRead(ctx context.Context, bucket, key string, failures []shar
 // healthy for a large block and hopeless for a small one.
 const slowShardFloor = 8 << 20 // bytes per second
 
+// slowShardMinBytes is the least a shard may deliver before its rate is worth
+// reading at all. A shard this size takes 32ms at the floor, well clear of the
+// round trip that would otherwise be the whole of the window it is timed over.
+const slowShardMinBytes = 256 << 10
+
+// shardBelowFloor reports whether a shard delivered slowly enough to name its
+// node for. A shard that arrived in one round trip is not judged: active is
+// then the latency, and bytes over a latency is not a throughput.
+//
+// Losing the small-object case costs no coverage. A degrading node shows up in
+// stalls, in the hedge and in connection eviction, none of which is a rate.
+func shardBelowFloor(bytes int64, active time.Duration) bool {
+	if bytes < slowShardMinBytes || active <= 0 {
+		return false
+	}
+
+	return bytes*int64(time.Second)/int64(active) < slowShardFloor
+}
+
 // hedgeProbeInterval is how often the stripe loop asks whether a shard is still
 // delivering. Fine enough that a stall is caught well inside the delay, coarse
 // enough to cost nothing on a healthy read.

--- a/internal/gate/handlers/streamread.go
+++ b/internal/gate/handlers/streamread.go
@@ -540,13 +540,11 @@ func (r *stripeReader) reportShard(ctx context.Context, index int, node config.N
 		Longest: time.Duration(p.longest.Load()),
 	})
 
-	if active <= 0 {
-		return
-	}
-	if rate := bytes * int64(time.Second) / int64(active); rate < slowShardFloor {
+	if shardBelowFloor(bytes, active) {
 		slog.WarnContext(ctx, "Shard delivered below the throughput floor",
 			"node", node, "index", index, "bytes", bytes,
-			"rate_KiBps", rate/1024, "stalls", p.stalls.Load(),
+			"rate_KiBps", bytes*int64(time.Second)/int64(active)/1024,
+			"stalls", p.stalls.Load(),
 			"longest_stall_ms", time.Duration(p.longest.Load()).Milliseconds())
 	}
 }

--- a/scripts/bench/e2e-stress.sh
+++ b/scripts/bench/e2e-stress.sh
@@ -22,8 +22,8 @@
 #                      "node-rejoin", "node-resync", "node-rebuild",
 #                      "multipart-upload", "last-modified", "large-object",
 #                      "concurrent-put", "torn-overwrite", "stale-shard",
-#                      "freeze", or "partial-put" — a client that stops sending
-#                      mid-body. Unset runs all thirteen.
+#                      "object-sizes", "freeze", or "partial-put" — a client
+#                      that stops sending mid-body. Unset runs all fourteen.
 #   STRESS_CONFIG      Profile to run (default: 4host)
 #   STRESS_HOST        "follower" (default), "leader", or an explicit host id.
 #                      The role is resolved against the running cluster, since
@@ -55,6 +55,12 @@
 #   STRESS_LARGE_SIZES Object sizes the large-object scenario writes and reads
 #                      (default: "2GiB 4GiB"). A size with no room on disk is
 #                      skipped loudly, never silently.
+#   STRESS_SIZES       The object-sizes ladder, in bytes (default: 4 through
+#                      131072). Every size is below one stream block, so the
+#                      scenario is about small objects and stays that way.
+#   STRESS_SIZE_KEYS   Keys written per size (default: 16). Placement follows
+#                      the object hash, so this is how many placements each
+#                      size is exercised over rather than repetition.
 #   STRESS_WORK_ROOT   Where the cluster work directory is created. Defaults to
 #                      TMPDIR, except when large-object is in the run: TMPDIR is
 #                      often tmpfs, which is RAM-backed, so it would both cap
@@ -88,7 +94,7 @@ STALE_KEYS="${STRESS_STALE_KEYS:-12}"
 SCENARIO="${STRESS_SCENARIO:-all}"
 case "$SCENARIO" in
     all|freeze|partial-put|torn-overwrite|stale-shard|repair|handoff|large-object|multipart-upload) ;;
-    last-modified|concurrent-put) ;;
+    last-modified|concurrent-put|object-sizes) ;;
     node-rejoin|node-resync|node-rebuild) ;;
     *) echo "unknown STRESS_SCENARIO: $SCENARIO" >&2; exit 1 ;;
 esac
@@ -1717,6 +1723,157 @@ LM_BUCKET="stress-lastmod"
 LM_FAILURES=0
 LM_CASES=0
 
+# --- Scenario: object-sizes ---
+#
+# Every other scenario here writes megabytes. The sizes a control plane actually
+# stores are much smaller — a placement record, a volume state document, a piece
+# of user data — and nothing was reading one back across nodes.
+#
+# What that missed: the gate judged every shard read against an 8 MiB/s
+# throughput floor with no minimum size, and for an object that arrives in one
+# read the window it divides by is the round trip. 195 warnings across two e2e
+# cells were all on objects of 297-489 bytes, all naming one node, and were read
+# as a blob node degrading.
+#
+# So this is a ladder rather than a size: small enough to be latency-bound, wide
+# enough that a padding or rounding error at a shard boundary has somewhere to
+# show, and written under many keys because placement follows the object hash.
+# One key exercises one placement; sixteen exercise the ring.
+
+SIZES_CLUSTER="${CONFIG_NAME}-sizes"
+SIZES_CONFIG="$PREDA_CONFIG_DIR/$SIZES_CLUSTER.toml"
+SIZES_BUCKET="stress-sizes"
+SIZES_LADDER="${STRESS_SIZES:-4 8 96 297 489 512 1024 2048 4096 8192 16384 32768 65536 131072}"
+SIZES_KEYS="${STRESS_SIZE_KEYS:-16}"
+SIZES_FAILURES=0
+SIZES_CASES=0
+
+# The warning this scenario exists to keep out of the logs. Matched as a fixed
+# string against every node log, since a gate names its own node in the line.
+SIZES_FLOOR_WARNING="Shard delivered below the throughput floor"
+
+sizes_check() {
+    local ok="$1" message="$2"
+    SIZES_CASES=$(( SIZES_CASES + 1 ))
+    if [ "$ok" = true ]; then
+        log "object-sizes: pass, $message"
+    else
+        log "object-sizes: FAIL $message"
+        SIZES_FAILURES=$(( SIZES_FAILURES + 1 ))
+    fi
+}
+
+render_sizes_profile() {
+    render_profile "$CONFIG_DIR/$CONFIG_NAME.toml" "$SIZES_CONFIG" "$(( PORT_OFFSET + 800 ))"
+    pin_availability "$SIZES_CONFIG" false false
+    pin_repair_off "$SIZES_CONFIG"
+    cat >> "$SIZES_CONFIG" <<EOF
+
+[[bucket]]
+name = "$SIZES_BUCKET"
+region = "$REGION"
+public = true
+account_id = "123456789012"
+EOF
+    cp "$SIZES_CONFIG" "$RUN_DIR/$SIZES_CLUSTER.toml"
+}
+
+run_object_sizes() {
+    local results="$RUN_DIR/object-sizes.tsv"
+    local gate read_gate size i key src dst bad short floor_lines log_file
+    local content_length
+
+    render_sizes_profile
+    log "object-sizes: starting $SIZES_CLUSTER"
+    "$SCRIPTS_DIR/start.sh" -w "$SIZES_CLUSTER"
+
+    gate="$(parse_hosts "$SIZES_CONFIG" | awk '!f && $3 != "" { print "https://" $2 ":" $3; f = 1 }')"
+    [ -n "$gate" ] || fail "object-sizes: no gate in $SIZES_CLUSTER"
+    read_gate="$(survivor_gate "$SIZES_CONFIG" "$(parse_hosts "$SIZES_CONFIG" | awk 'NR == 1 { print $1 }')")"
+    [ -n "$read_gate" ] \
+        || fail "object-sizes: $SIZES_CLUSTER has only one gate, so a read cannot come from another"
+    log "object-sizes: writing through $gate, reading back through $read_gate, $SIZES_KEYS keys per size"
+
+    printf 'size\tkeys\tmismatched\twrong_length\tverdict\n' > "$results"
+
+    src="$WORK_DIR/sizes-src.bin"
+    dst="$WORK_DIR/sizes-got.bin"
+
+    for size in $SIZES_LADDER; do
+        bad=0
+        short=0
+        for (( i = 0; i < SIZES_KEYS; i++ )); do
+            key="$(printf 'prefix-%02d/object-%d.bin' "$i" "$size")"
+            openssl rand -out "$src" "$size"
+
+            if ! aws_s3 "$gate" s3api put-object --bucket "$SIZES_BUCKET" --key "$key" \
+                --body "$src" >/dev/null 2>>"$RUN_DIR/object-sizes-errors.txt"; then
+                bad=$(( bad + 1 ))
+                continue
+            fi
+
+            # The read deliberately goes to a host that did not accept the
+            # write, so the shards cross the wire from nodes that have them
+            # only because the encode put them there.
+            #
+            # ContentLength comes off the GET rather than a third call: padding
+            # squares the last stripe, so an object that compares equal can
+            # still be served with the padded length, and this is the length
+            # the client was actually given.
+            content_length="$(aws_s3 "$read_gate" s3api get-object --bucket "$SIZES_BUCKET" \
+                --key "$key" --query ContentLength --output text \
+                "$dst" 2>>"$RUN_DIR/object-sizes-errors.txt")" || content_length=""
+            if [ -z "$content_length" ]; then
+                bad=$(( bad + 1 ))
+                continue
+            fi
+            cmp -s "$src" "$dst" || bad=$(( bad + 1 ))
+            [ "$content_length" = "$size" ] || short=$(( short + 1 ))
+        done
+
+        # HEAD is a different handler from GET and answers from the placement
+        # record rather than the stream, so one key per size is headed too.
+        key="$(printf 'prefix-00/object-%d.bin' "$size")"
+        content_length="$(aws_s3 "$read_gate" s3api head-object --bucket "$SIZES_BUCKET" \
+            --key "$key" --query ContentLength --output text 2>>"$RUN_DIR/object-sizes-errors.txt")"
+        sizes_check "$([ "$content_length" = "$size" ] && echo true || echo false)" \
+            "HEAD answers $size bytes for $key (got ${content_length:-nothing})"
+
+        if [ "$bad" -eq 0 ] && [ "$short" -eq 0 ]; then
+            printf '%s\t%s\t0\t0\tok\n' "$size" "$SIZES_KEYS" >> "$results"
+        else
+            printf '%s\t%s\t%s\t%s\tfailed\n' "$size" "$SIZES_KEYS" "$bad" "$short" >> "$results"
+        fi
+        sizes_check "$([ "$bad" -eq 0 ] && echo true || echo false)" \
+            "all $SIZES_KEYS keys at $size bytes round-tripped through a second gate ($bad mismatched)"
+        sizes_check "$([ "$short" -eq 0 ] && echo true || echo false)" \
+            "every GET at $size bytes was served that length ($short wrong)"
+    done
+    rm -f "$src" "$dst"
+
+    # The cluster is fresh and this scenario is its only workload, so any
+    # occurrence of the floor warning belongs to the ladder above — and every
+    # size in it is far too small for a throughput to have been measured.
+    floor_lines=0
+    for log_file in "$PREDA_DIR/$SIZES_CLUSTER/logs"/*; do
+        [ -f "$log_file" ] || continue
+        floor_lines=$(( floor_lines + $(grep -cF "$SIZES_FLOOR_WARNING" "$log_file" || true) ))
+    done
+    printf 'floor_warnings\t%s\n' "$floor_lines" >> "$results"
+    sizes_check "$([ "$floor_lines" -eq 0 ] && echo true || echo false)" \
+        "no node reported a shard below the throughput floor for a sub-128KiB object ($floor_lines lines)"
+
+    log "object-sizes: stopping $SIZES_CLUSTER"
+    "$SCRIPTS_DIR/stop.sh" -w "$SIZES_CLUSTER" >/dev/null 2>&1 || true
+    mkdir -p "$RUN_DIR/logs-sizes"
+    cp -R "$PREDA_DIR/$SIZES_CLUSTER/logs/." "$RUN_DIR/logs-sizes/" 2>/dev/null || true
+    if [ "$SIZES_FAILURES" -eq 0 ]; then
+        log "object-sizes: passed $SIZES_CASES assertions"
+    else
+        log "object-sizes: FAILED $SIZES_FAILURES of $SIZES_CASES assertions"
+    fi
+}
+
 lm_check() {
     local ok="$1" message="$2"
     LM_CASES=$(( LM_CASES + 1 ))
@@ -1923,6 +2080,17 @@ if [ "$SCENARIO" = all ] || [ "$SCENARIO" = large-object ]; then
         echo "Stress results: $RUN_DIR"
         [ "$LARGE_FAILURES" -eq 0 ] \
             || fail "large-object failed $LARGE_FAILURES of $LARGE_CASES assertions"
+        exit 0
+    fi
+fi
+
+if [ "$SCENARIO" = all ] || [ "$SCENARIO" = object-sizes ]; then
+    run_object_sizes
+
+    if [ "$SCENARIO" = object-sizes ]; then
+        echo "Stress results: $RUN_DIR"
+        [ "$SIZES_FAILURES" -eq 0 ] \
+            || fail "object-sizes failed $SIZES_FAILURES of $SIZES_CASES assertions"
         exit 0
     fi
 fi

--- a/scripts/bench/stress-gate.sh
+++ b/scripts/bench/stress-gate.sh
@@ -40,7 +40,7 @@ ALL_SCENARIOS=(
     repair handoff
     node-rejoin node-resync node-rebuild
     multipart-upload last-modified large-object concurrent-put
-    partial-put torn-overwrite stale-shard freeze
+    partial-put torn-overwrite stale-shard object-sizes freeze
 )
 
 if [ $# -gt 0 ]; then

--- a/scripts/stress-baseline.txt
+++ b/scripts/stress-baseline.txt
@@ -12,4 +12,5 @@ PASS|concurrent-put
 PASS|partial-put
 PASS|torn-overwrite
 PASS|stale-shard
+PASS|object-sizes
 PASS|freeze


### PR DESCRIPTION
## The bug

`shards.go` sets `slowShardFloor = 8 << 20` bytes/sec and `streamread.go` compared every shard read against it with no minimum-size guard. The denominator is the problem: `active` comes from `shardProgress.finish()` as `lastAt - blockStart`, and for an object small enough to arrive in one `Read` there is exactly one `advance`, so `active` collapses to the time-to-first-byte. **The rate is computed over a round trip rather than a transfer window**, and a 297-byte object would have to be served in 36µs to clear 8 MiB/s. The check could not pass.

The constant's own comment reasons about the case it was written for — "two seconds is healthy for a large block and hopeless for a small one" — and a rate is the right answer to that. The inverse was never considered.

Observed in the spinifex e2e nightly: 176 warnings in cell-20 and 19 in cell-28, every one of them on an object of 297–489 bytes, and all 176 naming `node 2, index 0`. That reads as one blob node degrading and is nothing of the sort.

**This is log noise, not a failed read.** cell-28 passed with the floor count going *up*, 19 → 27, which is the independent evidence that it is uncorrelated with outcome. The cost was diagnostic: it was nearly filed as the cause of cell-28. Analysis is class H of `docs/development/improvements/ci-review.md` in mulga; bead `mulga-55cid`.

## The fix

`slowShardMinBytes = 256 << 10`, checked before the rate. A shard that size takes 32ms at the floor, two orders of magnitude clear of the round trip it would otherwise be timed over. The decision moves into a `shardBelowFloor(bytes, active)` predicate so it can be stated in a test without a clock, a blob node or a log.

Nothing about what is *measured* changes — `RecordShardRead` still carries `Bytes` and `Active` for every shard at every size, so the rate stays derivable downstream. This narrows what is warned about.

What it gives up is nothing real: objects under 512 KiB on RS(2,1) no longer report a slow shard, and they never usefully did. A degrading node surfaces through `stalls`, the hedge (`HedgeNoTTFB`, `HedgeStall`) and connection eviction, all of which are size-independent and none of which is touched here.

## The coverage gap, which is the larger half

The guard is six lines. The reason it shipped is that **the read path had no test below 64 KiB and the write path none between 8 KiB and 1 MiB**, so an assumption about what a rate means could sit in a constant with nothing positioned to disagree with it.

`internal/gate/handlers/objectsizes_test.go` adds a ladder of 24 sizes from 1 byte to 128 KiB — `1 2 3 4 5 7 8 15 16 96 297 489 511 512 1024 2048 4095 4096 4097 8192 16384 32768 65536 131072` — chosen rather than stepped: below the shard count, the field sizes, the ±1 neighbours of a boundary, then doubling. It runs across RS(1,0), RS(2,1) and RS(4,2), **16 keys per size**. The keys are not repetition — placement is derived from `model.ObjectHash(bucket, key)`, so one key exercises one placement and sixteen exercise the ring.

Nothing in the ladder reaches `streamBlockSize`; multi-block reads are already covered in `streamread_test.go` and repeating them would make a millisecond test slow.

A note on why the log assertion needed a paced clock: the fake blob is fast enough that `active` is sometimes zero, which the early return skips, so the warning reproduces *stochastically* against it. `latencyBlob` charges a stated latency to the read that delivers the first bytes, which makes how fast a shard was delivered a property of the test rather than of the box.

## The multi-node scenario

A fourteenth stress scenario, `object-sizes`, runs the same ladder against a four-host RS(2,1) cluster through `aws s3api`. Every object is **read back through a gate that did not accept its write**, so the shards cross the wire from nodes that hold them only because the encode put them there. `ContentLength` is taken off the GET, which is the length the client was actually served; `head-object` still runs once per size because HEAD answers from the placement record rather than the stream. Afterwards it greps every node log for the warning and fails if the count is not zero.

Registered in all four places a scenario has to be — the `case` validation, `ALL_SCENARIOS` in `stress-gate.sh`, the `default=` list in the workflow, and `stress-baseline.txt`. Missing one of those is how `partial-put` came to have no coverage anywhere while being recorded as covered.

## Both layers were run against the bug first

A test that passes with and without the fix is not a regression test, so the guard was reverted and both layers re-run. Both fail, and on the field input rather than a contrived one.

Unit, with `slowShardMinBytes` removed from the predicate:

```
--- FAIL: TestShardBelowFloorIgnoresAShardTooSmallToTime
    --- FAIL: .../a_shard_of_a_297_byte_object_over_a_LAN_round_trip
    --- FAIL: .../the_same_shard_over_a_round_trip_ten_times_worse
    --- FAIL: .../a_four_byte_object
    --- FAIL: .../one_byte_under_the_minimum,_delivered_slowly
--- FAIL: TestASmallObjectDoesNotWarnAboutItsShards
```

E2E, `s3d` rebuilt from the same unguarded tree, real four-host cluster on `10.11.12.1–.4`:

```
object-sizes: FAIL no node reported a shard below the throughput floor
              for a sub-128KiB object (10 lines)
object-sizes: FAILED 1 of 3 assertions
```

Ten warnings from eight keys at 297 bytes — this PR's own signature, reproduced on demand.

`TestALargeSlowShardIsStillNamed` is the other half of the statement: a 2 MiB shard delivered over a second must still be named. Without it the sweep would pass just as well against a floor that had been deleted rather than guarded.

## Testing

| check | result |
| --- | --- |
| `go test -run 'ObjectSize\|ShardBelowFloor\|SmallObject\|LargeSlowShard' -count=5` | pass |
| `go test -race ./internal/gate/handlers/` | pass, 28.6s |
| `make preflight` | pass — lint 0 issues, govulncheck clean |
| `shellcheck scripts/bench/e2e-stress.sh` | clean |
| `STRESS_SCENARIO=object-sizes ./scripts/bench/e2e-stress.sh` | **43 assertions, 0 failures, 0 floor warnings** |

Every size, all sixteen keys:

```
size    keys  mismatched  wrong_length  verdict
4       16    0           0             ok
8       16    0           0             ok
96      16    0           0             ok
297     16    0           0             ok
489     16    0           0             ok
512     16    0           0             ok
1024    16    0           0             ok
2048    16    0           0             ok
4096    16    0           0             ok
8192    16    0           0             ok
16384   16    0           0             ok
32768   16    0           0             ok
65536   16    0           0             ok
131072  16    0           0             ok
floor_warnings  0
```

**Runtime: about 11 minutes** — 14 sizes × 16 keys × 2 AWS CLI invocations, and the CLI's own startup is roughly 1.4s of each. Second-longest scenario after `large-object`, inside the 30-minute leg timeout with room, and on its own hosted runner under `fail-fast: false` so it does not extend the critical path past itself. `STRESS_SIZES` and `STRESS_SIZE_KEYS` narrow both dimensions for debugging.

## Deliberately out of scope

That `active` conflates time-to-first-byte with transfer time for a single-block read is the deeper oddity here and is worth its own look. Changing what the telemetry means is a larger change than removing a false warning and does not belong in the same commit as a coverage fix.

The genuinely real signal in the same journals — `evicting unresponsive connection node=3 stalls=3`, three times in cell-20 — is not size-dependent and is untouched. Removing the noise should not also remove attention from the thing beside it.