### PR TITLE
perf: put the loopback benchmark's shards on an SSD, not the boot volume

### DIFF
--- a/.github/workflows/predastore-e2e.yml
+++ b/.github/workflows/predastore-e2e.yml
@@ -348,6 +348,14 @@ jobs:
         if: steps.gate.outputs.paused != 'true'
         run: make warp-install
 
+      # Not fatal: an unset variable falls back to TMPDIR, which is what this
+      # job did before. It is worth saying out loud though, because the fallback
+      # is the slow boot volume and the only other place that shows is the
+      # work_root line in run-info.txt.
+      - name: Warn if the loopback work root is unset
+        if: steps.gate.outputs.paused != 'true' && vars.PREDASTORE_PERF_WORK_ROOT == ''
+        run: echo "::warning::PREDASTORE_PERF_WORK_ROOT is unset, so the loopback shards land on the runner's boot volume and the PUT numbers measure that disk."
+
       # The bare-metal numbers have no denominator without this. The same code
       # and the same workloads with the network taken out is what says whether
       # three hosts are worth having, and PERF_CONFIGS covers 1host and 3host.
@@ -364,6 +372,12 @@ jobs:
           # /tmp here may be tmpfs and a 30s PUT workload stages gigabytes
           # through it, so the script's work directory is steered off it.
           TMPDIR: ${{ runner.temp }}
+          # runner.temp is on the boot volume, which is a Dell BOSS M.2 RAID
+          # the kernel reports as rotational: 88 MiB/s sequential and 8 MiB/s
+          # under fsync. Loopback PUT measured 6.62 MiB/s against it, which is
+          # that ceiling and not predastore's. The shards go on a SATA SSD
+          # instead, at 368 MiB/s sequential and 116 MiB/s under fsync.
+          PERF_WORK_ROOT: ${{ vars.PREDASTORE_PERF_WORK_ROOT }}
           PERF_RESULTS_ROOT: scripts/bench/results/e2e-performance-loopback
           PERF_CONFIGS: 3host
         run: make e2e-performance
@@ -379,6 +393,7 @@ jobs:
         if: steps.gate.outputs.paused != 'true'
         env:
           TMPDIR: ${{ runner.temp }}
+          PERF_WORK_ROOT: ${{ vars.PREDASTORE_PERF_WORK_ROOT }}
           PERF_RESULTS_ROOT: scripts/bench/results/e2e-performance-loopback-small
           PERF_CONFIGS: 3host
           PERF_PUT_SIZE: 64KiB

--- a/scripts/bench/e2e-performance.sh
+++ b/scripts/bench/e2e-performance.sh
@@ -12,6 +12,11 @@
 #   PERF_PRESET      smoke (30s per workload, default) or compare (2m)
 #   PERF_CONFIGS     Profiles to run, space separated (default: "1host 3host")
 #   PERF_RESULTS_ROOT Where runs are written
+#   PERF_WORK_ROOT   Where the cluster work directory is created, and so which
+#                    disk the shards land on. Defaults to TMPDIR. Point it at
+#                    the fastest local filesystem: the PUT numbers cannot
+#                    exceed what this disk sustains under fsync, so a slow one
+#                    is measured instead of predastore.
 #   PERF_KEEP_WORK   1 to keep the cluster work directory after the run
 #   PERF_PORT_OFFSET Added to every node port, so a run does not collide with a
 #                    cluster already on the defaults (default: 10000)
@@ -91,10 +96,32 @@ else
     SHA="$(git -C "$REPO_DIR" rev-parse --short HEAD)"
 fi
 RUN_DIR="$RESULTS_ROOT/${STAMP}-${SHA}"
-WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/predastore-e2e-performance.XXXXXX")"
+
+# The shards land under the work directory, so whatever disk this resolves to is
+# the disk the PUT numbers measure. TMPDIR is the wrong thing to inherit for
+# that: it is chosen for scratch space, is often tmpfs, and on a CI runner is
+# wherever the runner was installed rather than wherever the fast disk is.
+#
+# PERF_WORK_ROOT names it directly. A run whose write path is bounded by the
+# host's slowest filesystem is measuring that filesystem, not predastore.
+# rotational_of reports what the kernel thinks the backing device is. It is
+# worth recording because it is the one property that separates the disks here
+# by name and not by speed: the boot volume is an M.2 RAID that reports 1.
+rotational_of() {
+    local src base
+    src="$(findmnt -no SOURCE --target "$1" 2>/dev/null)" || return 0
+    base="$(lsblk -no PKNAME "$src" 2>/dev/null | head -n 1)"
+    [ -n "$base" ] || base="$(basename "$src")"
+    cat "/sys/block/$base/queue/rotational" 2>/dev/null || echo unknown
+}
+
+WORK_ROOT="${PERF_WORK_ROOT:-${TMPDIR:-/tmp}}"
+[ -d "$WORK_ROOT" ] || { echo "PERF_WORK_ROOT does not exist: $WORK_ROOT" >&2; exit 1; }
+[ -w "$WORK_ROOT" ] || { echo "PERF_WORK_ROOT is not writable: $WORK_ROOT" >&2; exit 1; }
+WORK_DIR="$(mktemp -d "$WORK_ROOT/predastore-e2e-performance.XXXXXX")"
 
 case "$WORK_DIR" in
-    ""|/|"${TMPDIR:-/tmp}") echo "refusing unsafe work directory: $WORK_DIR" >&2; exit 1 ;;
+    ""|/|"$WORK_ROOT"|"${TMPDIR:-/tmp}") echo "refusing unsafe work directory: $WORK_DIR" >&2; exit 1 ;;
 esac
 
 mkdir -p "$RUN_DIR/logs" "$RUN_DIR/correctness"
@@ -330,6 +357,12 @@ fi
     echo "cpu=$(uname -p)"
     echo "logical_cpus=$(getconf _NPROCESSORS_ONLN)"
     echo "memory_bytes=$(awk '/MemTotal/ {print $2 * 1024}' /proc/meminfo 2>/dev/null || echo unknown)"
+    # The disk the shards land on bounds every PUT number below it, so which
+    # one it was belongs beside the numbers rather than in the job that set it.
+    echo "work_root=$WORK_ROOT"
+    echo "work_root_source=$(findmnt -no SOURCE --target "$WORK_ROOT" 2>/dev/null || echo unknown)"
+    echo "work_root_fstype=$(findmnt -no FSTYPE --target "$WORK_ROOT" 2>/dev/null || echo unknown)"
+    echo "work_root_rotational=$(rotational_of "$WORK_ROOT")"
     echo
     echo "Workload controls"
     echo "-----------------"


### PR DESCRIPTION
## The loopback benchmark was measuring a disk, not predastore

The two loopback passes wrote into `runner.temp`. On the `predastore` self-hosted runner that resolves to `/dev/sdd2`, the boot volume — a **Dell BOSS M.2 RAID that the kernel reports as rotational**. Measured on the host:

| filesystem | device | seq write | fsync-per-write |
| --- | --- | --- | --- |
| `/` — where `runner.temp` lives | `DELLBOSS VD`, **rot=1** | 88 MiB/s | **8 MiB/s, 121 iops** |
| `/mnt/disk2` — the new work root | `SSDSC2KG960G7R` SATA SSD, rot=0 | 368 MiB/s | **116 MiB/s, 1863 iops** |

Run [34004467284](https://github.com/mulgadc/predastore/actions/runs/34004467284) put 1 MiB objects at **6.62 MiB/s** against a disk that fsyncs at 8 MiB/s. That is not a coincidence — the PUT ceiling *was* the BOSS card's fsync rate. The corroborating tell is that writes sat near 6 obj/s whether the object was 64 KiB or 1 MiB, which is seek time rather than anything in the write path, while GET ran at 868 MiB/s off page cache.

## The change

`PERF_WORK_ROOT` names the work directory's parent, mirroring `STRESS_WORK_ROOT` in `e2e-stress.sh`. `TMPDIR` was always the wrong thing to have inherited for this: it is chosen for scratch space, is often tmpfs, and on a CI runner points at wherever the runner was installed rather than wherever the fast disk is. It is checked for existence and writability up front rather than failing later inside `mktemp`, and the unsafe-work-directory guard covers the new root as well as `TMPDIR`.

`run-info.txt` now records `work_root` with its backing device, filesystem and rotational flag. **That is the part that was actually missing.** Nothing in the previous artifact said the numbers were disk-bound, and on this host the two devices are told apart by that flag rather than by their names — `/` looks like an M.2 SSD and reports rotational.

The workflow reads the path from repository variable `PREDASTORE_PERF_WORK_ROOT`, already set to `/mnt/disk2/predastore`. An unset variable falls back to `TMPDIR`, which is exactly the old behaviour, and emits a `::warning::` so the fallback is visible in the run rather than only in `run-info.txt`.

## Measured, loopback 3host

Baseline [34004467284](https://github.com/mulgadc/predastore/actions/runs/34004467284) against [34039282968](https://github.com/mulgadc/predastore/actions/runs/34039282968) on this branch, same code, same runner, same workloads:

| workload | before | after | |
| --- | --- | --- | --- |
| PUT 1 MiB | 6.62 MiB/s | **103.22 MiB/s** | **15.6×** |
| PUT 64 KiB | 0.37 MiB/s, 5.91 obj/s | **20.25 MiB/s, 324.08 obj/s** | **55×** |
| multipart-put 1 MiB | 5.75 MiB/s | **82.07 MiB/s** | 14.3× |
| multipart-put 64 KiB | 9.81 MiB/s | **101.13 MiB/s** | 10.3× |
| GET 10 MiB | 868.08 MiB/s | 929.35 MiB/s | 1.07× |
| GET 64 KiB | 518.06 MiB/s | 520.36 MiB/s | flat |

PUT latency collapsed with it, and so did its variance — the spread was the disk queue:

| | before | after |
| --- | --- | --- |
| PUT 1 MiB | Avg 771.4ms, 99% 1385.2ms, StdDev 239.9ms | **Avg 38.6ms, 99% 43.7ms, StdDev 2.8ms** |
| PUT 64 KiB | Avg 2550.7ms, 99% 3988.7ms, StdDev 986.4ms | **Avg 48.4ms, 99% 54.7ms, StdDev 4.2ms** |

**GET is the control and it barely moved.** Reads were served from page cache and were never disk-bound, so a change to the disk should do nothing to them, and it did nothing to them. Meanwhile the 15.6× on PUT tracks the 14.5× fsync ratio between the two devices almost exactly. Those two facts together are what make this a disk change rather than a lucky run.

The new artifact carries the provenance directly:

```
work_root=/mnt/disk2/predastore
work_root_source=/dev/sdc1
work_root_fstype=ext4
work_root_rotational=0
```

## Consequence worth stating plainly

**Every loopback number recorded before this is a measurement of the BOSS card, not of predastore.** They should be discarded rather than compared against anything produced after it. The bare-metal (`hwbench`) passes are unaffected — they run on the hardware hosts under `PREDASTORE_HW_ROOT`, which is already `/mnt/disk1/predastore-ci`.

Not changed here: the stress jobs run on hosted `ubuntu-26.04` runners and never touch this disk, and `e2e-stress.sh` already had its own `STRESS_WORK_ROOT`.

`/mnt/nvme` on the runner is a KIOXIA NVMe with 548 GiB free and would be faster again, but it is not writable by the runner user. If that is worth doing it is a one-line variable change once the ownership is sorted.