### PR TITLE
fix: read only the stripes a ranged GET touches

### DIFF
--- a/internal/gate/handlers/get_object.go
+++ b/internal/gate/handlers/get_object.go
@@ -127,13 +127,20 @@ func serveObject(
 		}
 	}
 
+	// A range that crosses a block still reads whole stripes, because a stripe
+	// is what parity rebuilds, but only the ones it touches. The lead-in from
+	// the stripe boundary up to start is read and dropped.
 	began := time.Now()
-	reader, err := newStripeReader(ctx, bc, cfg, objectHash, place, handoff)
+	reader, err := newStripeReader(ctx, bc, cfg, objectHash, place, handoff, withStart(start))
 	if err != nil {
 		HandleError(w, r, model.NewS3Error(model.ErrInternalError, err.Error(), 500))
 		return
 	}
 	defer reader.close(ctx)
+
+	// Taken from the reader's own layout, so the offset it opened at and the
+	// lead-in dropped here cannot disagree.
+	stripeAt, _ := reader.lay.stripeStart(start)
 
 	first, n, err := reader.next(ctx)
 	if err != nil {
@@ -144,8 +151,8 @@ func serveObject(
 
 	header(end-start+1, reader.reconstructed)
 
-	out := &windowWriter{dst: w, skip: start, limit: end - start + 1}
-	if err := drain(ctx, reader, out, first, n, size); err != nil {
+	out := &windowWriter{dst: w, skip: start - stripeAt, limit: end - start + 1}
+	if err := drain(ctx, reader, out, first, n, stripeAt, end+1); err != nil {
 		// The header and part of the body have gone; the only honest signal
 		// left is to stop short of Content-Length, which every client treats
 		// as the failure it is.

--- a/internal/gate/handlers/layout.go
+++ b/internal/gate/handlers/layout.go
@@ -56,6 +56,25 @@ func (l layout) locate(offset int64) (shard int, at int64) {
 	return int(rel / tail), full*l.blockSize + rel%tail
 }
 
+// stripeStart reports where the stripe holding an object offset begins: its
+// first object offset, and the offset the data shards must be opened at to
+// read it. A stripe is the smallest unit parity can rebuild, so a read that
+// starts part way through an object still starts on one of these.
+//
+// It splits the object exactly as locate does, because a start that disagreed
+// with locate would serve the wrong bytes rather than fail.
+func (l layout) stripeStart(offset int64) (objectAt, shardAt int64) {
+	full := l.shardSize / l.blockSize
+	head := full * int64(l.dataShards) * l.blockSize
+	if offset < head {
+		stripe := offset / (int64(l.dataShards) * l.blockSize)
+
+		return stripe * int64(l.dataShards) * l.blockSize, stripe * l.blockSize
+	}
+
+	return head, full * l.blockSize
+}
+
 // contiguous reports whether an object range is one unbroken run inside a
 // single shard, which is the only case a single ranged shard read can serve.
 func (l layout) contiguous(start, end int64) bool {

--- a/internal/gate/handlers/layout_test.go
+++ b/internal/gate/handlers/layout_test.go
@@ -203,3 +203,69 @@ func TestRangedReadsAgreeWithTheWholeObject(t *testing.T) {
 		})
 	}
 }
+
+// A range that crosses a block cannot be served off one shard, and the read
+// that replaces it used to start every shard at byte zero and run to the end of
+// the object. The bytes came back correct, so only a count of what the nodes
+// were made to deliver catches it: a two byte range cost a whole object of
+// shard reads, transfer and decryption.
+//
+// The bound is the stripes the range touches, because a stripe is the unit
+// parity rebuilds and so the smallest thing a degradable read can fetch.
+func TestARangedReadCostsOnlyTheStripesItTouches(t *testing.T) {
+	t.Parallel()
+
+	const size = 3*streamBlockSize + 7919
+	f := newWriteFixture(2, 1)
+	body := randomBytes(t, size)
+
+	ctx := context.Background()
+	objectHash := model.ObjectHash("b", "k")
+	place, _, err := f.write(ctx, objectHash, bytes.NewReader(body), size)
+	require.NoError(t, err)
+	f.publish(t, objectHash, place)
+
+	lay := newLayout(f.cfg.DataShards, size, place.BlockSize)
+
+	// touched is what the range ought to cost: every data shard, from the start
+	// of the stripe holding start to the end of the block holding end.
+	touched := func(start, end int64) int64 {
+		_, from := lay.stripeStart(start)
+		_, last := lay.stripeStart(end)
+		to := last + min(lay.blockSize, lay.shardSize-last)
+
+		return int64(lay.dataShards) * (to - from)
+	}
+
+	// The last stripe is short, so its offsets are spaced by the remainder
+	// rather than by the block. A range crossing inside it is what catches an
+	// alignment that rounded by the block size instead of asking the layout.
+	head := int64(lay.dataShards) * lay.blockSize * (lay.shardSize / lay.blockSize)
+	tailCross := head + lay.shardSize%lay.blockSize
+	require.Less(t, tailCross, int64(size), "fixture has no short last stripe to cross")
+
+	ranges := []struct{ start, end int64 }{
+		{streamBlockSize - 1, streamBlockSize},       // across the first boundary
+		{streamBlockSize - 1, 2 * streamBlockSize},   // across two
+		{2*streamBlockSize + 5, 3 * streamBlockSize}, // into the short last stripe
+		{tailCross - 1, tailCross},                   // across a boundary in the tail
+		{size - 2, size - 1},                         // one block: the fast path
+		{0, size - 1},                                // the whole object
+	}
+	// One tally over one object, so the ranges run in sequence rather than as
+	// parallel subtests: a shared counter cannot attribute concurrent reads.
+	for _, r := range ranges {
+		req := objectRequest(http.MethodGet, "k", "")
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", r.start, r.end))
+
+		f.bc.getBytes.Store(0)
+		w := httptest.NewRecorder()
+		GetObject(f.mc, f.bc, f.ring, testCache(), f.cfg).ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusPartialContent, w.Code, "range %d-%d", r.start, r.end)
+		require.Equal(t, body[r.start:r.end+1], w.Body.Bytes(), "range %d-%d", r.start, r.end)
+		assert.LessOrEqualf(t, f.bc.getBytes.Load(), touched(r.start, r.end),
+			"range %d-%d of %d bytes read %d from the nodes, more than the %d its stripes hold",
+			r.start, r.end, r.end-r.start+1, f.bc.getBytes.Load(), touched(r.start, r.end))
+	}
+}

--- a/internal/gate/handlers/streamread.go
+++ b/internal/gate/handlers/streamread.go
@@ -63,6 +63,17 @@ func withClock(c clock) stripeOption {
 	return func(r *stripeReader) { r.clk = c }
 }
 
+// withStart begins the read at the stripe holding an object offset rather than
+// at the start of the object, so a range costs the stripes it touches instead
+// of everything before it. The caller gets the bytes from that stripe boundary
+// on, and is the one that knows how many of them to drop.
+//
+// It aligns through the layout because the last stripe is short: rounding by
+// the block size would land in the wrong place there.
+func withStart(objectOffset int64) stripeOption {
+	return func(r *stripeReader) { _, r.offset = r.lay.stripeStart(objectOffset) }
+}
+
 func newStripeReader(
 	ctx context.Context, bc BlobClient, cfg Config,
 	objectHash [32]byte, place ObjectToShardNodes, handoff config.NodeID,
@@ -105,11 +116,16 @@ func newStripeReader(
 	// a connection and then says nothing costs shardOpenTimeout, and paying five
 	// seconds of that on every GET is exactly the availability loss parity is
 	// there to prevent.
+	//
+	// The start offset is read once here rather than inside the goroutines: an
+	// open the constructor gave up on outlives it, and the stripes that follow
+	// advance the same field.
 	nodes := place.AllNodes()
+	from := r.offset
 	opens := make(chan openResult, cfg.DataShards)
 	for i := range cfg.DataShards {
 		go func() {
-			rc, openErr := r.open(ctx, i, nodes[i], 0)
+			rc, openErr := r.open(ctx, i, nodes[i], from)
 			opens <- openResult{index: i, rc: rc, err: openErr}
 		}()
 	}
@@ -553,7 +569,15 @@ func (r *stripeReader) reportShard(ctx context.Context, index int, node config.N
 // shape both whole-object callers share: read the first stripe, then drain the
 // rest behind it.
 func pipeObject(ctx context.Context, r *stripeReader, dst io.Writer, size int64) error {
-	if size == 0 {
+	return pipeRange(ctx, r, dst, 0, size)
+}
+
+// pipeRange streams the object bytes in [from, to) from a reader already
+// positioned at the stripe that from begins. It emits from the stripe
+// boundary, so a caller wanting a range that starts inside one drops the
+// lead-in itself.
+func pipeRange(ctx context.Context, r *stripeReader, dst io.Writer, from, to int64) error {
+	if to <= from {
 		return nil
 	}
 	first, n, err := r.next(ctx)
@@ -561,7 +585,7 @@ func pipeObject(ctx context.Context, r *stripeReader, dst io.Writer, size int64)
 		return err
 	}
 
-	return drain(ctx, r, dst, first, n, size)
+	return drain(ctx, r, dst, first, n, from, to)
 }
 
 // copyStream reads a byte range of a stored object as a stream. The object is
@@ -588,21 +612,25 @@ func openCopyStream(
 		return &copyStream{pr: emptyPipe()}, nil
 	}
 
-	src, err := newStripeReader(ctx, bc, cfg, objectHash, place, handoff)
+	src, err := newStripeReader(ctx, bc, cfg, objectHash, place, handoff, withStart(start))
 	if err != nil {
 		return nil, err
 	}
 
+	// The reader begins at the stripe holding start, so the window drops what
+	// precedes start within that stripe rather than everything before it. The
+	// bound comes from the reader's own layout to keep the two in step.
+	stripeAt, _ := src.lay.stripeStart(start)
 	pr, pw := io.Pipe()
 	var dst io.Writer = pw
-	if start > 0 || length < size {
-		dst = &windowWriter{dst: pw, skip: start, limit: length}
+	if start > stripeAt || length < size {
+		dst = &windowWriter{dst: pw, skip: start - stripeAt, limit: length}
 	}
 
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		pw.CloseWithError(pipeObject(ctx, src, dst, size))
+		pw.CloseWithError(pipeRange(ctx, src, dst, stripeAt, start+length))
 	}()
 
 	return &copyStream{pr: pr, src: src, done: done}, nil
@@ -665,33 +693,37 @@ func (w *windowWriter) Write(p []byte) (int, error) {
 	return full, nil
 }
 
-// drain emits the object from the stripe already in hand and then the rest,
-// stopping at the object size so the padding that squares the last stripe is
-// never served. The first stripe is passed in because the caller has to read it
-// before it can send a header it cannot take back.
-func drain(ctx context.Context, r *stripeReader, dst io.Writer, first [][]byte, n int64, size int64) error {
-	var pos int64
+// drain emits object bytes [from, to) from the stripe already in hand and then
+// the rest, where from is the object offset that stripe begins at. Stopping at
+// to rather than at the object size is what keeps a range from reading the
+// whole object, and at to == size it is also what keeps the padding that
+// squares the last stripe from being served.
+//
+// The first stripe is passed in because the caller has to read it before it can
+// send a header it cannot take back.
+func drain(ctx context.Context, r *stripeReader, dst io.Writer, first [][]byte, n, from, to int64) error {
+	pos := from
 	blocks, count := first, n
 	for {
 		for i := range blocks {
-			if pos >= size {
+			if pos >= to {
 				break
 			}
 			chunk := blocks[i][:count]
-			if pos+int64(len(chunk)) > size {
-				chunk = chunk[:size-pos]
+			if pos+int64(len(chunk)) > to {
+				chunk = chunk[:to-pos]
 			}
 			if _, wErr := dst.Write(chunk); wErr != nil {
 				return wErr
 			}
 			pos += int64(len(chunk))
 		}
-		if pos >= size {
+		if pos >= to {
 			return nil
 		}
 		next, n, err := r.next(ctx)
 		if errors.Is(err, io.EOF) {
-			return fmt.Errorf("object ended after %d of %d bytes", pos, size)
+			return fmt.Errorf("object ended after %d of %d bytes", pos, to)
 		}
 		if err != nil {
 			return err

--- a/internal/gate/handlers/upload_part_copy_test.go
+++ b/internal/gate/handlers/upload_part_copy_test.go
@@ -147,6 +147,47 @@ func TestUploadPartCopyHonoursTheSourceRange(t *testing.T) {
 	assert.Equal(t, partETag(t, want), got.ETag)
 }
 
+// A copy range that crosses a block cannot be served off one shard, so it goes
+// through the same stripe reader a ranged GET does and carried the same read
+// amplification. The source is big enough for the range to start beyond the
+// first stripe, which is what the alignment has to get right.
+func TestUploadPartCopyOfARangeCrossingABlockCostsOnlyItsStripes(t *testing.T) {
+	t.Parallel()
+
+	f := newWriteFixture(2, 1)
+	const size = 3*streamBlockSize + 7919
+	source := randomBytes(t, size)
+	f.seedObject(t, "src", source)
+	f.seedEmptyUpload(t, "dst", "u1")
+
+	// The range straddles a block boundary inside the short last stripe, where
+	// offsets are spaced by the remainder rather than by the block. That is the
+	// case an alignment computed by dividing would put in the wrong place.
+	lay := writeLayout(f.cfg.DataShards, size)
+	tail := lay.shardSize % lay.blockSize
+	head := lay.shardSize / lay.blockSize * int64(lay.dataShards) * lay.blockSize
+	start := head + tail - 1
+	end := start + 4096
+	require.Less(t, end, int64(size), "range must stay inside the source")
+
+	f.bc.getBytes.Store(0)
+	w := httptest.NewRecorder()
+	UploadPartCopy(f.mc, f.bc, f.ring, copyTestCache(), f.cfg).ServeHTTP(w,
+		copyPartRequest("dst", "u1", 3, "/"+copyTestBucket+"/src", fmt.Sprintf("bytes=%d-%d", start, end)))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// Read before the part is fetched back, or that read joins the tally.
+	read := f.bc.getBytes.Load()
+
+	want := source[start : end+1]
+	assert.Equal(t, want, f.readStoredPart(t, "dst", "u1", 3))
+
+	stripe := int64(lay.dataShards) * tail
+	assert.LessOrEqual(t, read, stripe,
+		"a %d byte copy range read %d from the nodes, more than the %d stripe holding it",
+		end-start+1, read, stripe)
+}
+
 // An upload assembled entirely from copied parts has to read back byte for
 // byte, which is the property the registry's blob digest check depends on.
 func TestCompletedUploadOfCopiedPartsReadsBack(t *testing.T) {

--- a/internal/gate/handlers/writepath_test.go
+++ b/internal/gate/handlers/writepath_test.go
@@ -112,6 +112,11 @@ type fakeBlob struct {
 	commitCalls atomic.Int64
 	abortCalls  atomic.Int64
 
+	// getBytes counts what the shard streams actually delivered, not what they
+	// were asked for: a read that opens a stream to the end of the shard and
+	// closes it early costs the node only the part it took.
+	getBytes atomic.Int64
+
 	// released records every generation a writer said it had superseded, so a
 	// test can tell a bounded retention from one that only ages out.
 	released     []blob.ReleaseRequest
@@ -252,7 +257,22 @@ func (b *fakeBlob) Get(_ context.Context, _ config.NodeID, req blob.GetRequest) 
 	if req.RangeStart >= 0 && req.RangeEnd >= 0 {
 		data = data[req.RangeStart : req.RangeEnd+1]
 	}
-	return io.NopCloser(bytes.NewReader(data)), nil
+	return io.NopCloser(&tallyingReader{r: bytes.NewReader(data), n: &b.getBytes}), nil
+}
+
+// tallyingReader adds what a shard stream hands over to a shared counter. The
+// production countingReader is per-stream and unsynchronised; shard reads run
+// concurrently against one tally.
+type tallyingReader struct {
+	r io.Reader
+	n *atomic.Int64
+}
+
+func (c *tallyingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n.Add(int64(n))
+
+	return n, err
 }
 
 func (b *fakeBlob) Delete(_ context.Context, _ config.NodeID, req blob.DeleteRequest) (*blob.DeleteResponse, error) {


### PR DESCRIPTION
A range that crossed a 4 MiB block boundary fell off the single-shard fast path onto the stripe reader, which opened every data shard at byte zero and drained to the object size. The window writer discarded the rest and reported it as written, so nothing stopped the read early: an N byte range cost Z bytes of shard reads, transfer and decryption for an object of size Z.

The reader now starts at the stripe holding the range and stops at its end. Alignment goes through the layout rather than dividing by the block size, because the last stripe is short and its offsets are spaced by the remainder. A stripe is the unit parity rebuilds, so it is the smallest thing a read that may still have to reconstruct can fetch.

UploadPartCopy shared the defect through openCopyStream and is bounded the same way. Both paths are pinned by a test that counts what the ranged read pulls from the nodes, which is the only thing that catches this: the bytes returned were correct throughout.

Scope is multi-node. Single-node profiles are RS(1,0), where every offset locates to the same shard and the fast path always wins.