### PR TITLE
fix: let an external benchmark run supply the identity to measure as

### DIFF
--- a/scripts/bench/e2e-performance.sh
+++ b/scripts/bench/e2e-performance.sh
@@ -26,6 +26,9 @@
 #                    port offset and start/stop; the config name is a label.
 #   PERF_EXTERNAL_SHA, PERF_EXTERNAL_GO  Provenance for that cluster's build,
 #                    which this machine did not produce and cannot read.
+#   PERF_ACCESS_KEY, PERF_SECRET_KEY, PERF_REGION  The identity to measure as.
+#                    Defaults to the account the loopback configs trust, which
+#                    a cluster this script did not start will not have.
 #
 # Preset overrides: PERF_DURATION, PERF_CONCURRENT, PERF_PUT_SIZE,
 # PERF_PART_SIZE, PERF_PARTS, PERF_GET_SIZE.
@@ -45,9 +48,12 @@ WARP="${WARP:-$REPO_DIR/bin/tools/warp}"
 # shellcheck source=scripts/lib.sh
 source "$SCRIPTS_DIR/lib.sh"
 
-ACCESS_KEY="AKIAIOSFODNN7EXAMPLE"
-SECRET_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-REGION="ap-southeast-2"
+# The defaults are the account the loopback configs trust. A provisioned
+# cluster mints its own pair at bootstrap instead, so an external run has to
+# be told which identity to use.
+ACCESS_KEY="${PERF_ACCESS_KEY:-AKIAIOSFODNN7EXAMPLE}"
+SECRET_KEY="${PERF_SECRET_KEY:-wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY}"
+REGION="${PERF_REGION:-ap-southeast-2}"
 
 case "$PERF_PRESET" in
     smoke)


### PR DESCRIPTION
## Summary

`PERF_EXTERNAL_HOSTS` lets the benchmark measure a cluster it did not start, but the credentials stayed pinned to the account the loopback configs trust. A provisioned cluster mints its own pair at bootstrap, so every external run died on the first correctness call with `InvalidAccessKeyId`.

Three assignments gain an environment override. The defaults are unchanged, so the loopback path behaves exactly as before.

## Why it is needed now

The 3-node performance workflow (spinifex #1015) resolves the harness by sibling ref: same-named branch if one exists, `dev` otherwise. While that workflow lives on a branch it picks up this branch and works. **The moment #1015 merges, `GIT_BRANCH` becomes `dev` and the harness comes from predastore `dev`, which still hardcodes `AKIAIOSFODNN7EXAMPLE`** — so the workflow would arrive on `dev` broken.

This should merge before #1015.

## Testing

Exercised end to end by the workflow against provisioned 3-node clusters — runs 34437714908 and 34438922609 both ran the full warp suite through this path. Shell-only change; `bash -n` and shellcheck clean. Predastore's `preflight` is Go-only (`lint govulncheck test-cover diff-coverage test-integration`) so it does not cover this file.